### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/jpvelasco/juggernaut/security/code-scanning/3](https://github.com/jpvelasco/juggernaut/security/code-scanning/3)

In general, the fix is to explicitly declare the least-privilege `permissions` for the GITHUB_TOKEN, either at the workflow root (applies to all jobs) or per job. Since all three jobs are simple test jobs that only require repository read access (they use `actions/checkout` and run scripts), the best single change is to add a workflow-level `permissions` block with `contents: read`. This both documents the requirement and ensures that if repo/org defaults are broader, this workflow is still constrained.

Concretely:
- Edit `.github/workflows/test.yml`.
- Add a `permissions:` block near the top, after `name: Test` and before `on:` (or just before `jobs:`; both are valid at the workflow level).
- Set it to:
  ```yaml
  permissions:
    contents: read
  ```
No additional imports, methods, or definitions are needed since this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
