### PR TITLE
Remove file locking from setup scripts

### DIFF
--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -515,66 +515,6 @@ $ConfigBlock += "`n# END: Claude Code Bedrock Configuration"
 # Determine PowerShell profile path
 $ProfilePath = $PROFILE.CurrentUserAllHosts
 
-#───────────────────────────────────────────────────────────────────────────────
-# File Locking - Prevent concurrent modifications
-#───────────────────────────────────────────────────────────────────────────────
-
-$LockFile = "$ProfilePath.lock"
-$LockAcquired = $false
-$LockTimeout = 30  # seconds to wait for lock
-$StaleLockAge = 300  # 5 minutes - consider lock stale after this
-
-function Get-FileLock {
-    param([string]$LockPath)
-
-    $startTime = Get-Date
-    while (((Get-Date) - $startTime).TotalSeconds -lt $LockTimeout) {
-        try {
-            # Atomic lock creation using FileMode.CreateNew (fails if file exists)
-            $fs = [System.IO.File]::Open($LockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write)
-            $fs.Close()
-            return $true
-        } catch [System.IO.IOException] {
-            # Lock file exists - check if it's stale
-            try {
-                $lockAge = ((Get-Date) - (Get-Item $LockPath -ErrorAction Stop).LastWriteTime).TotalSeconds
-                if ($lockAge -gt $StaleLockAge) {
-                    Write-Host "Removing stale lock file (age: $([int]$lockAge)s)" -ForegroundColor Yellow
-                    Remove-Item $LockPath -Force -ErrorAction SilentlyContinue
-                    # Retry on next iteration rather than assuming we got it
-                }
-            } catch {
-                # Lock file disappeared between check and stat - retry
-            }
-            Start-Sleep -Milliseconds 500
-        }
-    }
-    return $false
-}
-
-function Release-FileLock {
-    param([string]$LockPath)
-    Remove-Item $LockPath -Force -ErrorAction SilentlyContinue
-}
-
-if (-not $DryRun) {
-    $LockAcquired = Get-FileLock -LockPath $LockFile
-    if (-not $LockAcquired) {
-        Write-Host "Error: Could not acquire lock on profile file" -ForegroundColor Red
-        Write-Host "Another instance may be modifying the profile. Try again later." -ForegroundColor Red
-        exit 1
-    }
-}
-
-# Ensure lock is released on exit (use -MessageData to capture values at registration time)
-$null = Register-EngineEvent -SourceIdentifier PowerShell.Exiting -MessageData @{
-    LockAcquired = $LockAcquired; LockFile = $LockFile
-} -Action {
-    if ($Event.MessageData.LockAcquired -and (Test-Path $Event.MessageData.LockFile)) {
-        Remove-Item $Event.MessageData.LockFile -Force -ErrorAction SilentlyContinue
-    }
-}
-
 # Create profile directory if it doesn't exist
 $ProfileDir = Split-Path -Parent $ProfilePath
 if (-not (Test-Path $ProfileDir)) {
@@ -653,7 +593,6 @@ if ($Auth -eq "api-key" -and $Storage -eq "keychain") {
             Write-Host "API key stored in Windows Credential Manager" -ForegroundColor Gray
         } else {
             Write-Host "Error: Failed to store API key in Credential Manager" -ForegroundColor Red
-            Release-FileLock -LockPath $LockFile
             exit 1
         }
     }
