### PR TITLE
Add --model and --fast-model flags for custom model IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,35 @@ Keychain storage requires OS-specific tools:
 - **macOS**: Keychain Access (built-in)
 - **Windows**: Credential Manager (built-in)
 
+## Custom Models
+
+Override the default model IDs from `bedrock-config.json`:
+
+```bash
+# Unix
+./setup --model=anthropic.claude-3-opus-20240229-v1:0
+./setup --fast-model=anthropic.claude-3-haiku-20240307-v1:0
+./setup --model=anthropic.claude-3-opus-20240229-v1:0 --fast-model=anthropic.claude-3-haiku-20240307-v1:0
+
+# PowerShell
+.\setup-claude-bedrock.ps1 -Model anthropic.claude-3-opus-20240229-v1:0
+.\setup-claude-bedrock.ps1 -FastModel anthropic.claude-3-haiku-20240307-v1:0
+```
+
+Reset to defaults from `bedrock-config.json`:
+```bash
+./setup --model=default --fast-model=default
+.\setup-claude-bedrock.ps1 -Model default -FastModel default
+```
+
+| Flag | PowerShell | Notes |
+|------|------------|-------|
+| `--model=ID` | `-Model ID` | Custom primary model |
+| `--fast-model=ID` | `-FastModel ID` | Custom fast model |
+| `--model=default` | `-Model default` | Reset to bedrock-config.json |
+
+Custom models are persisted via `# Model:` and `# FastModel:` comments in the config block. Re-running setup preserves custom models unless explicitly overridden.
+
 ## Key Files
 
 - `bedrock-config.json` - Environment variables, regions, defaults (edit this to change models)

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -9,13 +9,17 @@ param(
     [ValidateSet("profile", "keychain")]
     [string]$Storage = "profile",
     [string]$Region = "",
+    [string]$Model = "",
+    [string]$FastModel = "",
     [switch]$Force,
     [switch]$DryRun,
     [switch]$Help
 )
 
-# Track if -Auth was explicitly provided by the user
+# Track if parameters were explicitly provided by the user
 $AuthExplicit = $PSBoundParameters.ContainsKey('Auth')
+$ModelExplicit = $PSBoundParameters.ContainsKey('Model')
+$FastModelExplicit = $PSBoundParameters.ContainsKey('FastModel')
 
 $ErrorActionPreference = "Stop"
 
@@ -49,6 +53,75 @@ function Get-ExistingAuthMode {
     return $null
 }
 
