### PR TITLE
Upgrade to Claude Opus 4.6 and preserve auth mode on re-run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,12 @@ Tests run as a full suite only (no individual test execution). Categories: synta
 ./setup --auth=api-key --preserve-key       # Reuse AWS_BEARER_TOKEN_BEDROCK from env
 ```
 
+### Upgrade Models (Preserve Auth Mode)
+```bash
+./setup --force --preserve-key              # Re-running preserves existing auth mode automatically
+```
+When re-running setup without `--auth`, the script detects the existing auth mode from the config block (`# Auth mode: api-key` or `# Auth mode: iam`) and preserves it. Use explicit `--auth=` to override.
+
 ### Keychain Storage (optional)
 ```bash
 ./setup --auth=api-key --storage=keychain   # Store key in OS keychain instead of profile
@@ -86,6 +92,7 @@ ShellCheck configured via `.shellcheckrc`. Disabled: SC1091 (source paths), SC20
 - Non-interactive mode detection (requires `--bedrock-key` or `--preserve-key` in CI/CD)
 - Credential conflict detection warns when multiple auth methods are present
 - Setup script unsets conflicting env vars (`AWS_ACCESS_KEY_ID`, `AWS_PROFILE`, etc.) when switching auth modes
+- Auth mode preservation: re-running setup detects existing auth mode from `# Auth mode:` comment in config block
 
 ## Authentication Modes
 

--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -5,7 +5,7 @@
     "CLAUDE_CODE_USE_BEDROCK": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "16384",
     "MAX_THINKING_TOKENS": "32768",
-    "ANTHROPIC_MODEL": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+    "ANTHROPIC_MODEL": "global.anthropic.claude-opus-4-6-v1",
     "ANTHROPIC_SMALL_FAST_MODEL": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "DISABLE_ERROR_REPORTING": "1",
     "DISABLE_TELEMETRY": "1",

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -14,6 +14,9 @@ param(
     [switch]$Help
 )
 
+# Track if -Auth was explicitly provided by the user
+$AuthExplicit = $PSBoundParameters.ContainsKey('Auth')
+
 $ErrorActionPreference = "Stop"
 
 #───────────────────────────────────────────────────────────────────────────────
@@ -32,10 +35,36 @@ if (Test-Path $ConfigFile) {
     }
 }
 
+# Detect existing auth mode from profile file
+# Returns: "iam", "api-key", or $null if not found
+function Get-ExistingAuthMode {
+    param([string]$ProfilePath)
+
+    if (Test-Path $ProfilePath) {
+        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        if ($content -match "# Auth mode: (iam|api-key)") {
+            return $Matches[1]
+        }
+    }
+    return $null
+}
+
 # Apply defaults from config or use hardcoded fallbacks
 if ([string]::IsNullOrEmpty($Region)) {
     $Region = if ($Config -and $Config.defaults.region) { $Config.defaults.region } else { "us-west-2" }
 }
+
+# Detect existing auth mode if user didn't explicitly specify -Auth
+$ProfilePathForDetection = $PROFILE.CurrentUserAllHosts
+if (-not $AuthExplicit -and [string]::IsNullOrEmpty($Auth)) {
+    $existingAuth = Get-ExistingAuthMode -ProfilePath $ProfilePathForDetection
+    if ($existingAuth) {
+        $Auth = $existingAuth
+        Write-Host "Preserving existing auth mode: $Auth"
+    }
+}
+
+# Apply default if still unset
 if ([string]::IsNullOrEmpty($Auth)) {
     $Auth = if ($Config -and $Config.defaults.auth_mode) { $Config.defaults.auth_mode } else { "iam" }
 }

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -471,6 +471,15 @@ remove_existing_config() {
     sed_inplace '/# Claude Code - Amazon Bedrock Configuration/,/ANTHROPIC_SMALL_FAST_MODEL/d' "$config_file"
 }
 
+# Detect existing auth mode from config file
+# Returns: "iam", "api-key", or empty string if not found
+detect_existing_auth_mode() {
+    local config_file=$1
+    if [[ -f "$config_file" ]]; then
+        grep "^# Auth mode:" "$config_file" 2>/dev/null | sed 's/^# Auth mode: //'
+    fi
+}
+
 # File locking to prevent concurrent modifications
 LOCK_FD=""
 LOCK_FILE=""
@@ -592,7 +601,8 @@ FORCE=false
 PRESERVE_KEY=false
 AWS_REGION="${DEFAULT_REGION:-us-west-2}"
 SHELL_TYPE=""
-AUTH_MODE="${DEFAULT_AUTH:-iam}"
+AUTH_MODE=""                 # Don't set default yet - may be detected from existing config
+AUTH_MODE_EXPLICIT=false     # Track if user explicitly set --auth flag
 STORAGE_MODE="profile"
 BEDROCK_API_KEY=""
 
@@ -610,6 +620,7 @@ parse_arguments() {
                 ;;
             --auth=*)
                 AUTH_MODE="${arg#--auth=}"
+                AUTH_MODE_EXPLICIT=true   # User explicitly set auth mode
                 ;;
             --bedrock-key=*)
                 BEDROCK_API_KEY="${arg#--bedrock-key=}"
@@ -886,6 +897,25 @@ show_next_steps() {
 
 main() {
     parse_arguments "$@"
+
+    # Detect existing auth mode if user didn't explicitly specify
+    if [[ "$AUTH_MODE_EXPLICIT" != true ]]; then
+        local config_file="${SHELL_CONFIGS[$SHELL_TYPE]}"
+        if [[ -f "$config_file" ]] && grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
+            local existing_auth
+            existing_auth=$(detect_existing_auth_mode "$config_file")
+            if [[ -n "$existing_auth" ]]; then
+                AUTH_MODE="$existing_auth"
+                echo "Preserving existing auth mode: $AUTH_MODE"
+            fi
+        fi
+    fi
+
+    # Apply default if still unset
+    if [[ -z "$AUTH_MODE" ]]; then
+        AUTH_MODE="${DEFAULT_AUTH:-iam}"
+    fi
+
     validate_inputs
 
     if [[ "$DRY_RUN" == true ]]; then


### PR DESCRIPTION
## Summary

- Upgrade `ANTHROPIC_MODEL` to Claude Opus 4.6 (`global.anthropic.claude-opus-4-6-v1`)
- Preserve existing auth mode when re-running setup (prevents silent switch from api-key to iam)
- Document upgrade workflow in CLAUDE.md

## Problem

Re-running `./setup` to update configuration (e.g., after a model upgrade) would default to `--auth=iam`, silently switching users from api-key auth and breaking their setup.

## Solution

The setup script now detects the existing auth mode from the `# Auth mode:` comment in the config block and uses it as the default. Users can still override with explicit `--auth=` flag.

## Test plan

- [x] Run full test suite: `bash ./test.sh` (75 passed)
- [x] Verify api-key auth preserved on re-run
- [x] Verify iam auth preserved on re-run  
- [x] Verify explicit `--auth=` override still works
- [x] Live test with `./setup --force --preserve-key`