### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jpvelasco/juggernaut/security/code-scanning/2](https://github.com/jpvelasco/juggernaut/security/code-scanning/2)

Generally, the problem is fixed by explicitly defining a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal scope required. For most test-only workflows that only need to read the repository code, `contents: read` is sufficient. This can be set at the workflow root (applying to all jobs) or per job.

For this file, none of the jobs appear to need write access to the repository or to issues/PRs. The safest fix that preserves current behavior is to add a workflow-level `permissions:` block right after the `name: Test` line, setting `contents: read`. This will apply to `test-unix`, `test-windows-powershell`, and `test-windows-gitbash` without needing separate blocks for each job. No imports or additional methods are required; it is purely a YAML configuration change.

Concretely:
- Edit `.github/workflows/test.yml`.
- Insert a `permissions:` section after line 1 (`name: Test`).
- Set `contents: read` to restrict the `GITHUB_TOKEN` so it can only read repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
