### PR TITLE
Fix zsh indirect expansion in apply-config.sh display loop

### DIFF
--- a/apply-config.sh
+++ b/apply-config.sh
@@ -149,7 +149,11 @@ fi
 echo "Configuration applied:"
 echo "  AWS_REGION=$AWS_REGION"
 while IFS= read -r _JUGGERNAUT_KEY; do
-    echo "  ${_JUGGERNAUT_KEY}=${!_JUGGERNAUT_KEY}"
+    if [[ -n "$ZSH_VERSION" ]]; then
+        echo "  ${_JUGGERNAUT_KEY}=${(P)_JUGGERNAUT_KEY}"
+    else
+        echo "  ${_JUGGERNAUT_KEY}=${!_JUGGERNAUT_KEY}"
+    fi
 done <<< "$_JUGGERNAUT_ENV_KEYS"
 
 # Clean up temp variables and functions


### PR DESCRIPTION
## Summary

- `${!var}` is bash-only syntax. Zsh uses `${(P)var}` for indirect expansion.
- The display loop in `apply-config.sh` now checks `$ZSH_VERSION` and uses the correct syntax.
- Fixes cosmetic issue where `source apply-config.sh` in zsh would show empty values (e.g. `CLAUDE_CODE_USE_BEDROCK=`) even though the actual exports worked correctly.

**1 file changed:** `apply-config.sh`