### PR TITLE
Fix validate-setup bugs, sync config version, use config model for validity test

### DIFF
--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -1,6 +1,6 @@
 {
   "description": "Claude Code Bedrock configuration - single source of truth",
-  "version": "1.3.0",
+  "version": "1.4.3",
   "environment": {
     "CLAUDE_CODE_USE_BEDROCK": "1",
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "16384",

--- a/validate-setup.ps1
+++ b/validate-setup.ps1
@@ -207,9 +207,11 @@ function Test-ApiKeyValidity {
 
     try {
         # Make a minimal Bedrock API call to test the key
+        # Use the configured fast model (cheapest available) for the probe
+        $testModel = if ($ExpectedEnvVars["ANTHROPIC_SMALL_FAST_MODEL"]) { $ExpectedEnvVars["ANTHROPIC_SMALL_FAST_MODEL"] } else { "anthropic.claude-3-haiku-20240307-v1:0" }
         $result = aws bedrock-runtime converse `
             --region $region `
-            --model-id "anthropic.claude-3-haiku-20240307-v1:0" `
+            --model-id $testModel `
             --messages '[{"role":"user","content":[{"text":"hi"}]}]' `
             --max-tokens 1 2>&1
 

--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -275,9 +275,11 @@ check_api_key_validity() {
 
     # Try to invoke the model with a minimal request
     # This will fail fast if the key is invalid
+    # Use the configured fast model (cheapest available) for the probe
+    local test_model="${EXPECTED_ENV_VARS[ANTHROPIC_SMALL_FAST_MODEL]:-anthropic.claude-3-haiku-20240307-v1:0}"
     test_result=$(aws bedrock-runtime converse \
         --region "$region" \
-        --model-id "anthropic.claude-3-haiku-20240307-v1:0" \
+        --model-id "$test_model" \
         --messages '[{"role":"user","content":[{"text":"hi"}]}]' \
         --inference-config '{"maxTokens":1}' \
         2>&1)

--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -13,6 +13,16 @@ if [[ -z "$BASH_VERSION" ]]; then
     exit 1
 fi
 
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    echo "This script requires Bash 4.0 or later (found: $BASH_VERSION)"
+    echo ""
+    echo "Upgrade instructions:"
+    echo "  macOS:  brew install bash"
+    echo "  Ubuntu: sudo apt install bash"
+    echo "  RHEL:   sudo yum install bash"
+    exit 1
+fi
+
 #───────────────────────────────────────────────────────────────────────────────
 # Help
 #───────────────────────────────────────────────────────────────────────────────
@@ -77,7 +87,7 @@ for k, v in data.get('environment', {}).items():
 import sys, json
 data = json.load(sys.stdin)
 for k, v in data.get('environment', {}).items():
-    print(f'{k}={v}')
+    print('{0}={1}'.format(k, v))
 ")
     else
         echo "Error: jq or python required to parse config" >&2


### PR DESCRIPTION
## Summary

- **validate-setup.sh**: Add missing Bash 4+ version check — script uses `declare -A` (associative arrays) which silently fails on Bash 3.x
- **validate-setup.sh**: Fix Python 2 fallback using f-strings (`print(f'...')`) — replaced with `str.format()` for compatibility
- **validate-setup.sh / validate-setup.ps1**: Replace hardcoded `anthropic.claude-3-haiku-20240307-v1:0` in API key validity test with `ANTHROPIC_SMALL_FAST_MODEL` from `bedrock-config.json`, with fallback to the old model ID
- **bedrock-config.json**: Sync version field from `1.3.0` to `1.4.3` to match project `VERSION`

## Test plan

- [x] Full test suite passes (75 passed, 0 failed, 6 skipped for keychain on Linux)
- [x] `bash -n validate-setup.sh` syntax check passes
- [ ] CI: test-unix (Ubuntu + macOS)
- [ ] CI: test-windows-powershell
- [ ] CI: test-windows-gitbash