+# Detect existing custom model from profile file
+function Get-ExistingModel {
+    param([string]$ProfilePath)
+
+    if (Test-Path $ProfilePath) {
+        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        if ($content -match "# Model: (.+)$" ) {
+            return $Matches[1].Trim()
+        }
+    }
+    return $null
+}
+
+# Detect existing custom fast model from profile file
+function Get-ExistingFastModel {
+    param([string]$ProfilePath)
+
+    if (Test-Path $ProfilePath) {
+        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        if ($content -match "# FastModel: (.+)$") {
+            return $Matches[1].Trim()
+        }
+    }
+    return $null
+}
+
+# Validate model ID format
+function Test-ModelIdFormat {
+    param([string]$ModelId, [string]$ModelType)
+
+    # "default" is a special value to reset to bedrock-config.json
+    if ($ModelId -eq "default") {
+        return $true
+    }
+
+    # Non-empty check
+    if ([string]::IsNullOrEmpty($ModelId)) {
+        Write-Host "Error: -$ModelType model ID cannot be empty" -ForegroundColor Red
+        return $false
+    }
+
+    # Basic format check (Bedrock model ID patterns)
+    if ($ModelId -notmatch "^(global\.)?anthropic\.") {
+        Write-Host "Warning: '$ModelId' doesn't match expected Bedrock model ID format" -ForegroundColor Yellow
+        Write-Host "Expected patterns: anthropic.claude-* or global.anthropic.claude-*" -ForegroundColor Yellow
+    }
+
+    return $true
+}
+
+# Warn user about custom model usage
+function Show-CustomModelWarning {
+    param([string]$ModelId, [string]$ModelType)
+
+    Write-Host ""
+    Write-Host "Warning: Custom $ModelType model: $ModelId" -ForegroundColor Yellow
+    Write-Host "   Cannot validate without working AWS credentials."
+    Write-Host "   Ensure this model is available in your Bedrock region."
+    Write-Host ""
+
+    if (-not $Force -and -not $DryRun) {
+        $response = Read-Host "Continue with custom model? (y/n)"
+        if ($response -ne "y" -and $response -ne "Y") {
+            Write-Host "Setup cancelled" -ForegroundColor Red
+            exit 0
+        }
+    }
+}
+
 # Apply defaults from config or use hardcoded fallbacks
 if ([string]::IsNullOrEmpty($Region)) {
     $Region = if ($Config -and $Config.defaults.region) { $Config.defaults.region } else { "us-west-2" }
@@ -67,6 +140,48 @@ if (-not $AuthExplicit -and [string]::IsNullOrEmpty($Auth)) {
 # Apply default if still unset
 if ([string]::IsNullOrEmpty($Auth)) {
     $Auth = if ($Config -and $Config.defaults.auth_mode) { $Config.defaults.auth_mode } else { "iam" }
+}
+
+# Detect existing custom models if user didn't explicitly specify
+if (-not $ModelExplicit) {
+    $existingModel = Get-ExistingModel -ProfilePath $ProfilePathForDetection
+    if ($existingModel) {
+        $Model = $existingModel
+        Write-Host "Preserving existing custom model: $Model"
+    }
+}
+
+if (-not $FastModelExplicit) {
+    $existingFastModel = Get-ExistingFastModel -ProfilePath $ProfilePathForDetection
+    if ($existingFastModel) {
+        $FastModel = $existingFastModel
+        Write-Host "Preserving existing custom fast model: $FastModel"
+    }
+}
+
+# Handle "default" reset value - clears custom model
+if ($Model -eq "default") {
+    $Model = ""
+    Write-Host "Resetting primary model to default from bedrock-config.json"
+}
+if ($FastModel -eq "default") {
+    $FastModel = ""
+    Write-Host "Resetting fast model to default from bedrock-config.json"
+}
+
+# Validate and warn for custom models
+if (-not [string]::IsNullOrEmpty($Model)) {
+    if (-not (Test-ModelIdFormat -ModelId $Model -ModelType "Model")) {
+        exit 1
+    }
+    Show-CustomModelWarning -ModelId $Model -ModelType "primary"
+}
+
+if (-not [string]::IsNullOrEmpty($FastModel)) {
+    if (-not (Test-ModelIdFormat -ModelId $FastModel -ModelType "FastModel")) {
+        exit 1
+    }
+    Show-CustomModelWarning -ModelId $FastModel -ModelType "fast"
 }
 
 # Load valid regions from config or use defaults
@@ -93,6 +208,8 @@ if ($Help) {
     Write-Host "  -PreserveKey       Reuse existing API key from environment (no prompt)"
     Write-Host "  -Storage <MODE>    Where to store API key: profile (default) or keychain"
     Write-Host "  -Region <REGION>   AWS region (default: us-west-2)"
+    Write-Host "  -Model <ID>        Custom primary model (use 'default' to reset)"
+    Write-Host "  -FastModel <ID>    Custom fast model (use 'default' to reset)"
     Write-Host "  -Force             Overwrite existing configuration without prompting"
     Write-Host "  -DryRun            Preview changes without modifying files"
     Write-Host "  -Help              Show this help message"
@@ -115,6 +232,8 @@ if ($Help) {
     Write-Host "  .\setup-claude-bedrock.ps1 -Auth api-key -Storage keychain  # Secure storage"
     Write-Host "  .\setup-claude-bedrock.ps1 -Auth api-key -BedrockKey br-xxx  # Inline key"
     Write-Host "  .\setup-claude-bedrock.ps1 -Auth api-key -PreserveKey   # Reuse existing key"
+    Write-Host "  .\setup-claude-bedrock.ps1 -Model anthropic.claude-3-opus-20240229-v1:0  # Custom model"
+    Write-Host "  .\setup-claude-bedrock.ps1 -Model default               # Reset to default"
     Write-Host "  .\setup-claude-bedrock.ps1 -DryRun"
     exit 0
 }
@@ -227,6 +346,12 @@ Write-Host "Setting up Claude Code with Amazon Bedrock ($AuthDisplay auth)..." -
 
 # Build configuration block from JSON config or fallback to defaults
 $ConfigBlock = "`n# BEGIN: Claude Code Bedrock Configuration`n# Auth mode: $Auth`n"
+if (-not [string]::IsNullOrEmpty($Model)) {
+    $ConfigBlock += "# Model: $Model`n"
+}
+if (-not [string]::IsNullOrEmpty($FastModel)) {
+    $ConfigBlock += "# FastModel: $FastModel`n"
+}
 if ($Storage -eq "keychain") {
     $ConfigBlock += "# Storage: keychain (encrypted)`n"
 }
@@ -248,7 +373,15 @@ $ConfigBlock += "`$env:AWS_REGION = `"$Region`"`n"
 # Add environment variables from config
 if ($Config -and $Config.environment) {
     $Config.environment.PSObject.Properties | ForEach-Object {
-        $ConfigBlock += "`$env:$($_.Name) = `"$($_.Value)`"`n"
+        $value = $_.Value
+        # Use custom model if specified
+        if ($_.Name -eq "ANTHROPIC_MODEL" -and -not [string]::IsNullOrEmpty($Model)) {
+            $value = $Model
+        }
+        if ($_.Name -eq "ANTHROPIC_SMALL_FAST_MODEL" -and -not [string]::IsNullOrEmpty($FastModel)) {
+            $value = $FastModel
+        }
+        $ConfigBlock += "`$env:$($_.Name) = `"$value`"`n"
     }
 } else {
     Write-Host "Error: Could not load environment variables from config file" -ForegroundColor Red

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -351,6 +351,12 @@ generate_config_block() {
 
     config+=$'\n'"# BEGIN: Claude Code Bedrock Configuration"$'\n'
     config+="# Auth mode: $auth_mode"$'\n'
+    if [[ -n "$CUSTOM_MODEL" ]]; then
+        config+="# Model: $CUSTOM_MODEL"$'\n'
+    fi
+    if [[ -n "$CUSTOM_FAST_MODEL" ]]; then
+        config+="# FastModel: $CUSTOM_FAST_MODEL"$'\n'
+    fi
     if [[ "$storage_mode" == "keychain" ]]; then
         config+="# Storage: keychain (encrypted)"$'\n'
     fi
@@ -379,6 +385,10 @@ generate_config_block() {
         local value
         if [[ "$key" == "AWS_REGION" ]]; then
             value="$region"
+        elif [[ "$key" == "ANTHROPIC_MODEL" && -n "$CUSTOM_MODEL" ]]; then
+            value="$CUSTOM_MODEL"
+        elif [[ "$key" == "ANTHROPIC_SMALL_FAST_MODEL" && -n "$CUSTOM_FAST_MODEL" ]]; then
+            value="$CUSTOM_FAST_MODEL"
         else
             value="${BEDROCK_CONFIG[$key]}"
         fi
@@ -476,7 +486,66 @@ remove_existing_config() {
 detect_existing_auth_mode() {
     local config_file=$1
     if [[ -f "$config_file" ]]; then
-        grep "^# Auth mode:" "$config_file" 2>/dev/null | sed 's/^# Auth mode: //'
+        grep "^# Auth mode:" "$config_file" 2>/dev/null | head -1 | sed 's/^# Auth mode: //'
+    fi
+}
+
+# Detect existing custom model from config file
+detect_existing_model() {
+    local config_file=$1
+    if [[ -f "$config_file" ]]; then
+        grep "^# Model:" "$config_file" 2>/dev/null | head -1 | sed 's/^# Model: //'
+    fi
+}
+
+# Detect existing custom fast model from config file
+detect_existing_fast_model() {
+    local config_file=$1
+    if [[ -f "$config_file" ]]; then
+        grep "^# FastModel:" "$config_file" 2>/dev/null | head -1 | sed 's/^# FastModel: //'
+    fi
+}
+
+# Validate model ID format
+validate_model_id() {
+    local model_id=$1
+    local model_type=$2  # "model" or "fast-model"
+
+    # "default" is a special value to reset to bedrock-config.json
+    if [[ "$model_id" == "default" ]]; then
+        return 0
+    fi
+
+    # Non-empty check
+    if [[ -z "$model_id" ]]; then
+        echo "Error: --$model_type model ID cannot be empty" >&2
+        return 1
+    fi
+
+    # Basic format check (Bedrock model ID patterns)
+    if [[ ! "$model_id" =~ ^(global\.)?anthropic\. ]]; then
+        echo "Warning: '$model_id' doesn't match expected Bedrock model ID format" >&2
+        echo "Expected patterns: anthropic.claude-* or global.anthropic.claude-*" >&2
+    fi
+
+    return 0
+}
+
+# Warn user about custom model usage
+warn_custom_model() {
+    local model_id=$1
+    local model_type=$2
+
+    echo ""
+    echo "⚠️  Custom $model_type model: $model_id"
+    echo "   Cannot validate without working AWS credentials."
+    echo "   Ensure this model is available in your Bedrock region."
+    echo ""
+
+    if [[ "$FORCE" != true && "$DRY_RUN" != true ]]; then
+        read -p "Continue with custom model? (y/n) " -n 1 -r
+        echo
+        [[ ! $REPLY =~ ^[Yy]$ ]] && { echo "Setup cancelled"; exit 0; }
     fi
 }
 
@@ -548,6 +617,8 @@ Options:
   --preserve-key         Reuse existing API key from environment (no prompt)
   --storage=MODE         Where to store API key: profile (default) or keychain
   --region=REGION        AWS region (default: us-west-2)
+  --model=ID             Custom primary model (use "default" to reset)
+  --fast-model=ID        Custom fast model (use "default" to reset)
   --dry-run              Preview changes without modifying files
   --force, -f            Skip confirmation prompts
   --help, -h             Show this help message
@@ -586,6 +657,13 @@ Examples:
   # Update config while preserving existing API key
   ./setup-claude-bedrock.sh --auth=api-key --preserve-key
 
+  # Custom model IDs
+  ./setup-claude-bedrock.sh --model=anthropic.claude-3-opus-20240229-v1:0
+  ./setup-claude-bedrock.sh --fast-model=anthropic.claude-3-haiku-20240307-v1:0
+
+  # Reset custom model back to bedrock-config.json default
+  ./setup-claude-bedrock.sh --model=default
+
   # Preview changes
   ./setup-claude-bedrock.sh --dry-run
   ./setup-claude-bedrock.sh --auth=api-key --bedrock-key=br-xxx --dry-run
@@ -605,6 +683,10 @@ AUTH_MODE=""                 # Don't set default yet - may be detected from exis
 AUTH_MODE_EXPLICIT=false     # Track if user explicitly set --auth flag
 STORAGE_MODE="profile"
 BEDROCK_API_KEY=""
+CUSTOM_MODEL=""
+CUSTOM_FAST_MODEL=""
+MODEL_EXPLICIT=false
+FAST_MODEL_EXPLICIT=false
 
 parse_arguments() {
     for arg in "$@"; do
@@ -630,6 +712,14 @@ parse_arguments() {
                 ;;
             --storage=*)
                 STORAGE_MODE="${arg#--storage=}"
+                ;;
+            --model=*)
+                CUSTOM_MODEL="${arg#--model=}"
+                MODEL_EXPLICIT=true
+                ;;
+            --fast-model=*)
+                CUSTOM_FAST_MODEL="${arg#--fast-model=}"
+                FAST_MODEL_EXPLICIT=true
                 ;;
             --help|-h)
                 show_help
@@ -914,6 +1004,47 @@ main() {
     # Apply default if still unset
     if [[ -z "$AUTH_MODE" ]]; then
         AUTH_MODE="${DEFAULT_AUTH:-iam}"
+    fi
+
+    # Detect existing custom models if user didn't explicitly specify
+    local config_file="${SHELL_CONFIGS[$SHELL_TYPE]}"
+    if [[ "$MODEL_EXPLICIT" != true && -f "$config_file" ]]; then
+        local existing_model
+        existing_model=$(detect_existing_model "$config_file")
+        if [[ -n "$existing_model" ]]; then
+            CUSTOM_MODEL="$existing_model"
+            echo "Preserving existing custom model: $CUSTOM_MODEL"
+        fi
+    fi
+
+    if [[ "$FAST_MODEL_EXPLICIT" != true && -f "$config_file" ]]; then
+        local existing_fast_model
+        existing_fast_model=$(detect_existing_fast_model "$config_file")
+        if [[ -n "$existing_fast_model" ]]; then
+            CUSTOM_FAST_MODEL="$existing_fast_model"
+            echo "Preserving existing custom fast model: $CUSTOM_FAST_MODEL"
+        fi
+    fi
+
+    # Handle "default" reset value - clears custom model
+    if [[ "$CUSTOM_MODEL" == "default" ]]; then
+        CUSTOM_MODEL=""
+        echo "Resetting primary model to default from bedrock-config.json"
+    fi
+    if [[ "$CUSTOM_FAST_MODEL" == "default" ]]; then
+        CUSTOM_FAST_MODEL=""
+        echo "Resetting fast model to default from bedrock-config.json"
+    fi
+
+    # Validate and warn for custom models
+    if [[ -n "$CUSTOM_MODEL" ]]; then
+        validate_model_id "$CUSTOM_MODEL" "model" || exit 1
+        warn_custom_model "$CUSTOM_MODEL" "primary"
+    fi
+
+    if [[ -n "$CUSTOM_FAST_MODEL" ]]; then
+        validate_model_id "$CUSTOM_FAST_MODEL" "fast-model" || exit 1
+        warn_custom_model "$CUSTOM_FAST_MODEL" "fast"
     fi
 
     validate_inputs


### PR DESCRIPTION
## Summary

- Add `--model=ID` and `--fast-model=ID` flags to override default models from `bedrock-config.json`
- Custom models persist via config block comments (`# Model:`, `# FastModel:`) and are preserved on re-run
- Add `--model=default` to reset back to `bedrock-config.json` defaults
- Include format validation with warnings for non-standard Bedrock model ID patterns

## Changes

| File | Description |
|------|-------------|
| `setup-claude-bedrock.sh` | Add flags, detection, validation, warnings, config generation |
| `setup-claude-bedrock.ps1` | Equivalent PowerShell implementation |
| `CLAUDE.md` | Document new flags |

## Test plan

- [x] All 75 existing tests pass
- [x] `./setup --model=anthropic.claude-3-opus-20240229-v1:0 --dry-run` works
- [x] `./setup --fast-model=anthropic.claude-3-haiku-20240307-v1:0 --dry-run` works
- [x] `./setup --model=default --dry-run` resets to defaults
- [x] Re-running setup preserves custom models
- [x] Invalid format shows warning but allows proceed