### PR TITLE
Fix review regressions: function ordering, eval removal, key masking

### DIFF
--- a/apply-config.sh
+++ b/apply-config.sh
@@ -76,7 +76,7 @@ import sys,json,functools
 d=json.load(sys.stdin)
 keys=[k for k in sys.argv[1].split('.') if k]
 val=functools.reduce(lambda d,k: d[k], keys, d)
-print(val if val else '')
+print('' if val is None else val)
 " "$key" 2>/dev/null
     elif command -v python >/dev/null 2>&1; then
         echo "$_JUGGERNAUT_JSON_CONTENT" | python -c "
@@ -84,7 +84,7 @@ import sys,json,functools
 d=json.load(sys.stdin)
 keys=[k for k in sys.argv[1].split('.') if k]
 val=functools.reduce(lambda d,k: d[k], keys, d)
-print(val if val else '')
+print('' if val is None else val)
 " "$key" 2>/dev/null
     else
         echo "Error: jq or python required to parse config" >&2
@@ -149,7 +149,7 @@ fi
 echo "Configuration applied:"
 echo "  AWS_REGION=$AWS_REGION"
 while IFS= read -r _JUGGERNAUT_KEY; do
-    eval "echo \"  \${_JUGGERNAUT_KEY}=\${$_JUGGERNAUT_KEY}\""
+    echo "  ${_JUGGERNAUT_KEY}=${!_JUGGERNAUT_KEY}"
 done <<< "$_JUGGERNAUT_ENV_KEYS"
 
 # Clean up temp variables and functions

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -249,6 +249,73 @@ $ValidRegions = if ($Config -and $Config.regions) {
     )
 }
 
+#───────────────────────────────────────────────────────────────────────────────
+# Keychain Functions (Windows Credential Manager)
+#───────────────────────────────────────────────────────────────────────────────
+
+$KeychainTarget = "juggernaut-bedrock"
+
+function Test-KeychainAvailable {
+    # Windows Credential Manager is always available on Windows
+    return $true
+}
+
+function Set-KeychainCredential {
+    param([string]$Key)
+
+    # Use cmdkey to store in Windows Credential Manager
+    $null = cmdkey /delete:$KeychainTarget 2>$null
+    $result = cmdkey /generic:$KeychainTarget /user:api-key /pass:$Key 2>&1
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-KeychainCredential {
+    # Use Win32 CredRead API to retrieve from Credential Manager (no external modules)
+    try {
+        Add-Type -Namespace 'Win32' -Name 'Credential' -MemberDefinition '
+            [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+            public static extern bool CredRead(string target, int type, int flags, out IntPtr credential);
+            [DllImport("advapi32.dll")]
+            public static extern void CredFree(IntPtr credential);
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            public struct CREDENTIAL {
+                public int Flags; public int Type;
+                public string TargetName; public string Comment;
+                public long LastWritten; public int CredentialBlobSize;
+                public IntPtr CredentialBlob; public int Persist;
+                public int AttributeCount; public IntPtr Attributes;
+                public string TargetAlias; public string UserName;
+            }
+        ' -ErrorAction SilentlyContinue
+        $ptr = [IntPtr]::Zero
+        if ([Win32.Credential]::CredRead($KeychainTarget, 1, 0, [ref]$ptr)) {
+            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][Win32.Credential+CREDENTIAL])
+            $password = $null
+            if ($cred.CredentialBlobSize -gt 0) {
+                $password = [Runtime.InteropServices.Marshal]::PtrToStringUni($cred.CredentialBlob, $cred.CredentialBlobSize / 2)
+            }
+            [Win32.Credential]::CredFree($ptr)
+            return $password
+        }
+        return $null
+    } catch {
+        return $null
+    }
+}
+
+function Remove-KeychainCredential {
+    $null = cmdkey /delete:$KeychainTarget 2>$null
+}
+
+# Generate the PowerShell command to retrieve key from Credential Manager
+function Get-KeychainRetrievalCommand {
+    # This generates the code that will run in the profile to get the credential
+    # Uses Win32 CredRead API - no external modules required
+    return @'
+& { Add-Type -Namespace 'Win32' -Name 'Cred' -MemberDefinition '[DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)] public static extern bool CredRead(string t, int ty, int f, out IntPtr c); [DllImport("advapi32.dll")] public static extern void CredFree(IntPtr c); [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct CREDENTIAL { public int Flags; public int Type; public string TargetName; public string Comment; public long LastWritten; public int CredentialBlobSize; public IntPtr CredentialBlob; public int Persist; public int AttributeCount; public IntPtr Attributes; public string TargetAlias; public string UserName; }' -ErrorAction SilentlyContinue; $p=[IntPtr]::Zero; if([Win32.Cred]::CredRead('juggernaut-bedrock',1,0,[ref]$p)){ $c=[Runtime.InteropServices.Marshal]::PtrToStructure($p,[Type][Win32.Cred+CREDENTIAL]); $r=$null; if($c.CredentialBlobSize -gt 0){$r=[Runtime.InteropServices.Marshal]::PtrToStringUni($c.CredentialBlob,$c.CredentialBlobSize/2)}; [Win32.Cred]::CredFree($p); $r } }
+'@
+}
+
 # Show help
 if ($Help) {
     Write-Host "Claude Code - Amazon Bedrock Setup Script"
@@ -376,73 +443,6 @@ if (-not ($ValidRegions -contains $Region)) {
             exit 1
         }
     }