@@ -677,7 +616,6 @@ if ($DryRun) {
 try {
     Add-Content -Path $ProfilePath -Value $ConfigBlock -ErrorAction Stop
 } catch {
-    Release-FileLock -LockPath $LockFile
     Write-Host "" -ForegroundColor Red
     Write-Host "ERROR: Cannot write to $ProfilePath" -ForegroundColor Red
     Write-Host "Possible causes:" -ForegroundColor Red
@@ -711,6 +649,3 @@ if ($Auth -eq "api-key") {
 
 Write-Host ""
 Write-Host "Setup complete!" -ForegroundColor Green
-
-# Release file lock
-Release-FileLock -LockPath $LockFile

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -606,59 +606,6 @@ warn_custom_model() {
     fi
 }
 
-# File locking to prevent concurrent modifications
-LOCK_FD=""
-LOCK_FILE=""
-
-acquire_lock() {
-    local config_file=$1
-    LOCK_FILE="${config_file}.lock"
-
-    # Check if flock is available (Linux, some macOS with homebrew)
-    if command -v flock >/dev/null 2>&1; then
-        exec {LOCK_FD}>"$LOCK_FILE"
-        if ! flock -n "$LOCK_FD" 2>/dev/null; then
-            echo "ERROR: Another instance is modifying $config_file" >&2
-            echo "If no other setup is running, remove: $LOCK_FILE" >&2
-            exit 1
-        fi
-    else
-        # Fallback: use mkdir as atomic operation (portable)
-        if ! mkdir "$LOCK_FILE" 2>/dev/null; then
-            # Check if lock is stale (older than 5 minutes)
-            if [[ -d "$LOCK_FILE" ]]; then
-                local lock_age
-                lock_age=$(( $(date +%s) - $(stat -f %m "$LOCK_FILE" 2>/dev/null || stat -c %Y "$LOCK_FILE" 2>/dev/null || echo 0) ))
-                if [[ "$lock_age" -gt 300 ]]; then
-                    echo "Warning: Removing stale lock file (age: ${lock_age}s)"
-                    rmdir "$LOCK_FILE" 2>/dev/null || rm -rf "$LOCK_FILE"
-                    mkdir "$LOCK_FILE" || { echo "ERROR: Cannot acquire lock"; exit 1; }
-                else
-                    echo "ERROR: Another instance is modifying $config_file" >&2
-                    echo "If no other setup is running, remove: $LOCK_FILE" >&2
-                    exit 1
-                fi
-            fi
-        fi
-    fi
-}
-
-release_lock() {
-    if [[ -n "$LOCK_FILE" ]]; then
-        if [[ -n "$LOCK_FD" ]]; then
-            # flock mode: close file descriptor
-            exec {LOCK_FD}>&- 2>/dev/null || true
-        fi
-        # Remove lock file/directory
-        rmdir "$LOCK_FILE" 2>/dev/null || rm -f "$LOCK_FILE" 2>/dev/null || true
-        LOCK_FILE=""
-        LOCK_FD=""
-    fi
-}
-
-# Ensure lock is released on exit
-trap release_lock EXIT
-
 show_help() {
     cat << 'EOF'
 Claude Code - Amazon Bedrock Setup Script
@@ -987,11 +934,6 @@ setup_shell() {
         read -p "Configure $display_name for Bedrock? (y/n) " -n 1 -r
         echo
         [[ ! $REPLY =~ ^[Yy]$ ]] && { echo "Setup cancelled"; exit 0; }
-    fi
-
-    # Acquire lock before any file modifications
-    if [[ "$DRY_RUN" == false ]]; then
-        acquire_lock "$config_file"
     fi
 
     # Backup existing config file before any modifications


### PR DESCRIPTION
## Summary

Removes the file locking mechanism from both setup scripts. **123 lines deleted, 0 added.**

### Why

The lock protected against concurrent profile modifications — a scenario that never occurs in practice (setup is run manually, one at a time). Meanwhile, stale locks caused real user-facing failures when a previous run exited without cleanup. The timestamped backup mechanism already protects against file corruption.

### What's removed

- `setup-claude-bedrock.sh`: `acquire_lock()`, `release_lock()`, `LOCK_FD`/`LOCK_FILE` vars, `trap release_lock EXIT`, lock acquisition in `main()`
- `setup-claude-bedrock.ps1`: `Get-FileLock`, `Release-FileLock` functions, `$LockFile`/`$LockAcquired`/`$LockTimeout`/`$StaleLockAge` vars, `Register-EngineEvent` handler, lock acquisition block, all `Release-FileLock` calls in error paths

### What's kept

- Timestamped backup before profile modification (the actual safety mechanism)