### PR TITLE
Update fast model to Claude Sonnet 4.6 Global

### DIFF
--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -6,7 +6,7 @@
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "16384",
     "MAX_THINKING_TOKENS": "32768",
     "ANTHROPIC_MODEL": "global.anthropic.claude-opus-4-6-v1",
-    "ANTHROPIC_SMALL_FAST_MODEL": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "ANTHROPIC_SMALL_FAST_MODEL": "global.anthropic.claude-sonnet-4-6",
     "DISABLE_ERROR_REPORTING": "1",
     "DISABLE_TELEMETRY": "1",
     "DISABLE_AUTOUPDATE": "1",


### PR DESCRIPTION
## Summary

- Update `ANTHROPIC_SMALL_FAST_MODEL` from `global.anthropic.claude-sonnet-4-5-20250929-v1:0` to `global.anthropic.claude-sonnet-4-6`
- `ANTHROPIC_MODEL` (Opus 4.6 Global) was already up to date

**1 file changed:** `bedrock-config.json`