### PR TITLE
Increase token limits for Opus 4.6

### DIFF
--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -3,8 +3,8 @@
   "version": "1.5.0",
   "environment": {
     "CLAUDE_CODE_USE_BEDROCK": "1",
-    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "16384",
-    "MAX_THINKING_TOKENS": "32768",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32768",
+    "MAX_THINKING_TOKENS": "65536",
     "ANTHROPIC_MODEL": "global.anthropic.claude-opus-4-6-v1",
     "ANTHROPIC_SMALL_FAST_MODEL": "global.anthropic.claude-sonnet-4-6",
     "DISABLE_ERROR_REPORTING": "1",


### PR DESCRIPTION
## Summary
- Bump `CLAUDE_CODE_MAX_OUTPUT_TOKENS` from 16384 → 32768 (2x)
- Bump `MAX_THINKING_TOKENS` from 32768 → 65536 (2x)

Both Opus 4.6 (128k max output) and Sonnet 4.6 (64k max output) now have 1M context windows. These increases better utilize the available capacity while staying well within limits (32k output + 64k thinking = 96k, under Opus's 128k ceiling).

## Test plan
- [x] Full test suite passes (75/75)
- [ ] CI checks pass