-}
-
-#───────────────────────────────────────────────────────────────────────────────
-# Keychain Functions (Windows Credential Manager)
-#───────────────────────────────────────────────────────────────────────────────
-
-$KeychainTarget = "juggernaut-bedrock"
-
-function Test-KeychainAvailable {
-    # Windows Credential Manager is always available on Windows
-    return $true
-}
-
-function Set-KeychainCredential {
-    param([string]$Key)
-
-    # Use cmdkey to store in Windows Credential Manager
-    $null = cmdkey /delete:$KeychainTarget 2>$null
-    $result = cmdkey /generic:$KeychainTarget /user:api-key /pass:$Key 2>&1
-    return $LASTEXITCODE -eq 0
-}
-
-function Get-KeychainCredential {
-    # Use Win32 CredRead API to retrieve from Credential Manager (no external modules)
-    try {
-        Add-Type -Namespace 'Win32' -Name 'Credential' -MemberDefinition '
-            [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-            public static extern bool CredRead(string target, int type, int flags, out IntPtr credential);
-            [DllImport("advapi32.dll")]
-            public static extern void CredFree(IntPtr credential);
-            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-            public struct CREDENTIAL {
-                public int Flags; public int Type;
-                public string TargetName; public string Comment;
-                public long LastWritten; public int CredentialBlobSize;
-                public IntPtr CredentialBlob; public int Persist;
-                public int AttributeCount; public IntPtr Attributes;
-                public string TargetAlias; public string UserName;
-            }
-        ' -ErrorAction SilentlyContinue
-        $ptr = [IntPtr]::Zero
-        if ([Win32.Credential]::CredRead($KeychainTarget, 1, 0, [ref]$ptr)) {
-            $cred = [Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][Win32.Credential+CREDENTIAL])
-            $password = $null
-            if ($cred.CredentialBlobSize -gt 0) {
-                $password = [Runtime.InteropServices.Marshal]::PtrToStringUni($cred.CredentialBlob, $cred.CredentialBlobSize / 2)
-            }
-            [Win32.Credential]::CredFree($ptr)
-            return $password
-        }
-        return $null
-    } catch {
-        return $null
-    }
-}
-
-function Remove-KeychainCredential {
-    $null = cmdkey /delete:$KeychainTarget 2>$null
-}
-
-# Generate the PowerShell command to retrieve key from Credential Manager
-function Get-KeychainRetrievalCommand {
-    # This generates the code that will run in the profile to get the credential
-    # Uses Win32 CredRead API - no external modules required
-    return @'
-& { Add-Type -Namespace 'Win32' -Name 'Cred' -MemberDefinition '[DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)] public static extern bool CredRead(string t, int ty, int f, out IntPtr c); [DllImport("advapi32.dll")] public static extern void CredFree(IntPtr c); [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct CREDENTIAL { public int Flags; public int Type; public string TargetName; public string Comment; public long LastWritten; public int CredentialBlobSize; public IntPtr CredentialBlob; public int Persist; public int AttributeCount; public IntPtr Attributes; public string TargetAlias; public string UserName; }' -ErrorAction SilentlyContinue; $p=[IntPtr]::Zero; if([Win32.Cred]::CredRead('juggernaut-bedrock',1,0,[ref]$p)){ $c=[Runtime.InteropServices.Marshal]::PtrToStructure($p,[Type][Win32.Cred+CREDENTIAL]); $r=$null; if($c.CredentialBlobSize -gt 0){$r=[Runtime.InteropServices.Marshal]::PtrToStringUni($c.CredentialBlob,$c.CredentialBlobSize/2)}; [Win32.Cred]::CredFree($p); $r } }
-'@
 }
 
 if ($DryRun) {
@@ -594,7 +594,11 @@ Write-Host "Target:   $ProfilePath" -ForegroundColor Gray
 Write-Host "Region:   $Region" -ForegroundColor Gray
 Write-Host "Auth:     $Auth" -ForegroundColor Gray
 if ($Auth -eq "api-key") {
-    $MaskedKey = $BedrockKey.Substring(0, [Math]::Min(8, $BedrockKey.Length)) + "..." + $BedrockKey.Substring([Math]::Max(0, $BedrockKey.Length - 4))
+    if ($BedrockKey.Length -gt 12) {
+        $MaskedKey = $BedrockKey.Substring(0, 8) + "..." + $BedrockKey.Substring($BedrockKey.Length - 4)
+    } else {
+        $MaskedKey = "****"
+    }
     Write-Host "API Key:  $MaskedKey" -ForegroundColor Gray
     Write-Host "Storage:  $Storage" -ForegroundColor Gray
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -67,11 +67,19 @@ detect_os() {
     esac
 }
 
+# Track whether keychain has already been cleaned (prevents duplicate messages)
+_KEYCHAIN_CLEANED=false
+
 # Remove API key from system keychain if keychain storage was used
 cleanup_keychain() {
     local config_file=$1
     local keychain_service="juggernaut-bedrock"
     local keychain_account="api-key"
+
+    # Only clean up once, even if called for multiple shell configs
+    if [[ "$_KEYCHAIN_CLEANED" == true ]]; then
+        return 0
+    fi
 
     # Check if keychain storage was used by looking for the marker
     if ! grep -q "# Storage: keychain" "$config_file" 2>/dev/null; then
@@ -92,6 +100,7 @@ cleanup_keychain() {
             cmdkey.exe /delete:"$keychain_service" >/dev/null 2>&1 || true
             ;;
     esac
+    _KEYCHAIN_CLEANED=true
     echo "  Removed API key from system keychain"
 }
 


### PR DESCRIPTION
## Summary

Fixes 5 issues found during post-merge code review of v1.3.1 and v1.4.0 changes.

### Fixes

| # | Severity | File | Issue |
|---|----------|------|-------|
| 1 | **High** | `setup-claude-bedrock.ps1` | `Get-KeychainCredential` called before defined — runtime error on re-run with keychain storage |
| 2 | **Medium** | `apply-config.sh` | `eval` in display loop reintroduced injection risk removed elsewhere in the same commit |
| 3 | **Low** | `apply-config.sh` | `print(val if val else '')` suppresses falsy values (`0`, `false`) — changed to `val is None` check |
| 4 | **Low** | `setup-claude-bedrock.ps1` | Key masking missing length guard (bash side was fixed, PowerShell was missed) |
| 6 | **Cosmetic** | `uninstall.sh` | Keychain cleanup message printed redundantly when uninstalling all shells |

### Testing
- Full test suite: **75 passed, 0 failed, 6 skipped**