### PR TITLE
Add --version flag to all scripts

### DIFF
--- a/apply-config.ps1
+++ b/apply-config.ps1
@@ -5,8 +5,16 @@
 
 param(
     [string]$Region,
-    [switch]$Help
+    [switch]$Help,
+    [Alias("v")]
+    [switch]$Version
 )
+
+if ($Version) {
+    $versionFile = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "VERSION"
+    if (Test-Path $versionFile) { Get-Content $versionFile } else { Write-Host "unknown" }
+    return
+}
 
 if ($Help) {
     Write-Host "Apply Claude Code Bedrock Configuration"

--- a/apply-config.sh
+++ b/apply-config.sh
@@ -31,6 +31,10 @@ for arg in "$@"; do
         --region=*)
             _JUGGERNAUT_REGION="${arg#--region=}"
             ;;
+        --version|-v)
+            cat "$_JUGGERNAUT_SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
+            return 0 2>/dev/null || exit 0
+            ;;
         --help|-h)
             cat << 'EOF'
 Apply Claude Code Bedrock Configuration
@@ -42,6 +46,7 @@ This script must be sourced (not executed) for environment variables to persist.
 
 Options:
   --region=REGION    AWS region (default: from bedrock-config.json)
+  --version, -v      Show version
   --help, -h         Show this help message
 
 Examples:

--- a/setup
+++ b/setup
@@ -40,8 +40,12 @@ detect_shell() {
 # Main
 #───────────────────────────────────────────────────────────────────────────────
 
-# Pass through help flag
+# Pass through version/help flags
 for arg in "$@"; do
+    [[ "$arg" == "--version" || "$arg" == "-v" ]] && {
+        cat "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/VERSION" 2>/dev/null || echo "unknown"
+        exit 0
+    }
     [[ "$arg" == "--help" || "$arg" == "-h" ]] && {
         echo "Juggernaut - Claude Code Bedrock Setup"
         echo ""
@@ -58,6 +62,7 @@ for arg in "$@"; do
         echo "  --region=REGION      AWS region (default: us-west-2)"
         echo "  --dry-run            Preview changes without modifying files"
         echo "  --force, -f          Skip confirmation prompts"
+        echo "  --version, -v        Show version"
         echo "  --help, -h           Show this help message"
         echo ""
         echo "Examples:"

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -13,7 +13,9 @@ param(
     [string]$FastModel = "",
     [switch]$Force,
     [switch]$DryRun,
-    [switch]$Help
+    [switch]$Help,
+    [Alias("v")]
+    [switch]$Version
 )
 
 # Track if parameters were explicitly provided by the user
@@ -314,6 +316,13 @@ function Get-KeychainRetrievalCommand {
     return @'
 & { Add-Type -Namespace 'Win32' -Name 'Cred' -MemberDefinition '[DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)] public static extern bool CredRead(string t, int ty, int f, out IntPtr c); [DllImport("advapi32.dll")] public static extern void CredFree(IntPtr c); [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct CREDENTIAL { public int Flags; public int Type; public string TargetName; public string Comment; public long LastWritten; public int CredentialBlobSize; public IntPtr CredentialBlob; public int Persist; public int AttributeCount; public IntPtr Attributes; public string TargetAlias; public string UserName; }' -ErrorAction SilentlyContinue; $p=[IntPtr]::Zero; if([Win32.Cred]::CredRead('juggernaut-bedrock',1,0,[ref]$p)){ $c=[Runtime.InteropServices.Marshal]::PtrToStructure($p,[Type][Win32.Cred+CREDENTIAL]); $r=$null; if($c.CredentialBlobSize -gt 0){$r=[Runtime.InteropServices.Marshal]::PtrToStringUni($c.CredentialBlob,$c.CredentialBlobSize/2)}; [Win32.Cred]::CredFree($p); $r } }
 '@
+}
+
+# Show version
+if ($Version) {
+    $versionFile = Join-Path $ScriptDir "VERSION"
+    if (Test-Path $versionFile) { Get-Content $versionFile } else { Write-Host "unknown" }
+    exit 0
 }
 
 # Show help

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -626,6 +626,7 @@ Options:
   --fast-model=ID        Custom fast model (use "default" to reset)
   --dry-run              Preview changes without modifying files
   --force, -f            Skip confirmation prompts
+  --version, -v          Show version
   --help, -h             Show this help message
 
 Authentication Modes:
@@ -728,6 +729,10 @@ parse_arguments() {
             --fast-model=*)
                 CUSTOM_FAST_MODEL="${arg#--fast-model=}"
                 FAST_MODEL_EXPLICIT=true
+                ;;
+            --version|-v)
+                cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
+                exit 0
                 ;;
             --help|-h)
                 show_help

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -177,9 +177,15 @@ uninstall_shell() {
 
 TARGET="all"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 parse_arguments() {
     for arg in "$@"; do
         case "$arg" in
+            --version|-v)
+                cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
+                exit 0
+                ;;
             --help|-h)
                 show_help
                 exit 0

--- a/validate-setup.ps1
+++ b/validate-setup.ps1
@@ -3,8 +3,16 @@
 # Usage: .\validate-setup.ps1 [-Help]
 
 param(
-    [switch]$Help
+    [switch]$Help,
+    [Alias("v")]
+    [switch]$Version
 )
+
+if ($Version) {
+    $versionFile = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "VERSION"
+    if (Test-Path $versionFile) { Get-Content $versionFile } else { Write-Host "unknown" }
+    exit 0
+}
 
 if ($Help) {
     Write-Host "Juggernaut - Configuration Validator"

--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -29,6 +29,10 @@ fi
 
 for arg in "$@"; do
     case "$arg" in
+        --version|-v)
+            cat "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/VERSION" 2>/dev/null || echo "unknown"
+            exit 0
+            ;;
         --help|-h)
             cat << 'EOF'
 Juggernaut - Configuration Validator
@@ -39,6 +43,7 @@ Validates that Claude Code is properly configured for Amazon Bedrock.
 Checks environment variables, AWS credentials, Bedrock access, and Claude Code installation.
 
 Options:
+  --version, -v Show version
   --help, -h    Show this help message
 EOF
             exit 0


### PR DESCRIPTION
## Summary

- Add `--version` / `-v` flag to all 8 scripts (4 Bash, 4 PowerShell)
- Reads version from the `VERSION` file
- Updated help text in `setup`, `setup-claude-bedrock.sh`, `validate-setup.sh`, and `apply-config.sh` to document the flag

### Scripts updated
- `setup`
- `setup-claude-bedrock.sh` / `setup-claude-bedrock.ps1`
- `uninstall.sh`
- `validate-setup.sh` / `validate-setup.ps1`
- `apply-config.sh` / `apply-config.ps1`

## Test plan

- [x] `--version` and `-v` return `1.4.4` on all Bash scripts
- [x] Full test suite passes (75 passed, 0 failed)
- [ ] CI: test-unix (Ubuntu + macOS)
- [ ] CI: test-windows-powershell
- [ ] CI: test-windows-gitbash