### PR TITLE
Update validity test fallback model to Claude Haiku 4.5

### DIFF
--- a/validate-setup.ps1
+++ b/validate-setup.ps1
@@ -208,7 +208,7 @@ function Test-ApiKeyValidity {
     try {
         # Make a minimal Bedrock API call to test the key
         # Use the configured fast model (cheapest available) for the probe
-        $testModel = if ($ExpectedEnvVars["ANTHROPIC_SMALL_FAST_MODEL"]) { $ExpectedEnvVars["ANTHROPIC_SMALL_FAST_MODEL"] } else { "anthropic.claude-3-haiku-20240307-v1:0" }
+        $testModel = if ($ExpectedEnvVars["ANTHROPIC_SMALL_FAST_MODEL"]) { $ExpectedEnvVars["ANTHROPIC_SMALL_FAST_MODEL"] } else { "anthropic.claude-haiku-4-5-20251001-v1:0" }
         $result = aws bedrock-runtime converse `
             --region $region `
             --model-id $testModel `

--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -276,7 +276,7 @@ check_api_key_validity() {
     # Try to invoke the model with a minimal request
     # This will fail fast if the key is invalid
     # Use the configured fast model (cheapest available) for the probe
-    local test_model="${EXPECTED_ENV_VARS[ANTHROPIC_SMALL_FAST_MODEL]:-anthropic.claude-3-haiku-20240307-v1:0}"
+    local test_model="${EXPECTED_ENV_VARS[ANTHROPIC_SMALL_FAST_MODEL]:-anthropic.claude-haiku-4-5-20251001-v1:0}"
     test_result=$(aws bedrock-runtime converse \
         --region "$region" \
         --model-id "$test_model" \


### PR DESCRIPTION
## Summary

- Replace outdated `anthropic.claude-3-haiku-20240307-v1:0` (Claude 3 Haiku) fallback with `anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5) in both `validate-setup.sh` and `validate-setup.ps1`
- This fallback is only used if `ANTHROPIC_SMALL_FAST_MODEL` can't be read from `bedrock-config.json`

## Test plan

- [x] Full test suite passes (75 passed, 0 failed)
- [ ] CI: test-unix (Ubuntu + macOS)
- [ ] CI: test-windows-powershell
- [ ] CI: test-windows-gitbash