### PR TITLE
Fix PowerShell profile reload instruction

### DIFF
--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -639,8 +639,8 @@ try {
 Write-Host "Configuration added to $ProfilePath" -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Cyan
-Write-Host "1. Reload PowerShell profile:"
-Write-Host "   . `$PROFILE" -ForegroundColor White
+Write-Host "1. Restart PowerShell, or reload your profile:"
+Write-Host "   . `$PROFILE.CurrentUserAllHosts" -ForegroundColor White
 Write-Host ""
 
 if ($Auth -eq "api-key") {


### PR DESCRIPTION
## Summary
- Fix incorrect profile reload command in setup output
- Script writes to `$PROFILE.CurrentUserAllHosts` (`profile.ps1`) but told users to reload with `. $PROFILE` (`Microsoft.PowerShell_profile.ps1`) — different file
- Updated to: `. $PROFILE.CurrentUserAllHosts` and suggest restart as primary option

## Test plan
- [x] Full test suite passes (75/75)
- [ ] CI checks pass