### PR TITLE
fix: address code review findings

### DIFF
--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -537,7 +537,12 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
                 Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
                 Write-Host ""
                 $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
-                $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey))
+                $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
+                try {
+                    $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+                } finally {
+                    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+                }
                 if ([string]::IsNullOrEmpty($BedrockKey)) {
                     Write-Host "Error: API key cannot be empty" -ForegroundColor Red
                     exit 1
@@ -559,7 +564,12 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
         Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
         Write-Host ""
         $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
-        $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey))
+        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
+        try {
+            $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+        } finally {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
 
         if ([string]::IsNullOrEmpty($BedrockKey)) {
             Write-Host "Error: API key cannot be empty" -ForegroundColor Red

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -674,6 +674,7 @@ if ($Auth -eq "api-key") {
     $ConfigBlock += "Remove-Item Env:AWS_ACCESS_KEY_ID -ErrorAction SilentlyContinue`n"
     $ConfigBlock += "Remove-Item Env:AWS_SECRET_ACCESS_KEY -ErrorAction SilentlyContinue`n"
     $ConfigBlock += "Remove-Item Env:AWS_SESSION_TOKEN -ErrorAction SilentlyContinue`n"
+    $ConfigBlock += "Remove-Item Env:AWS_PROFILE -ErrorAction SilentlyContinue`n"
 } else {
     # Using IAM/SSO - unset API key that might interfere
     $ConfigBlock += "Remove-Item Env:AWS_BEARER_TOKEN_BEDROCK -ErrorAction SilentlyContinue`n"

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -655,7 +655,7 @@ warn_custom_model() {
     local model_type=$2
 
     echo ""
-    echo "⚠️  Custom $model_type model: $model_id"
+    echo "Warning: Custom $model_type model: $model_id"
     echo "   Cannot validate without working AWS credentials."
     echo "   Ensure this model is available in your Bedrock region."
     echo ""

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -600,8 +600,10 @@ detect_existing_sonnet_model() {
 # Detect existing 1M context setting from config file
 detect_existing_1m_context() {
     local profile_file=$1
-    if grep -q "# 1MContext: true" "$profile_file" 2>/dev/null; then
-        echo "true"
+    if [[ -f "$profile_file" ]]; then
+        if grep -q "# 1MContext: true" "$profile_file" 2>/dev/null; then
+            echo "true"
+        fi
     fi
 }
 

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -473,11 +473,12 @@ generate_config_block() {
                 config+="$syntax AWS_BEARER_TOKEN_BEDROCK=$keychain_cmd"$'\n'
             fi
         else
-            # Store directly in profile (legacy behavior)
+            # Store directly in profile — quote to prevent shell metacharacter interpretation
+            local escaped_api_key="${api_key//\"/\\\"}"
             if [[ "$shell" == "fish" ]]; then
-                config+="$syntax AWS_BEARER_TOKEN_BEDROCK $api_key"$'\n'
+                config+="$syntax AWS_BEARER_TOKEN_BEDROCK \"$escaped_api_key\""$'\n'
             else
-                config+="$syntax AWS_BEARER_TOKEN_BEDROCK=$api_key"$'\n'
+                config+="$syntax AWS_BEARER_TOKEN_BEDROCK=\"$escaped_api_key\""$'\n'
             fi
         fi
     fi

--- a/test.sh
+++ b/test.sh
@@ -655,6 +655,26 @@ test_1m_context() {
 }
 
 #───────────────────────────────────────────────────────────────────────────────
+# API Key Quoting Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_api_key_quoting() {
+    section "API Key Quoting in Config Block"
+
+    run_test "bash config block quotes API key value" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q 'AWS_BEARER_TOKEN_BEDROCK=\"br-test123\"'"
+
+    run_test "zsh config block quotes API key value" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh zsh --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q 'AWS_BEARER_TOKEN_BEDROCK=\"br-test123\"'"
+
+    run_test "bash config block quotes API key with dollar sign" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test\$var' --storage=profile --dry-run --force 2>&1 | grep 'AWS_BEARER_TOKEN_BEDROCK=' | grep -q '\"'"
+
+    run_test "fish config block quotes API key value" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q 'AWS_BEARER_TOKEN_BEDROCK \"br-test123\"'"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
 # Main
 #───────────────────────────────────────────────────────────────────────────────
 
@@ -686,6 +706,7 @@ main() {
     test_install_script
     test_capabilities
     test_1m_context
+    test_api_key_quoting
     test_required_files
     test_json_validity
     test_unified_entry_point

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -4,13 +4,13 @@
 
 $ErrorActionPreference = "Stop"
 
-Write-Host "🗑️  Removing Claude Code Bedrock configuration..." -ForegroundColor Cyan
+Write-Host "Removing Claude Code Bedrock configuration..." -ForegroundColor Cyan
 
 # Determine PowerShell profile path
 $ProfilePath = $PROFILE.CurrentUserAllHosts
 
 if (-not (Test-Path $ProfilePath)) {
-    Write-Host "⏭️  PowerShell profile not found ($ProfilePath)" -ForegroundColor Yellow
+    Write-Host "PowerShell profile not found ($ProfilePath)" -ForegroundColor Yellow
     exit 0
 }
 
@@ -30,14 +30,14 @@ if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
     $ProfileContent = $ProfileContent -replace "(\r?\n){3,}", "`n`n"
     Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline
     Add-Content -Path $ProfilePath -Value ""
-    Write-Host "✅ Configuration removed from $ProfilePath" -ForegroundColor Green
+    Write-Host "Configuration removed from $ProfilePath" -ForegroundColor Green
 } else {
-    Write-Host "⏭️  No configuration found in $ProfilePath" -ForegroundColor Yellow
+    Write-Host "No configuration found in $ProfilePath" -ForegroundColor Yellow
 }
 
 Write-Host ""
-Write-Host "📋 Next steps:" -ForegroundColor Cyan
+Write-Host "Next steps:" -ForegroundColor Cyan
 Write-Host "1. Restart PowerShell or run: . `$PROFILE"
 Write-Host "2. Claude Code will now use Anthropic's direct API (requires login)"
 Write-Host ""
-Write-Host "✨ Uninstall complete!" -ForegroundColor Green
+Write-Host "Uninstall complete!" -ForegroundColor Green

--- a/validate-setup.ps1
+++ b/validate-setup.ps1
@@ -221,7 +221,7 @@ function Test-ApiKeyValidity {
             --region $region `
             --model-id $testModel `
             --messages '[{"role":"user","content":[{"text":"hi"}]}]' `
-            --max-tokens 1 2>&1
+            --inference-config '{"maxTokens":1}' 2>&1
 
         if ($LASTEXITCODE -eq 0) {
             Write-Host "PASS" -ForegroundColor Green -NoNewline


### PR DESCRIPTION
## Summary
- Quote API key in generated bash/zsh/fish config blocks to prevent shell metacharacter injection
- Unset AWS_PROFILE in PowerShell api-key mode (matches bash behavior)
- Use --inference-config instead of --max-tokens in PowerShell validator
- Free BSTR after SecureString conversion to prevent memory leak
- Add file guard to detect_existing_1m_context for consistency
- Remove emojis for consistent cross-platform output

## Test plan
- [ ] `bash ./test.sh` passes (includes new API key quoting tests)
- [ ] CI passes on all 3 platform jobs
- [ ] `pwsh setup-claude-bedrock.ps1 -Auth api-key -BedrockKey br-test -DryRun` shows AWS_PROFILE removal