### PR TITLE
Harden scripts: fix injection risks, broken Windows keychain, and cleanup gaps

### DIFF
--- a/apply-config.sh
+++ b/apply-config.sh
@@ -65,14 +65,54 @@ fi
 _JUGGERNAUT_JSON_CONTENT=$(cat "$_JUGGERNAUT_CONFIG_FILE")
 
 # Parse JSON using jq or python fallback
+# Python fallback uses sys.argv to avoid eval() and shell injection risks
 _juggernaut_get_json_value() {
     local key=$1
     if command -v jq >/dev/null 2>&1; then
         echo "$_JUGGERNAUT_JSON_CONTENT" | jq -r "$key // empty"
     elif command -v python3 >/dev/null 2>&1; then
-        echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(eval('d$key') if eval('d$key') else '')" 2>/dev/null
+        echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "
+import sys,json,functools
+d=json.load(sys.stdin)
+keys=[k for k in sys.argv[1].split('.') if k]
+val=functools.reduce(lambda d,k: d[k], keys, d)
+print(val if val else '')
+" "$key" 2>/dev/null
     elif command -v python >/dev/null 2>&1; then
-        echo "$_JUGGERNAUT_JSON_CONTENT" | python -c "import sys,json; d=json.load(sys.stdin); print(eval('d$key') if eval('d$key') else '')" 2>/dev/null
+        echo "$_JUGGERNAUT_JSON_CONTENT" | python -c "
+import sys,json,functools
+d=json.load(sys.stdin)
+keys=[k for k in sys.argv[1].split('.') if k]
+val=functools.reduce(lambda d,k: d[k], keys, d)
+print(val if val else '')
+" "$key" 2>/dev/null
+    else
+        echo "Error: jq or python required to parse config" >&2
+        return 1
+    fi
+}
+
+# Helper to get all keys from a JSON object
+_juggernaut_get_json_keys() {
+    local key=$1
+    if command -v jq >/dev/null 2>&1; then
+        echo "$_JUGGERNAUT_JSON_CONTENT" | jq -r "$key | keys[]"
+    elif command -v python3 >/dev/null 2>&1; then
+        echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "
+import sys,json,functools
+d=json.load(sys.stdin)
+keys=[k for k in sys.argv[1].split('.') if k]
+obj=functools.reduce(lambda d,k: d[k], keys, d)
+print('\n'.join(obj.keys()))
+" "$key" 2>/dev/null
+    elif command -v python >/dev/null 2>&1; then
+        echo "$_JUGGERNAUT_JSON_CONTENT" | python -c "
+import sys,json,functools
+d=json.load(sys.stdin)
+keys=[k for k in sys.argv[1].split('.') if k]
+obj=functools.reduce(lambda d,k: d[k], keys, d)
+print('\n'.join(obj.keys()))
+" "$key" 2>/dev/null
     else
         echo "Error: jq or python required to parse config" >&2
         return 1
@@ -86,16 +126,17 @@ _juggernaut_get_json_value() {
 echo "Applying Claude Code Bedrock configuration..."
 echo ""
 
-# Load environment variables from config
-export CLAUDE_CODE_USE_BEDROCK="$(_juggernaut_get_json_value '.environment.CLAUDE_CODE_USE_BEDROCK')"
-export CLAUDE_CODE_MAX_OUTPUT_TOKENS="$(_juggernaut_get_json_value '.environment.CLAUDE_CODE_MAX_OUTPUT_TOKENS')"
-export MAX_THINKING_TOKENS="$(_juggernaut_get_json_value '.environment.MAX_THINKING_TOKENS')"
-export ANTHROPIC_MODEL="$(_juggernaut_get_json_value '.environment.ANTHROPIC_MODEL')"
-export ANTHROPIC_SMALL_FAST_MODEL="$(_juggernaut_get_json_value '.environment.ANTHROPIC_SMALL_FAST_MODEL')"
-export DISABLE_ERROR_REPORTING="$(_juggernaut_get_json_value '.environment.DISABLE_ERROR_REPORTING')"
-export DISABLE_TELEMETRY="$(_juggernaut_get_json_value '.environment.DISABLE_TELEMETRY')"
-export DISABLE_AUTOUPDATE="$(_juggernaut_get_json_value '.environment.DISABLE_AUTOUPDATE')"
-export DISABLE_BUG_COMMAND="$(_juggernaut_get_json_value '.environment.DISABLE_BUG_COMMAND')"
+# Dynamically load and export all environment variables from config
+_JUGGERNAUT_ENV_KEYS=$(_juggernaut_get_json_keys '.environment')
+if [[ -n "$_JUGGERNAUT_ENV_KEYS" ]]; then
+    while IFS= read -r _JUGGERNAUT_KEY; do
+        _JUGGERNAUT_VAL="$(_juggernaut_get_json_value ".environment.$_JUGGERNAUT_KEY")"
+        export "$_JUGGERNAUT_KEY=$_JUGGERNAUT_VAL"
+    done <<< "$_JUGGERNAUT_ENV_KEYS"
+else
+    echo "Error: Could not load environment variables from config" >&2
+    return 1 2>/dev/null || exit 1
+fi
 
 # Region: command line overrides config default
 if [[ -n "$_JUGGERNAUT_REGION" ]]; then
@@ -104,21 +145,18 @@ else
     export AWS_REGION="$(_juggernaut_get_json_value '.defaults.region')"
 fi
 
+# Display applied configuration
+echo "Configuration applied:"
+echo "  AWS_REGION=$AWS_REGION"
+while IFS= read -r _JUGGERNAUT_KEY; do
+    eval "echo \"  \${_JUGGERNAUT_KEY}=\${$_JUGGERNAUT_KEY}\""
+done <<< "$_JUGGERNAUT_ENV_KEYS"
+
 # Clean up temp variables and functions
 unset _JUGGERNAUT_REGION _JUGGERNAUT_SCRIPT_DIR _JUGGERNAUT_CONFIG_FILE _JUGGERNAUT_JSON_CONTENT
-unset -f _juggernaut_get_json_value
+unset _JUGGERNAUT_ENV_KEYS _JUGGERNAUT_KEY _JUGGERNAUT_VAL
+unset -f _juggernaut_get_json_value _juggernaut_get_json_keys
 
-echo "Configuration applied:"
-echo "  CLAUDE_CODE_USE_BEDROCK=$CLAUDE_CODE_USE_BEDROCK"
-echo "  AWS_REGION=$AWS_REGION"
-echo "  CLAUDE_CODE_MAX_OUTPUT_TOKENS=$CLAUDE_CODE_MAX_OUTPUT_TOKENS"
-echo "  MAX_THINKING_TOKENS=$MAX_THINKING_TOKENS"
-echo "  ANTHROPIC_MODEL=$ANTHROPIC_MODEL"
-echo "  ANTHROPIC_SMALL_FAST_MODEL=$ANTHROPIC_SMALL_FAST_MODEL"
-echo "  DISABLE_ERROR_REPORTING=$DISABLE_ERROR_REPORTING"
-echo "  DISABLE_TELEMETRY=$DISABLE_TELEMETRY"
-echo "  DISABLE_AUTOUPDATE=$DISABLE_AUTOUPDATE"
-echo "  DISABLE_BUG_COMMAND=$DISABLE_BUG_COMMAND"
 echo ""
 echo "This configuration is active for the current terminal session only."
 echo "To make it permanent, run: ./setup-claude-bedrock.sh"

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -309,17 +309,35 @@ function Set-KeychainCredential {
 }
 
 function Get-KeychainCredential {
-    # Use PowerShell to retrieve from Credential Manager
+    # Use Win32 CredRead API to retrieve from Credential Manager (no external modules)
     try {
-        Add-Type -AssemblyName System.Security -ErrorAction SilentlyContinue
-        $cred = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
-            [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR(
-                (Get-StoredCredential -Target $KeychainTarget -ErrorAction Stop).Password
-            )
-        )
-        return $cred
+        Add-Type -Namespace 'Win32' -Name 'Credential' -MemberDefinition '
+            [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+            public static extern bool CredRead(string target, int type, int flags, out IntPtr credential);
+            [DllImport("advapi32.dll")]
+            public static extern void CredFree(IntPtr credential);
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            public struct CREDENTIAL {
+                public int Flags; public int Type;
+                public string TargetName; public string Comment;
+                public long LastWritten; public int CredentialBlobSize;
+                public IntPtr CredentialBlob; public int Persist;
+                public int AttributeCount; public IntPtr Attributes;
+                public string TargetAlias; public string UserName;
+            }
+        ' -ErrorAction SilentlyContinue
+        $ptr = [IntPtr]::Zero
+        if ([Win32.Credential]::CredRead($KeychainTarget, 1, 0, [ref]$ptr)) {
+            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][Win32.Credential+CREDENTIAL])
+            $password = $null
+            if ($cred.CredentialBlobSize -gt 0) {
+                $password = [Runtime.InteropServices.Marshal]::PtrToStringUni($cred.CredentialBlob, $cred.CredentialBlobSize / 2)
+            }
+            [Win32.Credential]::CredFree($ptr)
+            return $password
+        }
+        return $null
     } catch {
-        # Fallback: try using cmdkey list and parse (less reliable)
         return $null
     }
 }
@@ -331,8 +349,9 @@ function Remove-KeychainCredential {
 # Generate the PowerShell command to retrieve key from Credential Manager
 function Get-KeychainRetrievalCommand {
     # This generates the code that will run in the profile to get the credential
+    # Uses Win32 CredRead API - no external modules required
     return @'
-(Get-StoredCredential -Target 'juggernaut-bedrock' -ErrorAction SilentlyContinue).GetNetworkCredential().Password
+& { Add-Type -Namespace 'Win32' -Name 'Cred' -MemberDefinition '[DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)] public static extern bool CredRead(string t, int ty, int f, out IntPtr c); [DllImport("advapi32.dll")] public static extern void CredFree(IntPtr c); [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct CREDENTIAL { public int Flags; public int Type; public string TargetName; public string Comment; public long LastWritten; public int CredentialBlobSize; public IntPtr CredentialBlob; public int Persist; public int AttributeCount; public IntPtr Attributes; public string TargetAlias; public string UserName; }' -ErrorAction SilentlyContinue; $p=[IntPtr]::Zero; if([Win32.Cred]::CredRead('juggernaut-bedrock',1,0,[ref]$p)){ $c=[Runtime.InteropServices.Marshal]::PtrToStructure($p,[Type][Win32.Cred+CREDENTIAL]); $r=$null; if($c.CredentialBlobSize -gt 0){$r=[Runtime.InteropServices.Marshal]::PtrToStringUni($c.CredentialBlob,$c.CredentialBlobSize/2)}; [Win32.Cred]::CredFree($p); $r } }
 '@
 }
 
@@ -392,8 +411,9 @@ if ($Config -and $Config.environment) {
 # Add API key if using api-key auth
 if ($Auth -eq "api-key") {
     if ($Storage -eq "keychain") {
-        # Retrieve from Credential Manager at profile load
-        $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = (Get-StoredCredential -Target 'juggernaut-bedrock' -ErrorAction SilentlyContinue).GetNetworkCredential().Password`n"
+        # Retrieve from Credential Manager at profile load using Win32 CredRead API
+        $retrievalCmd = Get-KeychainRetrievalCommand
+        $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = $retrievalCmd`n"
     } else {
         # Store directly in profile (legacy behavior)
         $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = `"$BedrockKey`"`n"
@@ -420,20 +440,22 @@ function Get-FileLock {
     $startTime = Get-Date
     while (((Get-Date) - $startTime).TotalSeconds -lt $LockTimeout) {
         try {
-            # Check for stale lock
-            if (Test-Path $LockPath) {
-                $lockAge = ((Get-Date) - (Get-Item $LockPath).LastWriteTime).TotalSeconds
+            # Atomic lock creation using FileMode.CreateNew (fails if file exists)
+            $fs = [System.IO.File]::Open($LockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write)
+            $fs.Close()
+            return $true
+        } catch [System.IO.IOException] {
+            # Lock file exists - check if it's stale
+            try {
+                $lockAge = ((Get-Date) - (Get-Item $LockPath -ErrorAction Stop).LastWriteTime).TotalSeconds
                 if ($lockAge -gt $StaleLockAge) {
                     Write-Host "Removing stale lock file (age: $([int]$lockAge)s)" -ForegroundColor Yellow
                     Remove-Item $LockPath -Force -ErrorAction SilentlyContinue
+                    # Retry on next iteration rather than assuming we got it
                 }
+            } catch {
+                # Lock file disappeared between check and stat - retry
             }
-
-            # Try to create lock file atomically
-            $null = New-Item -Path $LockPath -ItemType File -ErrorAction Stop
-            return $true
-        } catch {
-            # Lock exists, wait and retry
             Start-Sleep -Milliseconds 500
         }
     }
@@ -454,10 +476,12 @@ if (-not $DryRun) {
     }
 }
 
-# Ensure lock is released on exit
-$null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {
-    if ($LockAcquired -and (Test-Path $LockFile)) {
-        Remove-Item $LockFile -Force -ErrorAction SilentlyContinue
+# Ensure lock is released on exit (use -MessageData to capture values at registration time)
+$null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -MessageData @{
+    LockAcquired = $LockAcquired; LockFile = $LockFile
+} -Action {
+    if ($Event.MessageData.LockAcquired -and (Test-Path $Event.MessageData.LockFile)) {
+        Remove-Item $Event.MessageData.LockFile -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -517,7 +541,7 @@ if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
     } else {
         # Remove old configuration (supports both old and new marker formats)
         $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# BEGIN: Claude Code Bedrock Configuration.*?# END: Claude Code Bedrock Configuration\r?\n?", "`n"
-        $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# Claude Code - Amazon Bedrock Configuration.*?`$env:ANTHROPIC_SMALL_FAST_MODEL = `"[^`"]+`"\r?\n?", "`n"
+        $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# Claude Code - Amazon Bedrock Configuration.*?`$env:ANTHROPIC_(?:SMALL_FAST_)?MODEL = `"[^`"]+`"\r?\n?", "`n"
         # Remove multiple consecutive blank lines
         $ProfileContent = $ProfileContent -replace "(\r?\n){3,}", "`n`n"
         Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -62,13 +62,8 @@ declare -a VALID_STORAGE_MODES=(profile keychain)
 #───────────────────────────────────────────────────────────────────────────────
 # JSON Config Loading (using jq or python fallback)
 # All queries use jq-style dot notation: .key, .key.subkey
+# Python fallback uses sys.argv to avoid shell injection risks
 #───────────────────────────────────────────────────────────────────────────────
-
-# Convert jq query to Python: .key.subkey -> ["key"]["subkey"]
-jq_to_python() {
-    local query=$1
-    echo "$query" | sed "s/\\.\\([^.]*\\)/['\1']/g"
-}
 
 json_get() {
     local file=$1
@@ -77,10 +72,18 @@ json_get() {
     if command -v jq >/dev/null 2>&1; then
         jq -r "$query" "$file" 2>/dev/null
     else
-        local py_query
-        py_query=$(jq_to_python "$query")
-        python3 -c "import json; data=json.load(open('$file')); print(data$py_query)" 2>/dev/null || \
-        python -c "import json; data=json.load(open('$file')); print(data$py_query)" 2>/dev/null
+        python3 -c "
+import json,sys,functools
+data=json.load(open(sys.argv[1]))
+keys=[k for k in sys.argv[2].split('.') if k]
+print(functools.reduce(lambda d,k: d[k], keys, data))
+" "$file" "$query" 2>/dev/null || \
+        python -c "
+import json,sys,functools
+data=json.load(open(sys.argv[1]))
+keys=[k for k in sys.argv[2].split('.') if k]
+print(functools.reduce(lambda d,k: d[k], keys, data))
+" "$file" "$query" 2>/dev/null
     fi
 }
 
@@ -91,10 +94,20 @@ json_get_keys() {
     if command -v jq >/dev/null 2>&1; then
         jq -r "$query | keys[]" "$file" 2>/dev/null
     else
-        local py_query
-        py_query=$(jq_to_python "$query")
-        python3 -c "import json; data=json.load(open('$file')); print('\n'.join(data$py_query.keys()))" 2>/dev/null || \
-        python -c "import json; data=json.load(open('$file')); print('\n'.join(data$py_query.keys()))" 2>/dev/null
+        python3 -c "
+import json,sys,functools
+data=json.load(open(sys.argv[1]))
+keys=[k for k in sys.argv[2].split('.') if k]
+obj=functools.reduce(lambda d,k: d[k], keys, data)
+print('\n'.join(obj.keys()))
+" "$file" "$query" 2>/dev/null || \
+        python -c "
+import json,sys,functools
+data=json.load(open(sys.argv[1]))
+keys=[k for k in sys.argv[2].split('.') if k]
+obj=functools.reduce(lambda d,k: d[k], keys, data)
+print('\n'.join(obj.keys()))
+" "$file" "$query" 2>/dev/null
     fi
 }
 
@@ -105,10 +118,20 @@ json_get_array() {
     if command -v jq >/dev/null 2>&1; then
         jq -r "$query[]" "$file" 2>/dev/null
     else
-        local py_query
-        py_query=$(jq_to_python "$query")
-        python3 -c "import json; data=json.load(open('$file')); print('\n'.join(data$py_query))" 2>/dev/null || \
-        python -c "import json; data=json.load(open('$file')); print('\n'.join(data$py_query))" 2>/dev/null
+        python3 -c "
+import json,sys,functools
+data=json.load(open(sys.argv[1]))
+keys=[k for k in sys.argv[2].split('.') if k]
+arr=functools.reduce(lambda d,k: d[k], keys, data)
+print('\n'.join(str(x) for x in arr))
+" "$file" "$query" 2>/dev/null || \
+        python -c "
+import json,sys,functools
+data=json.load(open(sys.argv[1]))
+keys=[k for k in sys.argv[2].split('.') if k]
+arr=functools.reduce(lambda d,k: d[k], keys, data)
+print('\n'.join(str(x) for x in arr))
+" "$file" "$query" 2>/dev/null
     fi
 }
 
@@ -281,10 +304,31 @@ keychain_get() {
             secret-tool lookup service "$KEYCHAIN_SERVICE" account "$KEYCHAIN_ACCOUNT" 2>/dev/null
             ;;
         gitbash|cygwin)
-            # Use PowerShell to read from Windows Credential Manager
+            # Use PowerShell with .NET CredentialManager to read from Windows Credential Manager
             powershell.exe -NoProfile -Command "
-                \$cred = Get-StoredCredential -Target '$KEYCHAIN_SERVICE' -ErrorAction SilentlyContinue
-                if (\$cred) { \$cred.GetNetworkCredential().Password }
+                Add-Type -Namespace 'Win32' -Name 'Credential' -MemberDefinition '
+                    [DllImport(\"advapi32.dll\", SetLastError = true, CharSet = CharSet.Unicode)]
+                    public static extern bool CredRead(string target, int type, int flags, out IntPtr credential);
+                    [DllImport(\"advapi32.dll\")]
+                    public static extern void CredFree(IntPtr credential);
+                    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+                    public struct CREDENTIAL {
+                        public int Flags; public int Type;
+                        public string TargetName; public string Comment;
+                        public long LastWritten; public int CredentialBlobSize;
+                        public IntPtr CredentialBlob; public int Persist;
+                        public int AttributeCount; public IntPtr Attributes;
+                        public string TargetAlias; public string UserName;
+                    }
+                '
+                \$ptr = [IntPtr]::Zero
+                if ([Win32.Credential]::CredRead('$KEYCHAIN_SERVICE', 1, 0, [ref]\$ptr)) {
+                    \$cred = [Runtime.InteropServices.Marshal]::PtrToStructure(\$ptr, [Type][Win32.Credential+CREDENTIAL])
+                    if (\$cred.CredentialBlobSize -gt 0) {
+                        [Runtime.InteropServices.Marshal]::PtrToStringUni(\$cred.CredentialBlob, \$cred.CredentialBlobSize / 2)
+                    }
+                    [Win32.Credential]::CredFree(\$ptr)
+                }
             " 2>/dev/null | tr -d '\r'
             ;;
         *)
@@ -324,7 +368,7 @@ keychain_get_command() {
             cmd="secret-tool lookup service '$KEYCHAIN_SERVICE' account '$KEYCHAIN_ACCOUNT' 2>/dev/null"
             ;;
         gitbash|cygwin)
-            cmd="powershell.exe -NoProfile -Command \"(Get-StoredCredential -Target '$KEYCHAIN_SERVICE').GetNetworkCredential().Password\" 2>/dev/null | tr -d '\\r'"
+            cmd="powershell.exe -NoProfile -Command \"Add-Type -Namespace 'Win32' -Name 'Cred' -MemberDefinition '[DllImport(\\\"advapi32.dll\\\", SetLastError=true, CharSet=CharSet.Unicode)] public static extern bool CredRead(string t, int ty, int f, out IntPtr c); [DllImport(\\\"advapi32.dll\\\")] public static extern void CredFree(IntPtr c); [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct CREDENTIAL { public int Flags; public int Type; public string TargetName; public string Comment; public long LastWritten; public int CredentialBlobSize; public IntPtr CredentialBlob; public int Persist; public int AttributeCount; public IntPtr Attributes; public string TargetAlias; public string UserName; }'; \\\$p=[IntPtr]::Zero; if([Win32.Cred]::CredRead('$KEYCHAIN_SERVICE',1,0,[ref]\\\$p)){ \\\$c=[Runtime.InteropServices.Marshal]::PtrToStructure(\\\$p,[Type][Win32.Cred+CREDENTIAL]); if(\\\$c.CredentialBlobSize -gt 0){[Runtime.InteropServices.Marshal]::PtrToStringUni(\\\$c.CredentialBlob,\\\$c.CredentialBlobSize/2)}; [Win32.Cred]::CredFree(\\\$p) }\" 2>/dev/null | tr -d '\\r'"
             ;;
     esac
 
@@ -477,8 +521,8 @@ remove_existing_config() {
     # Remove config with markers (current format)
     sed_inplace '/# BEGIN: Claude Code Bedrock Configuration/,/# END: Claude Code Bedrock Configuration/d' "$config_file"
 
-    # Remove config without markers (legacy format)
-    sed_inplace '/# Claude Code - Amazon Bedrock Configuration/,/ANTHROPIC_SMALL_FAST_MODEL/d' "$config_file"
+    # Remove config without markers (legacy format - match from header to last known env var)
+    sed_inplace '/# Claude Code - Amazon Bedrock Configuration/,/ANTHROPIC_SMALL_FAST_MODEL\|ANTHROPIC_MODEL/d' "$config_file"
 }
 
 # Detect existing auth mode from config file
@@ -871,8 +915,13 @@ setup_shell() {
     echo "Region:   $AWS_REGION"
     echo "Auth:     $AUTH_MODE"
     if [[ "$AUTH_MODE" == "api-key" ]]; then
-        # Show masked key for security
-        local masked_key="${BEDROCK_API_KEY:0:8}...${BEDROCK_API_KEY: -4}"
+        # Show masked key for security (guard against short keys)
+        local masked_key
+        if [[ ${#BEDROCK_API_KEY} -gt 12 ]]; then
+            masked_key="${BEDROCK_API_KEY:0:8}...${BEDROCK_API_KEY: -4}"
+        else
+            masked_key="****"
+        fi
         echo "API Key:  $masked_key"
         echo "Storage:  $STORAGE_MODE"
     fi

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -17,9 +17,15 @@ if (-not (Test-Path $ProfilePath)) {
 $ProfileContent = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
 
 if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
+    # Clean up keychain credentials before removing config (needs the markers to detect storage mode)
+    if ($ProfileContent -match "# Storage: keychain") {
+        $null = cmdkey /delete:juggernaut-bedrock 2>$null
+        Write-Host "Removed API key from Windows Credential Manager" -ForegroundColor Gray
+    }
+
     # Remove configuration (supports both old and new marker formats)
     $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# BEGIN: Claude Code Bedrock Configuration.*?# END: Claude Code Bedrock Configuration\r?\n?", "`n"
-    $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# Claude Code - Amazon Bedrock Configuration.*?`$env:ANTHROPIC_SMALL_FAST_MODEL = `"[^`"]+`"\r?\n?", "`n"
+    $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# Claude Code - Amazon Bedrock Configuration.*?`$env:ANTHROPIC_(?:SMALL_FAST_)?MODEL = `"[^`"]+`"\r?\n?", "`n"
     # Remove multiple consecutive blank lines
     $ProfileContent = $ProfileContent -replace "(\r?\n){3,}", "`n`n"
     Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -55,6 +55,46 @@ sed_inplace() {
     fi
 }
 
+detect_os() {
+    case "$OSTYPE" in
+        darwin*)      echo "macos" ;;
+        linux*)
+            [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>/dev/null \
+                && echo "wsl" || echo "linux" ;;
+        msys*|mingw*) echo "gitbash" ;;
+        cygwin*)      echo "cygwin" ;;
+        *)            echo "unknown" ;;
+    esac
+}
+
+# Remove API key from system keychain if keychain storage was used
+cleanup_keychain() {
+    local config_file=$1
+    local keychain_service="juggernaut-bedrock"
+    local keychain_account="api-key"
+
+    # Check if keychain storage was used by looking for the marker
+    if ! grep -q "# Storage: keychain" "$config_file" 2>/dev/null; then
+        return 0
+    fi
+
+    local os=$(detect_os)
+    case "$os" in
+        macos)
+            security delete-generic-password -s "$keychain_service" -a "$keychain_account" 2>/dev/null || true
+            ;;
+        linux|wsl)
+            if command -v secret-tool >/dev/null 2>&1; then
+                secret-tool clear service "$keychain_service" account "$keychain_account" 2>/dev/null || true
+            fi
+            ;;
+        gitbash|cygwin)
+            cmdkey.exe /delete:"$keychain_service" >/dev/null 2>&1 || true
+            ;;
+    esac
+    echo "  Removed API key from system keychain"
+}
+
 show_help() {
     cat << 'EOF'
 Claude Code - Amazon Bedrock Uninstall Script
@@ -95,11 +135,14 @@ remove_config() {
         return 0
     fi
 
+    # Clean up keychain credentials before removing config (needs the markers to detect storage mode)
+    cleanup_keychain "$config_file"
+
     # Remove config with markers (current format)
     sed_inplace '/# BEGIN: Claude Code Bedrock Configuration/,/# END: Claude Code Bedrock Configuration/d' "$config_file"
 
-    # Remove config without markers (legacy format)
-    sed_inplace '/# Claude Code - Amazon Bedrock Configuration/,/ANTHROPIC_SMALL_FAST_MODEL/d' "$config_file"
+    # Remove config without markers (legacy format - match from header to last known env var)
+    sed_inplace '/# Claude Code - Amazon Bedrock Configuration/,/ANTHROPIC_SMALL_FAST_MODEL\|ANTHROPIC_MODEL/d' "$config_file"
 
     # Clean up multiple consecutive blank lines
     sed_inplace '/^$/N;/^\n$/d' "$config_file"


### PR DESCRIPTION
## Summary

Security hardening and bug fix pass across all setup/uninstall scripts, addressing 9 issues found during code review.

### Changes

**Security**
- Replace `Get-StoredCredential` (requires external PSGallery module) with Win32 `CredReadW` P/Invoke — zero-dependency Windows credential retrieval
- Eliminate Python `eval()` and string interpolation injection vectors in JSON parsing fallbacks (`json_get()`, `json_get_keys()`, `json_get_array()`, `apply-config.sh`)
- Fix API key masking for short keys (previously leaked full key if < 12 chars)

**Bug Fixes**
- PowerShell lock cleanup event handler now captures variables via `-MessageData` (was silently broken due to scope)
- PowerShell file locking uses `FileMode.CreateNew` for atomic lock creation (eliminates TOCTOU race)

**Robustness**
- `apply-config.sh` dynamically iterates env var keys from `bedrock-config.json` instead of hardcoding them
- Uninstall scripts now detect `# Storage: keychain` marker and clean up OS keychain credentials
- Legacy config removal regex accepts `ANTHROPIC_MODEL` as alternate end anchor

### Files Changed
- `setup-claude-bedrock.sh` — JSON parsing, keychain retrieval, key masking, legacy removal
- `setup-claude-bedrock.ps1` — Credential retrieval, locking, event handler, legacy removal
- `apply-config.sh` — JSON parsing rewrite, dynamic env var loading
- `uninstall.sh` — Keychain cleanup, legacy removal
- `uninstall.ps1` — Keychain cleanup, legacy removal

### Testing
- Full test suite: **75 passed, 0 failed, 6 skipped** (skips = keychain tools unavailable in test env)