### PR TITLE
Auto-migrate plaintext API keys to secure keychain on macOS/Windows

### DIFF
--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -20,6 +20,7 @@ param(
 $AuthExplicit = $PSBoundParameters.ContainsKey('Auth')
 $ModelExplicit = $PSBoundParameters.ContainsKey('Model')
 $FastModelExplicit = $PSBoundParameters.ContainsKey('FastModel')
+$StorageExplicit = $PSBoundParameters.ContainsKey('Storage')
 
 $ErrorActionPreference = "Stop"
 
@@ -77,6 +78,20 @@ function Get-ExistingFastModel {
         }
     }
     return $null
+}
+
+# Detect existing storage mode from profile file
+# Returns: "keychain" or "profile" (absence of marker = profile)
+function Get-ExistingStorageMode {
+    param([string]$ProfilePath)
+
+    if (Test-Path $ProfilePath) {
+        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        if ($content -match "# Storage: keychain") {
+            return "keychain"
+        }
+    }
+    return "profile"
 }
 
 # Validate model ID format
@@ -169,6 +184,44 @@ if ($FastModel -eq "default") {
     Write-Host "Resetting fast model to default from bedrock-config.json"
 }
 
+# Detect existing storage mode if user didn't explicitly specify
+if (-not $StorageExplicit) {
+    $existingStorage = Get-ExistingStorageMode -ProfilePath $ProfilePathForDetection
+    if ($existingStorage -eq "keychain") {
+        $Storage = "keychain"
+        Write-Host "Preserving existing storage mode: keychain"
+    }
+}
+
+# Platform-aware storage default for new installs (Windows defaults to keychain)
+if (-not $StorageExplicit -and $Storage -eq "profile") {
+    # On Windows, Credential Manager is always available
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    if (-not ($profileContent -match "CLAUDE_CODE_USE_BEDROCK")) {
+        # New install — default to keychain on Windows
+        $Storage = "keychain"
+    }
+}
+
+# Offer to migrate plaintext API keys to Credential Manager
+if ($Auth -eq "api-key" -and -not $StorageExplicit -and $Storage -eq "profile") {
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    if ($profileContent -match "CLAUDE_CODE_USE_BEDROCK" -and $profileContent -notmatch "# Storage: keychain") {
+        if ($Force) {
+            $Storage = "keychain"
+            Write-Host "Migrating API key to Windows Credential Manager (more secure)"
+        } elseif (-not $DryRun) {
+            Write-Host ""
+            Write-Host "Your API key is stored in plaintext in your PowerShell profile." -ForegroundColor Yellow
+            $response = Read-Host "Move to Windows Credential Manager for better security? (y/n)"
+            if ($response -eq "y" -or $response -eq "Y") {
+                $Storage = "keychain"
+                Write-Host "Migrating API key to Windows Credential Manager"
+            }
+        }
+    }
+}
+
 # Validate and warn for custom models
 if (-not [string]::IsNullOrEmpty($Model)) {
     if (-not (Test-ModelIdFormat -ModelId $Model -ModelType "Model")) {
@@ -206,7 +259,8 @@ if ($Help) {
     Write-Host "  -Auth <MODE>       Authentication: iam (default) or api-key"
     Write-Host "  -BedrockKey <KEY>  Bedrock API key (optional; prompts if not provided)"
     Write-Host "  -PreserveKey       Reuse existing API key from environment (no prompt)"
-    Write-Host "  -Storage <MODE>    Where to store API key: profile (default) or keychain"
+    Write-Host "  -Storage <MODE>    Where to store API key: profile or keychain"
+    Write-Host "                     Default: keychain on Windows, profile on Linux"
     Write-Host "  -Region <REGION>   AWS region (default: us-west-2)"
     Write-Host "  -Model <ID>        Custom primary model (use 'default' to reset)"
     Write-Host "  -FastModel <ID>    Custom fast model (use 'default' to reset)"
@@ -223,8 +277,8 @@ if ($Help) {
     Write-Host "             Get key from: AWS Console -> Bedrock -> API keys"
     Write-Host ""
     Write-Host "Storage Modes:"
-    Write-Host "  profile    Store API key directly in PowerShell profile (default)"
-    Write-Host "  keychain   Store API key in Windows Credential Manager (more secure)"
+    Write-Host "  profile    Store API key directly in PowerShell profile"
+    Write-Host "  keychain   Store API key in Windows Credential Manager (default, more secure)"
     Write-Host ""
     Write-Host "Examples:"
     Write-Host "  .\setup-claude-bedrock.ps1                              # IAM/SSO (default)"
@@ -250,6 +304,42 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
             Write-Host "Error: -PreserveKey specified but AWS_BEARER_TOKEN_BEDROCK is not set" -ForegroundColor Red
             Write-Host "Run setup without -PreserveKey to enter a new key"
             exit 1
+        }
+    } elseif (-not $AuthExplicit) {
+        # Auth mode was auto-detected from existing config — try to reuse key automatically
+        $existingKey = [Environment]::GetEnvironmentVariable("AWS_BEARER_TOKEN_BEDROCK")
+        if (-not [string]::IsNullOrEmpty($existingKey)) {
+            $BedrockKey = $existingKey
+            Write-Host "Using existing API key from environment"
+        } elseif ($Storage -eq "keychain") {
+            $keychainKey = Get-KeychainCredential
+            if (-not [string]::IsNullOrEmpty($keychainKey)) {
+                $BedrockKey = $keychainKey
+                Write-Host "Using existing API key from Credential Manager"
+            }
+        }
+        # If still empty, fall through to prompt below
+        if ([string]::IsNullOrEmpty($BedrockKey)) {
+            if ($DryRun) {
+                Write-Host "[DRY RUN] Would prompt for Bedrock API key" -ForegroundColor Magenta
+                $BedrockKey = "dry-run-placeholder"
+            } elseif (-not [Environment]::UserInteractive -or [Console]::IsInputRedirected) {
+                Write-Host "Error: -BedrockKey or -PreserveKey is required in non-interactive mode" -ForegroundColor Red
+                Write-Host ""
+                Write-Host "Usage: .\setup-claude-bedrock.ps1 -Auth api-key -BedrockKey YOUR_KEY"
+                Write-Host "   or: .\setup-claude-bedrock.ps1 -Auth api-key -PreserveKey"
+                exit 1
+            } else {
+                Write-Host "Get your Bedrock API key from:"
+                Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
+                Write-Host ""
+                $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
+                $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey))
+                if ([string]::IsNullOrEmpty($BedrockKey)) {
+                    Write-Host "Error: API key cannot be empty" -ForegroundColor Red
+                    exit 1
+                }
+            }
         }
     } elseif ($DryRun) {
         Write-Host "[DRY RUN] Would prompt for Bedrock API key" -ForegroundColor Magenta

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -542,6 +542,19 @@ detect_existing_model() {
     fi
 }
 
+# Detect existing storage mode from config file
+# Returns: "keychain" or "profile" (absence of marker = profile)
+detect_existing_storage_mode() {
+    local config_file=$1
+    if [[ -f "$config_file" ]]; then
+        if grep -q "^# Storage: keychain" "$config_file" 2>/dev/null; then
+            echo "keychain"
+            return
+        fi
+    fi
+    echo "profile"
+}
+
 # Detect existing custom fast model from config file
 detect_existing_fast_model() {
     local config_file=$1
@@ -659,7 +672,8 @@ Options:
   --auth=MODE            Authentication mode: iam (default) or api-key
   --bedrock-key=KEY      Bedrock API key (optional; prompts if not provided)
   --preserve-key         Reuse existing API key from environment (no prompt)
-  --storage=MODE         Where to store API key: profile (default) or keychain
+  --storage=MODE         Where to store API key: profile or keychain
+                         Default: keychain on macOS/Windows, profile on Linux
   --region=REGION        AWS region (default: us-west-2)
   --model=ID             Custom primary model (use "default" to reset)
   --fast-model=ID        Custom fast model (use "default" to reset)
@@ -676,13 +690,14 @@ Authentication Modes:
              Get key from: AWS Console → Bedrock → API keys
 
 Storage Modes:
-  profile    Store API key directly in shell profile (default)
+  profile    Store API key directly in shell profile
              Key is plaintext but protected by file permissions
+             Default on Linux (keychain requires libsecret-tools)
 
   keychain   Store API key in system keychain (more secure)
-             macOS: Keychain Access
+             macOS: Keychain Access (default)
              Linux: Secret Service (GNOME Keyring / KWallet)
-             Windows: Credential Manager
+             Windows: Credential Manager (default)
 
 Examples:
   # IAM/SSO authentication (default)
@@ -726,6 +741,7 @@ SHELL_TYPE=""
 AUTH_MODE=""                 # Don't set default yet - may be detected from existing config
 AUTH_MODE_EXPLICIT=false     # Track if user explicitly set --auth flag
 STORAGE_MODE="profile"
+STORAGE_MODE_EXPLICIT=false  # Track if user explicitly set --storage flag
 BEDROCK_API_KEY=""
 CUSTOM_MODEL=""
 CUSTOM_FAST_MODEL=""
@@ -756,6 +772,7 @@ parse_arguments() {
                 ;;
             --storage=*)
                 STORAGE_MODE="${arg#--storage=}"
+                STORAGE_MODE_EXPLICIT=true
                 ;;
             --model=*)
                 CUSTOM_MODEL="${arg#--model=}"
@@ -848,6 +865,44 @@ validate_inputs() {
                 echo "Error: --preserve-key specified but AWS_BEARER_TOKEN_BEDROCK is not set" >&2
                 echo "Run setup without --preserve-key to enter a new key" >&2
                 exit 1
+            fi
+        elif [[ "$AUTH_MODE_EXPLICIT" != true ]]; then
+            # Auth mode was auto-detected from existing config — try to reuse key automatically
+            if [[ -n "$AWS_BEARER_TOKEN_BEDROCK" ]]; then
+                BEDROCK_API_KEY="$AWS_BEARER_TOKEN_BEDROCK"
+                echo "Using existing API key from environment"
+            elif [[ "$STORAGE_MODE" == "keychain" ]] && keychain_available; then
+                local keychain_key
+                keychain_key=$(keychain_get)
+                if [[ -n "$keychain_key" ]]; then
+                    BEDROCK_API_KEY="$keychain_key"
+                    echo "Using existing API key from keychain"
+                fi
+            fi
+            # If still empty, fall through to prompt below
+            if [[ -z "$BEDROCK_API_KEY" ]]; then
+                if [[ "$DRY_RUN" == true ]]; then
+                    echo "[DRY RUN] Would prompt for Bedrock API key"
+                    BEDROCK_API_KEY="dry-run-placeholder"
+                elif [[ ! -t 0 ]]; then
+                    echo "Error: --bedrock-key or --preserve-key is required in non-interactive mode" >&2
+                    echo "" >&2
+                    echo "Usage: ./setup-claude-bedrock.sh --auth=api-key --bedrock-key=YOUR_KEY" >&2
+                    echo "   or: ./setup-claude-bedrock.sh --auth=api-key --preserve-key" >&2
+                    exit 1
+                else
+                    echo "Get your Bedrock API key from:"
+                    echo "  AWS Console → Amazon Bedrock → API keys"
+                    echo ""
+                    read -s -p "Enter your Bedrock API key: " BEDROCK_API_KEY
+                    echo ""
+                    BEDROCK_API_KEY="${BEDROCK_API_KEY%"${BEDROCK_API_KEY##*[![:space:]]}"}"
+                    BEDROCK_API_KEY="${BEDROCK_API_KEY#"${BEDROCK_API_KEY%%[![:space:]]*}"}"
+                    if [[ -z "$BEDROCK_API_KEY" ]]; then
+                        echo "Error: API key cannot be empty"
+                        exit 1
+                    fi
+                fi
             fi
         elif [[ "$DRY_RUN" == true ]]; then
             echo "[DRY RUN] Would prompt for Bedrock API key"
@@ -1072,6 +1127,58 @@ main() {
         if [[ -n "$existing_fast_model" ]]; then
             CUSTOM_FAST_MODEL="$existing_fast_model"
             echo "Preserving existing custom fast model: $CUSTOM_FAST_MODEL"
+        fi
+    fi
+
+    # Detect existing storage mode if user didn't explicitly specify
+    if [[ "$STORAGE_MODE_EXPLICIT" != true && -f "$config_file" ]]; then
+        local existing_storage
+        existing_storage=$(detect_existing_storage_mode "$config_file")
+        if [[ "$existing_storage" == "keychain" ]]; then
+            STORAGE_MODE="keychain"
+            echo "Preserving existing storage mode: keychain"
+        fi
+    fi
+
+    # Platform-aware storage default for new installs (macOS/Windows default to keychain)
+    if [[ "$STORAGE_MODE_EXPLICIT" != true && "$STORAGE_MODE" == "profile" ]]; then
+        local os=$(detect_os)
+        if [[ "$os" == "macos" || "$os" == "gitbash" || "$os" == "cygwin" ]]; then
+            # Only change default if there's no existing config (new install)
+            if ! grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
+                if keychain_available; then
+                    STORAGE_MODE="keychain"
+                fi
+            fi
+        fi
+    fi
+
+    # Offer to migrate plaintext API keys to keychain on macOS/Windows
+    if [[ "$AUTH_MODE" == "api-key" && "$STORAGE_MODE_EXPLICIT" != true && "$STORAGE_MODE" == "profile" ]]; then
+        local os=$(detect_os)
+        if [[ "$os" == "macos" || "$os" == "gitbash" || "$os" == "cygwin" ]]; then
+            if [[ -f "$config_file" ]] && grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
+                if ! grep -q "# Storage: keychain" "$config_file" 2>/dev/null && keychain_available; then
+                    local keychain_name
+                    case "$os" in
+                        macos) keychain_name="macOS Keychain" ;;
+                        *)     keychain_name="Windows Credential Manager" ;;
+                    esac
+                    if [[ "$FORCE" == true ]]; then
+                        STORAGE_MODE="keychain"
+                        echo "Migrating API key to $keychain_name (more secure)"
+                    elif [[ "$DRY_RUN" == false && -t 0 ]]; then
+                        echo ""
+                        echo "Your API key is stored in plaintext in your shell profile."
+                        read -p "Move to $keychain_name for better security? (y/n) " -n 1 -r
+                        echo
+                        if [[ $REPLY =~ ^[Yy]$ ]]; then
+                            STORAGE_MODE="keychain"
+                            echo "Migrating API key to $keychain_name"
+                        fi
+                    fi
+                fi
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Default new installs to **keychain storage** on macOS and Windows, where secure credential stores are always available (Linux keeps `profile` as default since `secret-tool` may not be installed)
- On re-run with existing plaintext config, **prompt to migrate** API key to keychain (`--force` auto-accepts)
- **Auto-detect existing API keys** from environment or keychain on implicit re-run — no more unnecessary key prompts when just upgrading scripts
- Preserve existing storage mode from config markers on re-run

## Behavior Matrix

| Scenario | Before | After |
|----------|--------|-------|
| New install on macOS/Windows | `--storage=profile` (plaintext) | `--storage=keychain` (encrypted) |
| New install on Linux | `--storage=profile` | `--storage=profile` (unchanged) |
| Re-run with no flags (existing api-key config) | Prompts for API key | Auto-detects key from env/keychain |
| Re-run with plaintext key on macOS/Windows | No migration prompt | Prompts to migrate to keychain |
| Re-run with `--force` on macOS/Windows | No migration | Auto-migrates to keychain |
| Explicit `--storage=profile` | Plaintext | Plaintext (respects explicit choice) |

## Files Changed
- `setup-claude-bedrock.sh` — Storage detection, platform-aware defaults, migration prompt, auto-detect key
- `setup-claude-bedrock.ps1` — Same changes for PowerShell/Windows

## Testing
- Full test suite: **75 passed, 0 failed, 6 skipped** (skips = keychain tools unavailable in test env)
- Migration prompt and auto-detect require interactive + existing config — manual testing on Windows/macOS needed