### PR TITLE
feat: pre-flight checks, shellcheck CI, and version sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Auto-detect text files and normalize line endings
+* text=auto
+
+# Shell scripts must use LF (Unix) line endings — bash chokes on CRLF
+*.sh text eol=lf
+
+# Entry point script without .sh extension
+setup text eol=lf
+
+# Shellcheck config
+.shellcheckrc text eol=lf
+
+# PowerShell scripts use CRLF (Windows)
+*.ps1 text eol=crlf
+
+# JSON/YAML config files — LF for consistency
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Markdown — LF for consistency
+*.md text eol=lf
+
+# Keep VERSION file with LF
+VERSION text eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,11 @@ jobs:
       - name: Verify version sync
         run: |
           FILE_VERSION=$(tr -d '[:space:]' < VERSION)
-          JSON_VERSION=$(jq -r '.version' bedrock-config.json | tr -d '[:space:]')
+          if command -v jq &>/dev/null; then
+            JSON_VERSION=$(jq -r '.version' bedrock-config.json | tr -d '[:space:]')
+          else
+            JSON_VERSION=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" bedrock-config.json | tr -d '[:space:]')
+          fi
           if [[ "$FILE_VERSION" != "$JSON_VERSION" ]]; then
             echo "ERROR: VERSION ($FILE_VERSION) != bedrock-config.json ($JSON_VERSION)"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,34 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run shellcheck
+        run: shellcheck setup-claude-bedrock.sh uninstall.sh validate-setup.sh apply-config.sh install.sh setup
+
+      - name: Verify version sync
+        run: |
+          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          JSON_VERSION=$(jq -r '.version' bedrock-config.json | tr -d '[:space:]')
+          if [[ "$FILE_VERSION" != "$JSON_VERSION" ]]; then
+            echo "ERROR: VERSION ($FILE_VERSION) != bedrock-config.json ($JSON_VERSION)"
+            exit 1
+          fi
+          echo "Version sync OK: $FILE_VERSION"
+
   test-unix:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -111,6 +136,7 @@ jobs:
   test-windows-powershell:
     name: Test on Windows (PowerShell)
     runs-on: windows-latest
+    needs: lint
 
     steps:
       - name: Checkout
@@ -175,6 +201,7 @@ jobs:
   test-windows-gitbash:
     name: Test on Windows (Git Bash)
     runs-on: windows-latest
+    needs: lint
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Verify version sync
         run: |
-          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          FILE_VERSION=$(tr -d '[:space:]' < VERSION)
           JSON_VERSION=$(jq -r '.version' bedrock-config.json | tr -d '[:space:]')
           if [[ "$FILE_VERSION" != "$JSON_VERSION" ]]; then
             echo "ERROR: VERSION ($FILE_VERSION) != bedrock-config.json ($JSON_VERSION)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Install lint dependencies
+        run: sudo apt-get update && sudo apt-get install -y shellcheck jq
 
       - name: Run shellcheck
         run: shellcheck setup-claude-bedrock.sh uninstall.sh validate-setup.sh apply-config.sh install.sh setup

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See [Model Switching on Bedrock](#model-switching-on-bedrock-v16) for details.
 3. Claude Code installed
 4. Valid AWS credentials
 5. Bash 4.0+ (macOS users: `brew install bash`)
+6. `jq` or `python3` (for JSON parsing — the setup script checks this automatically)
 
 ## Quick Setup (New Machine)
 
@@ -200,6 +201,15 @@ Use the provided setup script for your operating system:
 ./setup --region=us-east-1                 # Override default region
 .\setup-claude-bedrock.ps1 -Region us-east-1  # Windows PowerShell
 ```
+
+**Skip pre-flight dependency checks:**
+```bash
+./setup --skip-preflight                   # Unix/macOS/Linux
+.\setup-claude-bedrock.ps1 -SkipPreflight  # Windows PowerShell
+JUGGERNAUT_SKIP_PREFLIGHT=1 ./setup        # Environment variable (useful for CI)
+```
+
+The setup script checks for required tools (`jq`/`python3`, `aws` CLI) before running. Use `--skip-preflight` to bypass the `aws` CLI check if you know your environment is configured correctly or you're using API key authentication.
 
 ### API Key Authentication (Alternative)
 
@@ -557,6 +567,10 @@ When using Bedrock, Claude Code follows this precedence:
    - Check file permissions on your shell profile
    - On Windows, try running PowerShell as Administrator
    - A backup is automatically created before modifications
+
+7. **"jq or python3 is required" error**
+   - Install jq: `brew install jq` (macOS), `sudo apt install jq` (Linux), `winget install jqlang.jq` (Windows)
+   - Or install python3 as a fallback
 
 ## Uninstalling
 

--- a/apply-config.sh
+++ b/apply-config.sh
@@ -165,11 +165,15 @@ print('\n'.join(obj.keys()))
     echo "To make it permanent, run: ./setup-claude-bedrock.sh"
 }
 
-# Run and clean up
-_juggernaut_apply_config "$@"
-_juggernaut_rc=$?
-unset -f _juggernaut_apply_config _juggernaut_get_json_value _juggernaut_get_json_keys
-return "$_juggernaut_rc" 2>/dev/null
-# Reached only when executed directly (not sourced) — return fails, so exit runs
-# shellcheck disable=SC2317
-exit "$_juggernaut_rc"
+# Run and clean up — avoid temp variable that would leak into user's shell when sourced
+if _juggernaut_apply_config "$@"; then
+    unset -f _juggernaut_apply_config _juggernaut_get_json_value _juggernaut_get_json_keys
+    return 0 2>/dev/null
+    # shellcheck disable=SC2317
+    exit 0
+else
+    unset -f _juggernaut_apply_config _juggernaut_get_json_value _juggernaut_get_json_keys
+    return 1 2>/dev/null
+    # shellcheck disable=SC2317
+    exit 1
+fi

--- a/apply-config.sh
+++ b/apply-config.sh
@@ -11,9 +11,11 @@
 #───────────────────────────────────────────────────────────────────────────────
 
 # Get script directory (works when sourced)
-if [[ -n "$BASH_SOURCE" ]]; then
+if [[ -n "${BASH_SOURCE[0]+x}" ]]; then
     _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 elif [[ -n "$ZSH_VERSION" ]]; then
+    # ${(%):-%x} is zsh syntax for current script path
+    # shellcheck disable=SC2296
     _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${(%):-%x}")" && pwd)"
 else
     _JUGGERNAUT_SCRIPT_DIR="$(pwd)"
@@ -33,6 +35,8 @@ for arg in "$@"; do
             ;;
         --version|-v)
             cat "$_JUGGERNAUT_SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
+            # exit 0 is fallback when script is executed, not sourced
+            # shellcheck disable=SC2317
             return 0 2>/dev/null || exit 0
             ;;
         --help|-h)
@@ -53,6 +57,8 @@ Examples:
   source apply-config.sh
   source apply-config.sh --region=us-east-1
 EOF
+            # exit 0 is fallback when script is executed, not sourced
+            # shellcheck disable=SC2317
             return 0 2>/dev/null || exit 0
             ;;
     esac
@@ -64,6 +70,8 @@ done
 
 if [[ ! -f "$_JUGGERNAUT_CONFIG_FILE" ]]; then
     echo "Error: Config file not found: $_JUGGERNAUT_CONFIG_FILE" >&2
+    # exit 1 is fallback when script is executed, not sourced
+    # shellcheck disable=SC2317
     return 1 2>/dev/null || exit 1
 fi
 
@@ -127,6 +135,8 @@ if [[ -n "$_JUGGERNAUT_ENV_KEYS" ]]; then
     done <<< "$_JUGGERNAUT_ENV_KEYS"
 else
     echo "Error: Could not load environment variables from config" >&2
+    # exit 1 is fallback when script is executed, not sourced
+    # shellcheck disable=SC2317
     return 1 2>/dev/null || exit 1
 fi
 
@@ -134,7 +144,8 @@ fi
 if [[ -n "$_JUGGERNAUT_REGION" ]]; then
     export AWS_REGION="$_JUGGERNAUT_REGION"
 else
-    export AWS_REGION="$(_juggernaut_get_json_value '.defaults.region')"
+    _JUGGERNAUT_DEFAULT_REGION="$(_juggernaut_get_json_value '.defaults.region')"
+    export AWS_REGION="$_JUGGERNAUT_DEFAULT_REGION"
 fi
 
 # Display applied configuration
@@ -142,6 +153,8 @@ echo "Configuration applied:"
 echo "  AWS_REGION=$AWS_REGION"
 while IFS= read -r _JUGGERNAUT_KEY; do
     if [[ -n "$ZSH_VERSION" ]]; then
+        # ${(P)...} is zsh indirect expansion
+        # shellcheck disable=SC2296
         echo "  ${_JUGGERNAUT_KEY}=${(P)_JUGGERNAUT_KEY}"
     else
         echo "  ${_JUGGERNAUT_KEY}=${!_JUGGERNAUT_KEY}"

--- a/apply-config.sh
+++ b/apply-config.sh
@@ -35,7 +35,7 @@ for arg in "$@"; do
             ;;
         --version|-v)
             cat "$_JUGGERNAUT_SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
-            # exit 0 is fallback when script is executed, not sourced
+            # return fails when not sourced, so exit is the reachable fallback
             # shellcheck disable=SC2317
             return 0 2>/dev/null || exit 0
             ;;
@@ -57,7 +57,7 @@ Examples:
   source apply-config.sh
   source apply-config.sh --region=us-east-1
 EOF
-            # exit 0 is fallback when script is executed, not sourced
+            # return fails when not sourced, so exit is the reachable fallback
             # shellcheck disable=SC2317
             return 0 2>/dev/null || exit 0
             ;;
@@ -70,7 +70,7 @@ done
 
 if [[ ! -f "$_JUGGERNAUT_CONFIG_FILE" ]]; then
     echo "Error: Config file not found: $_JUGGERNAUT_CONFIG_FILE" >&2
-    # exit 1 is fallback when script is executed, not sourced
+    # return fails when not sourced, so exit is the reachable fallback
     # shellcheck disable=SC2317
     return 1 2>/dev/null || exit 1
 fi
@@ -135,7 +135,7 @@ if [[ -n "$_JUGGERNAUT_ENV_KEYS" ]]; then
     done <<< "$_JUGGERNAUT_ENV_KEYS"
 else
     echo "Error: Could not load environment variables from config" >&2
-    # exit 1 is fallback when script is executed, not sourced
+    # return fails when not sourced, so exit is the reachable fallback
     # shellcheck disable=SC2317
     return 1 2>/dev/null || exit 1
 fi

--- a/apply-config.sh
+++ b/apply-config.sh
@@ -18,6 +18,7 @@ _juggernaut_apply_config() {
         _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     elif [[ -n "$ZSH_VERSION" ]]; then
         # ${(%):-%x} is zsh syntax for current script path
+        # SC2296: shellcheck doesn't understand zsh parameter expansion syntax
         # shellcheck disable=SC2296
         _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${(%):-%x}")" && pwd)"
     else
@@ -153,6 +154,7 @@ print('\n'.join(obj.keys()))
     while IFS= read -r _JUGGERNAUT_KEY; do
         if [[ -n "$ZSH_VERSION" ]]; then
             # ${(P)...} is zsh indirect expansion
+            # SC2296: shellcheck doesn't understand zsh parameter expansion syntax
             # shellcheck disable=SC2296
             echo "  ${_JUGGERNAUT_KEY}=${(P)_JUGGERNAUT_KEY}"
         else
@@ -169,11 +171,13 @@ print('\n'.join(obj.keys()))
 if _juggernaut_apply_config "$@"; then
     unset -f _juggernaut_apply_config _juggernaut_get_json_value _juggernaut_get_json_keys
     return 0 2>/dev/null
+    # SC2317: exit is the fallback when script is executed (not sourced); return exits first when sourced
     # shellcheck disable=SC2317
     exit 0
 else
     unset -f _juggernaut_apply_config _juggernaut_get_json_value _juggernaut_get_json_keys
     return 1 2>/dev/null
+    # SC2317: exit is the fallback when script is executed (not sourced); return exits first when sourced
     # shellcheck disable=SC2317
     exit 1
 fi

--- a/apply-config.sh
+++ b/apply-config.sh
@@ -6,41 +6,43 @@
 # NOTE: This script must be sourced (not executed) for environment variables to persist.
 # Works with both bash and zsh.
 
-#───────────────────────────────────────────────────────────────────────────────
-# Find Config File
-#───────────────────────────────────────────────────────────────────────────────
+_juggernaut_apply_config() {
 
-# Get script directory (works when sourced)
-if [[ -n "${BASH_SOURCE[0]+x}" ]]; then
-    _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-elif [[ -n "$ZSH_VERSION" ]]; then
-    # ${(%):-%x} is zsh syntax for current script path
-    # shellcheck disable=SC2296
-    _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${(%):-%x}")" && pwd)"
-else
-    _JUGGERNAUT_SCRIPT_DIR="$(pwd)"
-fi
-_JUGGERNAUT_CONFIG_FILE="$_JUGGERNAUT_SCRIPT_DIR/bedrock-config.json"
+    #───────────────────────────────────────────────────────────────────────────────
+    # Find Config File
+    #───────────────────────────────────────────────────────────────────────────────
 
-#───────────────────────────────────────────────────────────────────────────────
-# Argument Parsing
-#───────────────────────────────────────────────────────────────────────────────
+    # Get script directory (works when sourced)
+    local _JUGGERNAUT_SCRIPT_DIR
+    if [[ -n "${BASH_SOURCE[0]+x}" ]]; then
+        _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    elif [[ -n "$ZSH_VERSION" ]]; then
+        # ${(%):-%x} is zsh syntax for current script path
+        # shellcheck disable=SC2296
+        _JUGGERNAUT_SCRIPT_DIR="$(cd "$(dirname "${(%):-%x}")" && pwd)"
+    else
+        _JUGGERNAUT_SCRIPT_DIR="$(pwd)"
+    fi
+    local _JUGGERNAUT_CONFIG_FILE="$_JUGGERNAUT_SCRIPT_DIR/bedrock-config.json"
 
-_JUGGERNAUT_REGION=""
+    #───────────────────────────────────────────────────────────────────────────────
+    # Argument Parsing
+    #───────────────────────────────────────────────────────────────────────────────
 
-for arg in "$@"; do
-    case "$arg" in
-        --region=*)
-            _JUGGERNAUT_REGION="${arg#--region=}"
-            ;;
-        --version|-v)
-            cat "$_JUGGERNAUT_SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
-            # return fails when not sourced, so exit is the reachable fallback
-            # shellcheck disable=SC2317
-            return 0 2>/dev/null || exit 0
-            ;;
-        --help|-h)
-            cat << 'EOF'
+    local _JUGGERNAUT_REGION=""
+
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --region=*)
+                _JUGGERNAUT_REGION="${arg#--region=}"
+                ;;
+            --version|-v)
+                cat "$_JUGGERNAUT_SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"
+                return 0
+                ;;
+            --help|-h)
+                cat << 'EOF'
 Apply Claude Code Bedrock Configuration
 
 Usage: source apply-config.sh [--region=REGION]
@@ -57,115 +59,117 @@ Examples:
   source apply-config.sh
   source apply-config.sh --region=us-east-1
 EOF
-            # return fails when not sourced, so exit is the reachable fallback
-            # shellcheck disable=SC2317
-            return 0 2>/dev/null || exit 0
-            ;;
-    esac
-done
+                return 0
+                ;;
+        esac
+    done
 
-#───────────────────────────────────────────────────────────────────────────────
-# Load Configuration from JSON
-#───────────────────────────────────────────────────────────────────────────────
+    #───────────────────────────────────────────────────────────────────────────────
+    # Load Configuration from JSON
+    #───────────────────────────────────────────────────────────────────────────────
 
-if [[ ! -f "$_JUGGERNAUT_CONFIG_FILE" ]]; then
-    echo "Error: Config file not found: $_JUGGERNAUT_CONFIG_FILE" >&2
-    # return fails when not sourced, so exit is the reachable fallback
-    # shellcheck disable=SC2317
-    return 1 2>/dev/null || exit 1
-fi
+    if [[ ! -f "$_JUGGERNAUT_CONFIG_FILE" ]]; then
+        echo "Error: Config file not found: $_JUGGERNAUT_CONFIG_FILE" >&2
+        return 1
+    fi
 
-_JUGGERNAUT_JSON_CONTENT=$(cat "$_JUGGERNAUT_CONFIG_FILE")
+    local _JUGGERNAUT_JSON_CONTENT
+    _JUGGERNAUT_JSON_CONTENT=$(cat "$_JUGGERNAUT_CONFIG_FILE")
 
-# Parse JSON using jq or python3 fallback
-# Python fallback uses sys.argv to avoid eval() and shell injection risks
-_juggernaut_get_json_value() {
-    local key=$1
-    if command -v jq >/dev/null 2>&1; then
-        echo "$_JUGGERNAUT_JSON_CONTENT" | jq -r "$key // empty" | tr -d '\r'
-    elif command -v python3 >/dev/null 2>&1; then
-        echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "
+    # Parse JSON using jq or python3 fallback
+    # Python fallback uses sys.argv to avoid shell injection risks
+    _juggernaut_get_json_value() {
+        local key=$1
+        if command -v jq >/dev/null 2>&1; then
+            echo "$_JUGGERNAUT_JSON_CONTENT" | jq -r "$key // empty" | tr -d '\r'
+        elif command -v python3 >/dev/null 2>&1; then
+            echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "
 import sys,json,functools
 d=json.load(sys.stdin)
 keys=[k for k in sys.argv[1].split('.') if k]
 val=functools.reduce(lambda d,k: d[k], keys, d)
 print('' if val is None else val)
 " "$key" 2>/dev/null | tr -d '\r'
-    else
-        echo "Error: jq or python3 required to parse config" >&2
-        return 1
-    fi
-}
+        else
+            echo "Error: jq or python3 required to parse config" >&2
+            return 1
+        fi
+    }
 
-# Helper to get all keys from a JSON object
-_juggernaut_get_json_keys() {
-    local key=$1
-    if command -v jq >/dev/null 2>&1; then
-        echo "$_JUGGERNAUT_JSON_CONTENT" | jq -r "$key | keys[]" 2>/dev/null | tr -d '\r'
-    elif command -v python3 >/dev/null 2>&1; then
-        echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "
+    # Helper to get all keys from a JSON object
+    _juggernaut_get_json_keys() {
+        local key=$1
+        if command -v jq >/dev/null 2>&1; then
+            echo "$_JUGGERNAUT_JSON_CONTENT" | jq -r "$key | keys[]" 2>/dev/null | tr -d '\r'
+        elif command -v python3 >/dev/null 2>&1; then
+            echo "$_JUGGERNAUT_JSON_CONTENT" | python3 -c "
 import sys,json,functools
 d=json.load(sys.stdin)
 keys=[k for k in sys.argv[1].split('.') if k]
 obj=functools.reduce(lambda d,k: d[k], keys, d)
 print('\n'.join(obj.keys()))
 " "$key" 2>/dev/null | tr -d '\r'
+        else
+            echo "Error: jq or python3 required to parse config" >&2
+            return 1
+        fi
+    }
+
+    #───────────────────────────────────────────────────────────────────────────────
+    # Apply Configuration
+    #───────────────────────────────────────────────────────────────────────────────
+
+    echo "Applying Claude Code Bedrock configuration..."
+    echo ""
+
+    # Dynamically load and export all environment variables from config
+    local _JUGGERNAUT_ENV_KEYS _JUGGERNAUT_KEY _JUGGERNAUT_VAL
+    _JUGGERNAUT_ENV_KEYS=$(_juggernaut_get_json_keys '.environment')
+    if [[ -n "$_JUGGERNAUT_ENV_KEYS" ]]; then
+        while IFS= read -r _JUGGERNAUT_KEY; do
+            _JUGGERNAUT_VAL="$(_juggernaut_get_json_value ".environment.$_JUGGERNAUT_KEY")"
+            if [[ -z "$_JUGGERNAUT_VAL" ]]; then
+                echo "Warning: empty value for $_JUGGERNAUT_KEY in config" >&2
+            fi
+            export "$_JUGGERNAUT_KEY=$_JUGGERNAUT_VAL"
+        done <<< "$_JUGGERNAUT_ENV_KEYS"
     else
-        echo "Error: jq or python3 required to parse config" >&2
+        echo "Error: Could not load environment variables from config" >&2
         return 1
     fi
+
+    # Region: command line overrides config default
+    local _JUGGERNAUT_DEFAULT_REGION
+    if [[ -n "$_JUGGERNAUT_REGION" ]]; then
+        export AWS_REGION="$_JUGGERNAUT_REGION"
+    else
+        _JUGGERNAUT_DEFAULT_REGION="$(_juggernaut_get_json_value '.defaults.region')"
+        export AWS_REGION="$_JUGGERNAUT_DEFAULT_REGION"
+    fi
+
+    # Display applied configuration
+    echo "Configuration applied:"
+    echo "  AWS_REGION=$AWS_REGION"
+    while IFS= read -r _JUGGERNAUT_KEY; do
+        if [[ -n "$ZSH_VERSION" ]]; then
+            # ${(P)...} is zsh indirect expansion
+            # shellcheck disable=SC2296
+            echo "  ${_JUGGERNAUT_KEY}=${(P)_JUGGERNAUT_KEY}"
+        else
+            echo "  ${_JUGGERNAUT_KEY}=${!_JUGGERNAUT_KEY}"
+        fi
+    done <<< "$_JUGGERNAUT_ENV_KEYS"
+
+    echo ""
+    echo "This configuration is active for the current terminal session only."
+    echo "To make it permanent, run: ./setup-claude-bedrock.sh"
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# Apply Configuration
-#───────────────────────────────────────────────────────────────────────────────
-
-echo "Applying Claude Code Bedrock configuration..."
-echo ""
-
-# Dynamically load and export all environment variables from config
-_JUGGERNAUT_ENV_KEYS=$(_juggernaut_get_json_keys '.environment')
-if [[ -n "$_JUGGERNAUT_ENV_KEYS" ]]; then
-    while IFS= read -r _JUGGERNAUT_KEY; do
-        _JUGGERNAUT_VAL="$(_juggernaut_get_json_value ".environment.$_JUGGERNAUT_KEY")"
-        if [[ -z "$_JUGGERNAUT_VAL" ]]; then
-            echo "Warning: empty value for $_JUGGERNAUT_KEY in config" >&2
-        fi
-        export "$_JUGGERNAUT_KEY=$_JUGGERNAUT_VAL"
-    done <<< "$_JUGGERNAUT_ENV_KEYS"
-else
-    echo "Error: Could not load environment variables from config" >&2
-    # return fails when not sourced, so exit is the reachable fallback
-    # shellcheck disable=SC2317
-    return 1 2>/dev/null || exit 1
-fi
-
-# Region: command line overrides config default
-if [[ -n "$_JUGGERNAUT_REGION" ]]; then
-    export AWS_REGION="$_JUGGERNAUT_REGION"
-else
-    _JUGGERNAUT_DEFAULT_REGION="$(_juggernaut_get_json_value '.defaults.region')"
-    export AWS_REGION="$_JUGGERNAUT_DEFAULT_REGION"
-fi
-
-# Display applied configuration
-echo "Configuration applied:"
-echo "  AWS_REGION=$AWS_REGION"
-while IFS= read -r _JUGGERNAUT_KEY; do
-    if [[ -n "$ZSH_VERSION" ]]; then
-        # ${(P)...} is zsh indirect expansion
-        # shellcheck disable=SC2296
-        echo "  ${_JUGGERNAUT_KEY}=${(P)_JUGGERNAUT_KEY}"
-    else
-        echo "  ${_JUGGERNAUT_KEY}=${!_JUGGERNAUT_KEY}"
-    fi
-done <<< "$_JUGGERNAUT_ENV_KEYS"
-
-# Clean up temp variables and functions
-unset _JUGGERNAUT_REGION _JUGGERNAUT_SCRIPT_DIR _JUGGERNAUT_CONFIG_FILE _JUGGERNAUT_JSON_CONTENT
-unset _JUGGERNAUT_ENV_KEYS _JUGGERNAUT_KEY _JUGGERNAUT_VAL
-unset -f _juggernaut_get_json_value _juggernaut_get_json_keys
-
-echo ""
-echo "This configuration is active for the current terminal session only."
-echo "To make it permanent, run: ./setup-claude-bedrock.sh"
+# Run and clean up
+_juggernaut_apply_config "$@"
+_juggernaut_rc=$?
+unset -f _juggernaut_apply_config _juggernaut_get_json_value _juggernaut_get_json_keys
+return "$_juggernaut_rc" 2>/dev/null
+# Reached only when executed directly (not sourced) — return fails, so exit runs
+# shellcheck disable=SC2317
+exit "$_juggernaut_rc"

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -56,7 +56,7 @@ if (Test-Path $ConfigFile) {
 }
 
 #───────────────────────────────────────────────────────────────────────────────
-# Pre-flight Dependency Checks
+# Helpers
 #───────────────────────────────────────────────────────────────────────────────
 
 function ConvertFrom-SecureStringPlainText {
@@ -708,7 +708,7 @@ if ($Storage -eq "keychain") {
 
 # Unset conflicting auth variables to prevent credential conflicts
 if ($Auth -eq "api-key") {
-    # Using API key - unset AWS STS credentials that might interfere
+    # Using API key - unset IAM/profile variables that might interfere
     $ConfigBlock += "Remove-Item Env:AWS_ACCESS_KEY_ID -ErrorAction SilentlyContinue`n"
     $ConfigBlock += "Remove-Item Env:AWS_SECRET_ACCESS_KEY -ErrorAction SilentlyContinue`n"
     $ConfigBlock += "Remove-Item Env:AWS_SESSION_TOKEN -ErrorAction SilentlyContinue`n"
@@ -755,7 +755,7 @@ if ($Auth -eq "api-key") {
         $retrievalCmd = Get-KeychainRetrievalCommand
         $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = $retrievalCmd`n"
     } else {
-        # Store directly in profile (legacy behavior)
+        # Store directly in profile
         $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = `"$BedrockKey`"`n"
     }
 }

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -1,5 +1,5 @@
 # Claude Code - Amazon Bedrock Setup Script for Windows
-# Usage: .\setup-claude-bedrock.ps1 [-Auth <iam|api-key>] [-BedrockKey <key>] [-PreserveKey] [-Region <region>] [-Model <id>] [-FastModel <id>] [-OpusModel <id>] [-SonnetModel <id>] [-HaikuModel <id>] [-Global] [-ModelPrefix <prefix>] [-Force] [-DryRun]
+# Usage: .\setup-claude-bedrock.ps1 [-Auth <iam|api-key>] [-BedrockKey <key>] [-PreserveKey] [-Region <region>] [-Model <id>] [-FastModel <id>] [-OpusModel <id>] [-SonnetModel <id>] [-HaikuModel <id>] [-Global] [-ModelPrefix <prefix>] [-Force] [-SkipPreflight] [-DryRun]
 
 param(
     [ValidateSet("iam", "api-key")]
@@ -508,6 +508,7 @@ if ($Help) {
     Write-Host "  -OneM              Enable 1M token context window (Opus & Sonnet only)"
     Write-Host "  -NoOneM            Disable 1M context (revert to standard ~200K)"
     Write-Host "  -Force             Overwrite existing configuration without prompting"
+    Write-Host "  -SkipPreflight     Skip dependency checks (also: `$env:JUGGERNAUT_SKIP_PREFLIGHT=1)"
     Write-Host "  -DryRun            Preview changes without modifying files"
     Write-Host "  -Help              Show this help message"
     Write-Host ""

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -55,6 +55,33 @@ if (Test-Path $ConfigFile) {
     }
 }
 
+#───────────────────────────────────────────────────────────────────────────────
+# Pre-flight Dependency Checks
+#───────────────────────────────────────────────────────────────────────────────
+
+function Test-Prerequisites {
+    param(
+        [string]$AuthMode
+    )
+
+    $errors = 0
+
+    # AWS CLI: required for IAM mode
+    if ($AuthMode -eq "iam" -and -not (Get-Command aws -ErrorAction SilentlyContinue)) {
+        Write-Host "Error: aws CLI is required for IAM authentication mode" -ForegroundColor Red
+        Write-Host "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+        $errors++
+    } elseif (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+        Write-Host "Note: aws CLI not found (needed if you switch to IAM mode later)" -ForegroundColor Yellow
+    }
+
+    if ($errors -gt 0) {
+        Write-Host ""
+        Write-Host "Missing required dependencies. Install them and try again." -ForegroundColor Red
+        exit 1
+    }
+}
+
 # Detect existing auth mode from profile file
 # Returns: "iam", "api-key", or $null if not found
 function Get-ExistingAuthMode {
@@ -494,6 +521,9 @@ if ($Help) {
     Write-Host "  .\setup-claude-bedrock.ps1 -DryRun"
     exit 0
 }
+
+# Pre-flight dependency checks
+Test-Prerequisites -AuthMode $Auth
 
 # Handle API key for api-key auth mode
 if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -59,26 +59,34 @@ if (Test-Path $ConfigFile) {
 # Pre-flight Dependency Checks
 #───────────────────────────────────────────────────────────────────────────────
 
+function ConvertFrom-SecureStringPlainText {
+    param([SecureString]$Secure)
+    $bstr = [IntPtr]::Zero
+    try {
+        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Secure)
+        return [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    } finally {
+        if ($bstr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
+    }
+}
+
 function Test-Prerequisites {
     param(
         [string]$AuthMode
     )
 
-    $errors = 0
+    $hasAws = [bool](Get-Command aws -ErrorAction SilentlyContinue)
 
-    # AWS CLI: required for IAM mode
-    if ($AuthMode -eq "iam" -and -not (Get-Command aws -ErrorAction SilentlyContinue)) {
+    if ($AuthMode -eq "iam" -and -not $hasAws) {
         Write-Host "Error: aws CLI is required for IAM authentication mode" -ForegroundColor Red
         Write-Host "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
-        $errors++
-    } elseif (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
-        Write-Host "Note: aws CLI not found (needed if you switch to IAM mode later)" -ForegroundColor Yellow
-    }
-
-    if ($errors -gt 0) {
         Write-Host ""
         Write-Host "Missing required dependencies. Install them and try again." -ForegroundColor Red
         exit 1
+    } elseif (-not $hasAws) {
+        Write-Host "Note: aws CLI not found (needed if you switch to IAM mode later)" -ForegroundColor Yellow
     }
 }
 
@@ -567,15 +575,7 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
                 Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
                 Write-Host ""
                 $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
-                $bstr = [IntPtr]::Zero
-                try {
-                    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
-                    $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-                } finally {
-                    if ($bstr -ne [IntPtr]::Zero) {
-                        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-                    }
-                }
+                $BedrockKey = ConvertFrom-SecureStringPlainText $SecureKey
                 if ([string]::IsNullOrEmpty($BedrockKey)) {
                     Write-Host "Error: API key cannot be empty" -ForegroundColor Red
                     exit 1
@@ -597,15 +597,7 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
         Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
         Write-Host ""
         $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
-        $bstr = [IntPtr]::Zero
-        try {
-            $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
-            $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-        } finally {
-            if ($bstr -ne [IntPtr]::Zero) {
-                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-            }
-        }
+        $BedrockKey = ConvertFrom-SecureStringPlainText $SecureKey
 
         if ([string]::IsNullOrEmpty($BedrockKey)) {
             Write-Host "Error: API key cannot be empty" -ForegroundColor Red

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -567,11 +567,14 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
                 Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
                 Write-Host ""
                 $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
-                $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
+                $bstr = [IntPtr]::Zero
                 try {
+                    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
                     $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
                 } finally {
-                    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+                    if ($bstr -ne [IntPtr]::Zero) {
+                        [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+                    }
                 }
                 if ([string]::IsNullOrEmpty($BedrockKey)) {
                     Write-Host "Error: API key cannot be empty" -ForegroundColor Red
@@ -594,11 +597,14 @@ if ($Auth -eq "api-key" -and [string]::IsNullOrEmpty($BedrockKey)) {
         Write-Host "  AWS Console -> Amazon Bedrock -> API keys"
         Write-Host ""
         $SecureKey = Read-Host "Enter your Bedrock API key" -AsSecureString
-        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
+        $bstr = [IntPtr]::Zero
         try {
+            $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureKey)
             $BedrockKey = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
         } finally {
-            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+            if ($bstr -ne [IntPtr]::Zero) {
+                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+            }
         }
 
         if ([string]::IsNullOrEmpty($BedrockKey)) {

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -21,6 +21,7 @@ param(
     [Alias("standard-context")]
     [switch]$NoOneM,
     [switch]$Force,
+    [switch]$SkipPreflight,
     [switch]$DryRun,
     [switch]$Help,
     [Alias("v")]
@@ -77,13 +78,17 @@ function Test-Prerequisites {
         [string]$AuthMode
     )
 
+    # Allow skipping via flag or env var (for CI or advanced users)
+    if ($SkipPreflight -or $env:JUGGERNAUT_SKIP_PREFLIGHT -eq "1") { return }
+
     $hasAws = [bool](Get-Command aws -ErrorAction SilentlyContinue)
 
     if ($AuthMode -eq "iam" -and -not $hasAws) {
         Write-Host "Error: aws CLI is required for IAM authentication mode" -ForegroundColor Red
-        Write-Host "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
         Write-Host ""
-        Write-Host "Missing required dependencies. Install them and try again." -ForegroundColor Red
+        Write-Host "  Install: winget install Amazon.AWSCLI"
+        Write-Host ""
+        Write-Host "Or skip this check: -SkipPreflight" -ForegroundColor Yellow
         exit 1
     } elseif (-not $hasAws) {
         Write-Host "Note: aws CLI not found (needed if you switch to IAM mode later)" -ForegroundColor Yellow
@@ -755,8 +760,9 @@ if ($Auth -eq "api-key") {
         $retrievalCmd = Get-KeychainRetrievalCommand
         $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = $retrievalCmd`n"
     } else {
-        # Store directly in profile
-        $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = `"$BedrockKey`"`n"
+        # Store directly in profile — single-quote to prevent backtick expansion
+        $escapedKey = $BedrockKey -replace "'", "''"
+        $ConfigBlock += "`$env:AWS_BEARER_TOKEN_BEDROCK = '$escapedKey'`n"
     }
 }
 

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -170,6 +170,16 @@ load_config() {
     DEFAULT_AUTH=$(json_get "$CONFIG_FILE" '.defaults.auth_mode')
 }
 
+# Check JSON parser availability before loading config
+if ! command -v jq &>/dev/null && ! command -v python3 &>/dev/null; then
+    echo "Error: jq or python3 is required for JSON parsing" >&2
+    echo "  Install jq:      https://jqlang.github.io/jq/download/" >&2
+    echo "  Or python3:      https://www.python.org/downloads/" >&2
+    exit 1
+elif ! command -v jq &>/dev/null; then
+    echo "Note: jq not found, using python3 for JSON parsing (jq is faster)" >&2
+fi
+
 # Initialize config arrays
 declare -A BEDROCK_CONFIG
 declare -a CONFIG_KEY_ORDER=(AWS_REGION)  # AWS_REGION always first, rest loaded from JSON
@@ -182,33 +192,17 @@ load_config
 # Pre-flight Dependency Checks
 #───────────────────────────────────────────────────────────────────────────────
 
-preflight_checks() {
+preflight_check_aws() {
     local auth_mode=$1
-    local errors=0
 
-    # JSON parser: need jq or python3
-    if ! command -v jq &>/dev/null && ! command -v python3 &>/dev/null; then
-        echo "Error: jq or python3 is required for JSON parsing" >&2
-        echo "  Install jq:      https://jqlang.github.io/jq/download/" >&2
-        echo "  Or python3:      https://www.python.org/downloads/" >&2
-        errors=1
-    elif ! command -v jq &>/dev/null; then
-        echo "Note: jq not found, using python3 for JSON parsing (jq is faster)" >&2
-    fi
-
-    # AWS CLI: required for IAM mode
     if [[ "$auth_mode" == "iam" ]] && ! command -v aws &>/dev/null; then
         echo "Error: aws CLI is required for IAM authentication mode" >&2
         echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2
-        errors=1
-    elif ! command -v aws &>/dev/null; then
-        echo "Note: aws CLI not found (needed if you switch to IAM mode later)" >&2
-    fi
-
-    if [[ "$errors" -gt 0 ]]; then
         echo "" >&2
         echo "Missing required dependencies. Install them and try again." >&2
         exit 1
+    elif ! command -v aws &>/dev/null; then
+        echo "Note: aws CLI not found (needed if you switch to IAM mode later)" >&2
     fi
 }
 
@@ -509,12 +503,13 @@ generate_config_block() {
                 config+="$syntax AWS_BEARER_TOKEN_BEDROCK=$keychain_cmd"$'\n'
             fi
         else
-            # Store directly in profile — quote to prevent shell metacharacter interpretation
-            local escaped_api_key="${api_key//\"/\\\"}"
+            # Store directly in profile — single-quote to prevent all shell expansion
+            # Escape embedded single quotes: ' → '\'' (end quote, escaped quote, start quote)
+            local escaped_api_key="${api_key//\'/\'\\\'\'}"
             if [[ "$shell" == "fish" ]]; then
-                config+="$syntax AWS_BEARER_TOKEN_BEDROCK \"$escaped_api_key\""$'\n'
+                config+="$syntax AWS_BEARER_TOKEN_BEDROCK '$escaped_api_key'"$'\n'
             else
-                config+="$syntax AWS_BEARER_TOKEN_BEDROCK=\"$escaped_api_key\""$'\n'
+                config+="$syntax AWS_BEARER_TOKEN_BEDROCK='$escaped_api_key'"$'\n'
             fi
         fi
     fi
@@ -1215,7 +1210,7 @@ main() {
     fi
 
     # Check dependencies before proceeding
-    preflight_checks "$AUTH_MODE"
+    preflight_check_aws "$AUTH_MODE"
 
     # Detect existing custom models if user didn't explicitly specify
     local config_file="${SHELL_CONFIGS[$SHELL_TYPE]}"

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -1246,7 +1246,6 @@ main() {
         AUTH_MODE="${DEFAULT_AUTH:-iam}"
     fi
 
-    # Check dependencies before proceeding
     preflight_check_aws "$AUTH_MODE"
 
     local os; os=$(detect_os)

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -1212,6 +1212,8 @@ main() {
     # Check dependencies before proceeding
     preflight_check_aws "$AUTH_MODE"
 
+    local os; os=$(detect_os)
+
     # Detect existing custom models if user didn't explicitly specify
     local config_file="${SHELL_CONFIGS[$SHELL_TYPE]}"
     if [[ "$MODEL_EXPLICIT" != true && -f "$config_file" ]]; then
@@ -1280,7 +1282,6 @@ main() {
 
     # Platform-aware storage default for new installs (macOS/Windows default to keychain)
     if [[ "$STORAGE_MODE_EXPLICIT" != true && "$STORAGE_MODE" == "profile" ]]; then
-        local os; os=$(detect_os)
         if [[ "$os" == "macos" || "$os" == "gitbash" || "$os" == "cygwin" ]]; then
             # Only change default if there's no existing config (new install)
             if ! grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
@@ -1293,7 +1294,6 @@ main() {
 
     # Offer to migrate plaintext API keys to keychain on macOS/Windows
     if [[ "$AUTH_MODE" == "api-key" && "$STORAGE_MODE_EXPLICIT" != true && "$STORAGE_MODE" == "profile" ]]; then
-        local os; os=$(detect_os)
         if [[ "$os" == "macos" || "$os" == "gitbash" || "$os" == "cygwin" ]]; then
             if [[ -f "$config_file" ]] && grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
                 if ! grep -q "# Storage: keychain" "$config_file" 2>/dev/null && keychain_available; then

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -117,6 +117,8 @@ json_get_array() {
     local result
 
     if command -v jq >/dev/null 2>&1; then
+        # $query[] is jq syntax, not bash array expansion
+        # shellcheck disable=SC1087
         result=$(jq -r "$query[]" "$file" 2>/dev/null) || return 1
         printf '%s\n' "$result" | tr -d '\r'
     elif command -v python3 >/dev/null 2>&1; then
@@ -279,7 +281,7 @@ KEYCHAIN_ACCOUNT="api-key"
 
 # Detect if keychain is available on this system
 keychain_available() {
-    local os=$(detect_os)
+    local os; os=$(detect_os)
     case "$os" in
         macos)
             command -v security >/dev/null 2>&1
@@ -300,7 +302,7 @@ keychain_available() {
 # Store API key in system keychain
 keychain_store() {
     local key=$1
-    local os=$(detect_os)
+    local os; os=$(detect_os)
 
     case "$os" in
         macos)
@@ -327,7 +329,7 @@ keychain_store() {
 
 # Retrieve API key from system keychain
 keychain_get() {
-    local os=$(detect_os)
+    local os; os=$(detect_os)
 
     case "$os" in
         macos)
@@ -372,7 +374,7 @@ keychain_get() {
 
 # Delete API key from system keychain
 keychain_delete() {
-    local os=$(detect_os)
+    local os; os=$(detect_os)
 
     case "$os" in
         macos)
@@ -390,7 +392,7 @@ keychain_delete() {
 # Generate the shell command to retrieve key from keychain
 keychain_get_command() {
     local shell=$1
-    local os=$(detect_os)
+    local os; os=$(detect_os)
     local cmd=""
 
     case "$os" in
@@ -536,7 +538,7 @@ sed_inplace() {
 
 backup_config_file() {
     local config_file=$1
-    local backup_file="${config_file}.backup.$(date +%Y%m%d_%H%M%S)"
+    local backup_file; backup_file="${config_file}.backup.$(date +%Y%m%d_%H%M%S)"
 
     if [[ -f "$config_file" ]]; then
         if cp "$config_file" "$backup_file" 2>/dev/null; then
@@ -937,7 +939,7 @@ validate_inputs() {
     # Check keychain availability when using keychain storage
     if [[ "$STORAGE_MODE" == "keychain" ]]; then
         if ! keychain_available; then
-            local os=$(detect_os)
+            local os; os=$(detect_os)
             echo "Error: Keychain storage not available on this system" >&2
             echo "" >&2
             case "$os" in
@@ -1001,7 +1003,7 @@ validate_inputs() {
                     echo "Get your Bedrock API key from:"
                     echo "  AWS Console → Amazon Bedrock → API keys"
                     echo ""
-                    read -s -p "Enter your Bedrock API key: " BEDROCK_API_KEY
+                    read -rs -p "Enter your Bedrock API key: " BEDROCK_API_KEY
                     echo ""
                     BEDROCK_API_KEY="${BEDROCK_API_KEY%"${BEDROCK_API_KEY##*[![:space:]]}"}"
                     BEDROCK_API_KEY="${BEDROCK_API_KEY#"${BEDROCK_API_KEY%%[![:space:]]*}"}"
@@ -1025,7 +1027,7 @@ validate_inputs() {
             echo "Get your Bedrock API key from:"
             echo "  AWS Console → Amazon Bedrock → API keys"
             echo ""
-            read -s -p "Enter your Bedrock API key: " BEDROCK_API_KEY
+            read -rs -p "Enter your Bedrock API key: " BEDROCK_API_KEY
             echo ""  # newline after hidden input
 
             # Strip any trailing whitespace/carriage returns (common from copy-paste)
@@ -1060,7 +1062,7 @@ setup_shell() {
     local shell=$1
     local config_file="${SHELL_CONFIGS[$shell]}"
     local display_name="${SHELL_DISPLAY_NAMES[$shell]}"
-    local os=$(detect_os)
+    local os; os=$(detect_os)
 
     # Create parent directory for fish
     if [[ "$shell" == "fish" && "$DRY_RUN" == false ]]; then
@@ -1283,7 +1285,7 @@ main() {
 
     # Platform-aware storage default for new installs (macOS/Windows default to keychain)
     if [[ "$STORAGE_MODE_EXPLICIT" != true && "$STORAGE_MODE" == "profile" ]]; then
-        local os=$(detect_os)
+        local os; os=$(detect_os)
         if [[ "$os" == "macos" || "$os" == "gitbash" || "$os" == "cygwin" ]]; then
             # Only change default if there's no existing config (new install)
             if ! grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
@@ -1296,7 +1298,7 @@ main() {
 
     # Offer to migrate plaintext API keys to keychain on macOS/Windows
     if [[ "$AUTH_MODE" == "api-key" && "$STORAGE_MODE_EXPLICIT" != true && "$STORAGE_MODE" == "profile" ]]; then
-        local os=$(detect_os)
+        local os; os=$(detect_os)
         if [[ "$os" == "macos" || "$os" == "gitbash" || "$os" == "cygwin" ]]; then
             if [[ -f "$config_file" ]] && grep -q "CLAUDE_CODE_USE_BEDROCK" "$config_file" 2>/dev/null; then
                 if ! grep -q "# Storage: keychain" "$config_file" 2>/dev/null && keychain_available; then

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -177,6 +177,40 @@ declare -a VALID_REGIONS
 load_config
 
 #───────────────────────────────────────────────────────────────────────────────
+# Pre-flight Dependency Checks
+#───────────────────────────────────────────────────────────────────────────────
+
+preflight_checks() {
+    local auth_mode=$1
+    local errors=0
+
+    # JSON parser: need jq or python3
+    if ! command -v jq &>/dev/null && ! command -v python3 &>/dev/null; then
+        echo "Error: jq or python3 is required for JSON parsing" >&2
+        echo "  Install jq:      https://jqlang.github.io/jq/download/" >&2
+        echo "  Or python3:      https://www.python.org/downloads/" >&2
+        errors=1
+    elif ! command -v jq &>/dev/null; then
+        echo "Note: jq not found, using python3 for JSON parsing (jq is faster)" >&2
+    fi
+
+    # AWS CLI: required for IAM mode
+    if [[ "$auth_mode" == "iam" ]] && ! command -v aws &>/dev/null; then
+        echo "Error: aws CLI is required for IAM authentication mode" >&2
+        echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2
+        errors=1
+    elif ! command -v aws &>/dev/null; then
+        echo "Note: aws CLI not found (needed if you switch to IAM mode later)" >&2
+    fi
+
+    if [[ "$errors" -gt 0 ]]; then
+        echo "" >&2
+        echo "Missing required dependencies. Install them and try again." >&2
+        exit 1
+    fi
+}
+
+#───────────────────────────────────────────────────────────────────────────────
 # Detection Functions
 #───────────────────────────────────────────────────────────────────────────────
 
@@ -1177,6 +1211,9 @@ main() {
     if [[ -z "$AUTH_MODE" ]]; then
         AUTH_MODE="${DEFAULT_AUTH:-iam}"
     fi
+
+    # Check dependencies before proceeding
+    preflight_checks "$AUTH_MODE"
 
     # Detect existing custom models if user didn't explicitly specify
     local config_file="${SHELL_CONFIGS[$SHELL_TYPE]}"

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -504,11 +504,13 @@ generate_config_block() {
             fi
         else
             # Store directly in profile — single-quote to prevent all shell expansion
-            # Escape embedded single quotes: ' → '\'' (end quote, escaped quote, start quote)
-            local escaped_api_key="${api_key//\'/\'\\\'\'}"
             if [[ "$shell" == "fish" ]]; then
-                config+="$syntax AWS_BEARER_TOKEN_BEDROCK '$escaped_api_key'"$'\n'
+                # Fish 3.0+ supports \' inside single quotes
+                local fish_escaped_key="${api_key//\'/\\\'}"
+                config+="$syntax AWS_BEARER_TOKEN_BEDROCK '$fish_escaped_key'"$'\n'
             else
+                # POSIX/bash: escape embedded single quotes: ' → '\'' (end quote, escaped quote, start quote)
+                local escaped_api_key="${api_key//\'/\'\\\'\'}"
                 config+="$syntax AWS_BEARER_TOKEN_BEDROCK='$escaped_api_key'"$'\n'
             fi
         fi

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -117,8 +117,8 @@ json_get_array() {
     local result
 
     if command -v jq >/dev/null 2>&1; then
-        # $query[] is jq syntax, not bash array expansion
-        # shellcheck disable=SC1087
+        # $query[] is jq syntax, not bash array expansion — shellcheck misreads it
+        # shellcheck disable=SC1087  # SC1087: Use braces when expanding arrays
         result=$(jq -r "$query[]" "$file" 2>/dev/null) || return 1
         printf '%s\n' "$result" | tr -d '\r'
     elif command -v python3 >/dev/null 2>&1; then
@@ -170,11 +170,28 @@ load_config() {
     DEFAULT_AUTH=$(json_get "$CONFIG_FILE" '.defaults.auth_mode')
 }
 
-# Check JSON parser availability before loading config
+# Check JSON parser availability before loading config (hard requirement, not skippable)
 if ! command -v jq &>/dev/null && ! command -v python3 &>/dev/null; then
     echo "Error: jq or python3 is required for JSON parsing" >&2
-    echo "  Install jq:      https://jqlang.github.io/jq/download/" >&2
-    echo "  Or python3:      https://www.python.org/downloads/" >&2
+    echo "" >&2
+    case "$OSTYPE" in
+        darwin*)
+            echo "  Install jq:  brew install jq" >&2
+            echo "  Or python3:  brew install python3" >&2
+            ;;
+        linux*)
+            echo "  Install jq:  sudo apt install jq" >&2
+            echo "  Or python3:  sudo apt install python3" >&2
+            ;;
+        msys*|mingw*|cygwin*)
+            echo "  Install jq:  winget install jqlang.jq" >&2
+            echo "  Or python3:  winget install Python.Python.3" >&2
+            ;;
+        *)
+            echo "  Install jq:  https://jqlang.github.io/jq/download/" >&2
+            echo "  Or python3:  https://www.python.org/downloads/" >&2
+            ;;
+    esac
     exit 1
 elif ! command -v jq &>/dev/null; then
     echo "Note: jq not found, using python3 for JSON parsing (jq is faster)" >&2
@@ -195,11 +212,24 @@ load_config
 preflight_check_aws() {
     local auth_mode=$1
 
+    # Allow skipping via flag or env var (for CI or advanced users)
+    [[ "$SKIP_PREFLIGHT" == true || "${JUGGERNAUT_SKIP_PREFLIGHT:-}" == "1" ]] && return 0
+
     if [[ "$auth_mode" == "iam" ]] && ! command -v aws &>/dev/null; then
         echo "Error: aws CLI is required for IAM authentication mode" >&2
-        echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2
         echo "" >&2
-        echo "Missing required dependencies. Install them and try again." >&2
+        case "$OSTYPE" in
+            darwin*)
+                echo "  Install: brew install awscli" >&2 ;;
+            linux*)
+                echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2 ;;
+            msys*|mingw*|cygwin*)
+                echo "  Install: winget install Amazon.AWSCLI" >&2 ;;
+            *)
+                echo "  Install: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html" >&2 ;;
+        esac
+        echo "" >&2
+        echo "Or skip this check: --skip-preflight" >&2
         exit 1
     elif ! command -v aws &>/dev/null; then
         echo "Note: aws CLI not found (needed if you switch to IAM mode later)" >&2
@@ -745,6 +775,7 @@ Options:
   --no-1m-context        Disable 1M context (revert to standard ~200K)
   --dry-run              Preview changes without modifying files
   --force, -f            Skip confirmation prompts
+  --skip-preflight       Skip dependency checks (also: JUGGERNAUT_SKIP_PREFLIGHT=1)
   --version, -v          Show version
   --help, -h             Show this help message
 
@@ -802,6 +833,7 @@ EOF
 
 DRY_RUN=false
 FORCE=false
+SKIP_PREFLIGHT=false
 PRESERVE_KEY=false
 AWS_REGION="${DEFAULT_REGION:-us-west-2}"
 SHELL_TYPE=""
@@ -833,6 +865,9 @@ parse_arguments() {
                 ;;
             --force|-f)
                 FORCE=true
+                ;;
+            --skip-preflight)
+                SKIP_PREFLIGHT=true
                 ;;
             --region=*)
                 AWS_REGION="${arg#--region=}"

--- a/test.sh
+++ b/test.sh
@@ -711,8 +711,18 @@ test_preflight_checks() {
         "! PATH=/usr/bin:/bin env -u JQ_PATH bash -c 'export PATH=\$(echo \$PATH | tr \":\" \"\n\" | grep -v -E \"(jq|python)\" | tr \"\n\" \":\"); $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force' 2>&1"
 
     # When --auth=iam and aws CLI is missing, setup should fail
-    run_test "fails when --auth=iam and aws CLI missing" \
-        "! PATH=\$(echo \$PATH | tr ':' '\n' | grep -v aws | tr '\n' ':') $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1"
+    # Create a temp PATH that has essential tools but not aws
+    if command -v aws &>/dev/null; then
+        run_test "fails when --auth=iam and aws CLI missing" \
+            "TMPBIN=\$(mktemp -d) &&
+             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname; do
+                 p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
+             done &&
+             PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1;
+             rc=\$?; rm -rf \"\$TMPBIN\"; [ \$rc -ne 0 ]"
+    else
+        skip_test "fails when --auth=iam and aws CLI missing" "aws CLI not installed"
+    fi
 
     # Normal invocation should pass preflight (jq or python3 exists in CI)
     run_test "passes preflight with normal PATH" \

--- a/test.sh
+++ b/test.sh
@@ -89,6 +89,9 @@ _tmpbin_cleanup() {
     unset _TMPBIN _REAL_BASH
 }
 
+# Core tools needed by setup-claude-bedrock.sh in restricted-PATH tests
+_TMPBIN_CORE_CMDS=(grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename)
+
 #───────────────────────────────────────────────────────────────────────────────
 # Test Cases
 #───────────────────────────────────────────────────────────────────────────────
@@ -727,9 +730,8 @@ test_preflight_checks() {
     section "Pre-flight Dependency Checks"
 
     # When both jq and python3 are missing, setup should fail with clear error
-    # Uses _tmpbin_create wrapper pattern — deliberately excludes jq and python3
     run_test "fails when neither jq nor python3 available" \
-        "_tmpbin_create grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename &&
+        "_tmpbin_create \"\${_TMPBIN_CORE_CMDS[@]}\" &&
          PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1 |
          grep -q 'jq or python3 is required';
          rc=\$?; _tmpbin_cleanup; [ \$rc -eq 0 ]"
@@ -737,7 +739,7 @@ test_preflight_checks() {
     # When --auth=iam and aws CLI is missing, setup should fail
     if command -v aws &>/dev/null; then
         run_test "fails when --auth=iam and aws CLI missing" \
-            "_tmpbin_create jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename &&
+            "_tmpbin_create jq python3 \"\${_TMPBIN_CORE_CMDS[@]}\" &&
              PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1;
              rc=\$?; _tmpbin_cleanup; [ \$rc -ne 0 ]"
     else
@@ -845,7 +847,7 @@ test_credential_conflict_prevention() {
     # api-key mode should warn (not fail) when aws is missing
     if command -v aws &>/dev/null; then
         run_test "api-key mode warns (not fails) without aws" \
-            "_tmpbin_create jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename &&
+            "_tmpbin_create jq python3 \"\${_TMPBIN_CORE_CMDS[@]}\" &&
              PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1;
              rc=\$?; _tmpbin_cleanup; [ \$rc -eq 0 ]"
     else

--- a/test.sh
+++ b/test.sh
@@ -36,8 +36,9 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 TESTS_SKIPPED=0
 
-# Script directory
+# Script directory (and an eval-safe quoted version for run_test)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR_Q="$(printf '%q' "$SCRIPT_DIR")"
 
 #───────────────────────────────────────────────────────────────────────────────
 # Test Framework
@@ -46,6 +47,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 run_test() {
     local test_name=$1
     local test_command=$2
+
+    # Auto-quote SCRIPT_DIR paths so eval handles spaces correctly
+    test_command="${test_command//"$SCRIPT_DIR"/$SCRIPT_DIR_Q}"
 
     printf "  %-45s " "$test_name"
     if eval "$test_command" >/dev/null 2>&1; then
@@ -700,6 +704,25 @@ test_api_key_quoting() {
     # Backtick must NOT be expanded in the generated config
     run_test "bash config preserves literal backtick" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test\`id\`' --storage=profile --dry-run --force 2>&1 | grep 'AWS_BEARER_TOKEN_BEDROCK=' | grep -q '\`id\`'"
+
+    # Embedded single quote must be escaped correctly — verify by evaluating the output
+    # Use helper functions to avoid eval quoting nightmares with nested single quotes
+
+    # bash/zsh: eval the export line and confirm the variable round-trips correctly
+    _test_bash_quote_escape() {
+        local line
+        line=$("$SCRIPT_DIR/setup-claude-bedrock.sh" bash --auth=api-key --bedrock-key="br-te'st" --storage=profile --dry-run --force 2>&1 | grep '^export AWS_BEARER_TOKEN_BEDROCK=')
+        eval "$line"
+        [[ "$AWS_BEARER_TOKEN_BEDROCK" == "br-te'st" ]]
+    }
+    run_test "bash config escapes embedded single quote" "_test_bash_quote_escape"
+
+    # fish: verify the output contains \' (backslash-quote) escape for the embedded quote
+    _test_fish_quote_escape() {
+        "$SCRIPT_DIR/setup-claude-bedrock.sh" fish --auth=api-key --bedrock-key="br-te'st" --storage=profile --dry-run --force 2>&1 \
+            | grep 'AWS_BEARER_TOKEN_BEDROCK' | grep -qF "\'"
+    }
+    run_test "fish config escapes embedded single quote" "_test_fish_quote_escape"
 }
 
 #───────────────────────────────────────────────────────────────────────────────
@@ -848,6 +871,10 @@ test_credential_conflict_prevention() {
 
     run_test "fish api-key erases AWS_PROFILE" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_PROFILE'"
+
+    # Fish IAM mode should erase API key var
+    run_test "fish iam erases AWS_BEARER_TOKEN_BEDROCK" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=iam --dry-run --force 2>&1 | grep -q 'set -e AWS_BEARER_TOKEN_BEDROCK'"
 
     # api-key mode should warn (not fail) when aws is missing
     if command -v aws &>/dev/null; then

--- a/test.sh
+++ b/test.sh
@@ -870,40 +870,46 @@ test_version_flags() {
 test_credential_conflict_prevention() {
     section "Credential Conflict Prevention in Config Block"
 
+    # Capture output once per invocation variant (avoids spawning setup 10 times)
+    local _bash_apikey _bash_iam _fish_apikey _fish_iam
+    _bash_apikey=$("$SCRIPT_DIR/setup-claude-bedrock.sh" bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1)
+    _bash_iam=$("$SCRIPT_DIR/setup-claude-bedrock.sh" bash --auth=iam --dry-run --force 2>&1)
+    _fish_apikey=$("$SCRIPT_DIR/setup-claude-bedrock.sh" fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1)
+    _fish_iam=$("$SCRIPT_DIR/setup-claude-bedrock.sh" fish --auth=iam --dry-run --force 2>&1)
+
     # API key mode should unset all IAM-related vars
-    # All four vars are on one unset line; match unset + var in one grep to avoid false positives
     run_test "api-key mode unsets AWS_ACCESS_KEY_ID" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_ACCESS_KEY_ID'"
+        "echo \"\$_bash_apikey\" | grep -qE 'unset[^#]*AWS_ACCESS_KEY_ID'"
 
     run_test "api-key mode unsets AWS_SECRET_ACCESS_KEY" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_SECRET_ACCESS_KEY'"
+        "echo \"\$_bash_apikey\" | grep -qE 'unset[^#]*AWS_SECRET_ACCESS_KEY'"
 
     run_test "api-key mode unsets AWS_SESSION_TOKEN" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_SESSION_TOKEN'"
+        "echo \"\$_bash_apikey\" | grep -qE 'unset[^#]*AWS_SESSION_TOKEN'"
 
     run_test "api-key mode unsets AWS_PROFILE" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_PROFILE'"
+        "echo \"\$_bash_apikey\" | grep -qE 'unset[^#]*AWS_PROFILE'"
 
     # IAM mode should unset API key var
     run_test "iam mode unsets AWS_BEARER_TOKEN_BEDROCK" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_BEARER_TOKEN_BEDROCK'"
+        "echo \"\$_bash_iam\" | grep -qE 'unset[^#]*AWS_BEARER_TOKEN_BEDROCK'"
 
     # Fish uses different syntax — verify all four vars
     run_test "fish api-key erases AWS_ACCESS_KEY_ID" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_ACCESS_KEY_ID'"
+        "echo \"\$_fish_apikey\" | grep -q 'set -e AWS_ACCESS_KEY_ID'"
 
     run_test "fish api-key erases AWS_SECRET_ACCESS_KEY" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_SECRET_ACCESS_KEY'"
+        "echo \"\$_fish_apikey\" | grep -q 'set -e AWS_SECRET_ACCESS_KEY'"
 
     run_test "fish api-key erases AWS_SESSION_TOKEN" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_SESSION_TOKEN'"
+        "echo \"\$_fish_apikey\" | grep -q 'set -e AWS_SESSION_TOKEN'"
 
     run_test "fish api-key erases AWS_PROFILE" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_PROFILE'"
+        "echo \"\$_fish_apikey\" | grep -q 'set -e AWS_PROFILE'"
 
     # Fish IAM mode should erase API key var
     run_test "fish iam erases AWS_BEARER_TOKEN_BEDROCK" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=iam --dry-run --force 2>&1 | grep -q 'set -e AWS_BEARER_TOKEN_BEDROCK'"
+        "echo \"\$_fish_iam\" | grep -q 'set -e AWS_BEARER_TOKEN_BEDROCK'"
 
     # api-key mode should warn (not fail) when aws is missing
     if command -v aws &>/dev/null; then

--- a/test.sh
+++ b/test.sh
@@ -74,7 +74,7 @@ section() {
 # Create a temporary bin directory with wrapper scripts for specified commands.
 # Uses wrappers (not symlinks) because ln -sf creates broken copies on MSYS/Git Bash.
 # Sets globals: _TMPBIN (temp directory path), _REAL_BASH (path to real bash binary).
-# shellcheck disable=SC2329 # invoked indirectly via eval in run_test
+# shellcheck disable=SC2317,SC2329 # invoked indirectly via eval in run_test
 _tmpbin_create() {
     _REAL_BASH=$(command -v bash)
     _TMPBIN=$(mktemp -d)
@@ -88,7 +88,7 @@ _tmpbin_create() {
     done
 }
 
-# shellcheck disable=SC2329 # invoked indirectly via eval in run_test
+# shellcheck disable=SC2317,SC2329 # invoked indirectly via eval in run_test
 _tmpbin_cleanup() {
     rm -rf "$_TMPBIN"
     unset _TMPBIN _REAL_BASH

--- a/test.sh
+++ b/test.sh
@@ -709,6 +709,7 @@ test_api_key_quoting() {
     # Use helper functions to avoid eval quoting nightmares with nested single quotes
 
     # bash/zsh: eval the export line and confirm the variable round-trips correctly
+    # shellcheck disable=SC2317
     _test_bash_quote_escape() {
         local line
         line=$("$SCRIPT_DIR/setup-claude-bedrock.sh" bash --auth=api-key --bedrock-key="br-te'st" --storage=profile --dry-run --force 2>&1 | grep '^export AWS_BEARER_TOKEN_BEDROCK=')
@@ -718,6 +719,7 @@ test_api_key_quoting() {
     run_test "bash config escapes embedded single quote" "_test_bash_quote_escape"
 
     # fish: verify the output contains \' (backslash-quote) escape for the embedded quote
+    # shellcheck disable=SC2317
     _test_fish_quote_escape() {
         "$SCRIPT_DIR/setup-claude-bedrock.sh" fish --auth=api-key --bedrock-key="br-te'st" --storage=profile --dry-run --force 2>&1 \
             | grep 'AWS_BEARER_TOKEN_BEDROCK' | grep -qF "\'"

--- a/test.sh
+++ b/test.sh
@@ -341,13 +341,6 @@ test_config_block_integrity() {
     run_test "config has ANTHROPIC_MODEL" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run 2>&1 | grep -q 'ANTHROPIC_MODEL'"
 
-    # Test: IAM mode unsets API key
-    run_test "iam mode unsets API key var" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run 2>&1 | grep -q 'unset AWS_BEARER_TOKEN_BEDROCK'"
-
-    # Test: API key mode unsets IAM vars
-    run_test "api-key mode unsets IAM vars" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run 2>&1 | grep -q 'unset AWS_ACCESS_KEY_ID'"
 }
 
 test_error_handling() {
@@ -792,22 +785,22 @@ test_credential_conflict_prevention() {
     section "Credential Conflict Prevention in Config Block"
 
     # API key mode should unset all IAM-related vars
-    # All four vars are on one unset line, so grep for the unset line then check each var
+    # All four vars are on one unset line; match unset + var in one grep to avoid false positives
     run_test "api-key mode unsets AWS_ACCESS_KEY_ID" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_ACCESS_KEY_ID'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_ACCESS_KEY_ID'"
 
     run_test "api-key mode unsets AWS_SECRET_ACCESS_KEY" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_SECRET_ACCESS_KEY'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_SECRET_ACCESS_KEY'"
 
     run_test "api-key mode unsets AWS_SESSION_TOKEN" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_SESSION_TOKEN'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_SESSION_TOKEN'"
 
     run_test "api-key mode unsets AWS_PROFILE" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_PROFILE'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_PROFILE'"
 
     # IAM mode should unset API key var
     run_test "iam mode unsets AWS_BEARER_TOKEN_BEDROCK" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_BEARER_TOKEN_BEDROCK'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_BEARER_TOKEN_BEDROCK'"
 
     # Fish uses different syntax
     run_test "fish api-key mode erases IAM vars" \
@@ -824,15 +817,11 @@ test_credential_conflict_prevention() {
 test_uninstall() {
     section "Uninstall Script"
 
-    run_test "uninstall.sh --help works" \
-        "$SCRIPT_DIR/uninstall.sh --help"
-
-    run_test "uninstall.sh syntax valid" \
-        "bash -n $SCRIPT_DIR/uninstall.sh"
+    # Syntax and help already covered by test_syntax and test_help_flags
 
     # Running uninstall with no profile should exit gracefully
     run_test "uninstall handles missing profile" \
-        "HOME=/nonexistent $SCRIPT_DIR/uninstall.sh 2>&1; [[ \$? -eq 0 ]]"
+        "HOME=/nonexistent $SCRIPT_DIR/uninstall.sh 2>&1"
 }
 
 #───────────────────────────────────────────────────────────────────────────────

--- a/test.sh
+++ b/test.sh
@@ -3,6 +3,9 @@
 # Juggernaut Test Suite
 # Runs tests to verify scripts work correctly
 
+# run_test passes command strings to eval — shellcheck can't trace into eval'd strings
+# shellcheck disable=SC2288
+
 #───────────────────────────────────────────────────────────────────────────────
 # Bash Check
 #───────────────────────────────────────────────────────────────────────────────
@@ -71,6 +74,7 @@ section() {
 # Create a temporary bin directory with wrapper scripts for specified commands.
 # Uses wrappers (not symlinks) because ln -sf creates broken copies on MSYS/Git Bash.
 # Sets globals: _TMPBIN (temp directory path), _REAL_BASH (path to real bash binary).
+# shellcheck disable=SC2329 # invoked indirectly via eval in run_test
 _tmpbin_create() {
     _REAL_BASH=$(command -v bash)
     _TMPBIN=$(mktemp -d)
@@ -84,6 +88,7 @@ _tmpbin_create() {
     done
 }
 
+# shellcheck disable=SC2329 # invoked indirectly via eval in run_test
 _tmpbin_cleanup() {
     rm -rf "$_TMPBIN"
     unset _TMPBIN _REAL_BASH

--- a/test.sh
+++ b/test.sh
@@ -792,21 +792,22 @@ test_credential_conflict_prevention() {
     section "Credential Conflict Prevention in Config Block"
 
     # API key mode should unset all IAM-related vars
+    # All four vars are on one unset line, so grep for the unset line then check each var
     run_test "api-key mode unsets AWS_ACCESS_KEY_ID" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_ACCESS_KEY_ID'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_ACCESS_KEY_ID'"
 
     run_test "api-key mode unsets AWS_SECRET_ACCESS_KEY" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_SECRET_ACCESS_KEY'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_SECRET_ACCESS_KEY'"
 
     run_test "api-key mode unsets AWS_SESSION_TOKEN" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_SESSION_TOKEN'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_SESSION_TOKEN'"
 
     run_test "api-key mode unsets AWS_PROFILE" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_PROFILE'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_PROFILE'"
 
     # IAM mode should unset API key var
     run_test "iam mode unsets AWS_BEARER_TOKEN_BEDROCK" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep -q 'unset AWS_BEARER_TOKEN_BEDROCK'"
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep 'unset' | grep -q 'AWS_BEARER_TOKEN_BEDROCK'"
 
     # Fish uses different syntax
     run_test "fish api-key mode erases IAM vars" \

--- a/test.sh
+++ b/test.sh
@@ -730,6 +730,111 @@ test_preflight_checks() {
 }
 
 #───────────────────────────────────────────────────────────────────────────────
+# Shellcheck Compliance Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_shellcheck_compliance() {
+    section "Shellcheck Compliance"
+
+    if ! command -v shellcheck &>/dev/null; then
+        skip_test "shellcheck all scripts" "shellcheck not installed"
+        return
+    fi
+
+    local scripts=(
+        "$SCRIPT_DIR/setup-claude-bedrock.sh"
+        "$SCRIPT_DIR/uninstall.sh"
+        "$SCRIPT_DIR/validate-setup.sh"
+        "$SCRIPT_DIR/apply-config.sh"
+        "$SCRIPT_DIR/install.sh"
+        "$SCRIPT_DIR/setup"
+    )
+
+    for script in "${scripts[@]}"; do
+        local name
+        name=$(basename "$script")
+        run_test "shellcheck $name" \
+            "shellcheck '$script'"
+    done
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# Version Flag Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_version_flags() {
+    section "Version Flags"
+
+    local expected_version
+    expected_version=$(tr -d '[:space:]' < "$SCRIPT_DIR/VERSION")
+
+    run_test "setup --version shows version" \
+        "$SCRIPT_DIR/setup --version 2>&1 | grep -q '$expected_version'"
+
+    run_test "setup-claude-bedrock.sh --version" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh --version 2>&1 | grep -q '$expected_version'"
+
+    run_test "validate-setup.sh --version" \
+        "$SCRIPT_DIR/validate-setup.sh --version 2>&1 | grep -q '$expected_version'"
+
+    run_test "apply-config.sh --version" \
+        "bash -c 'source $SCRIPT_DIR/apply-config.sh --version' 2>&1 | grep -q '$expected_version'"
+
+    run_test "uninstall.sh --version" \
+        "$SCRIPT_DIR/uninstall.sh --version 2>&1 | grep -q '$expected_version'"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# Credential Conflict Prevention Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_credential_conflict_prevention() {
+    section "Credential Conflict Prevention in Config Block"
+
+    # API key mode should unset all IAM-related vars
+    run_test "api-key mode unsets AWS_ACCESS_KEY_ID" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_ACCESS_KEY_ID'"
+
+    run_test "api-key mode unsets AWS_SECRET_ACCESS_KEY" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_SECRET_ACCESS_KEY'"
+
+    run_test "api-key mode unsets AWS_SESSION_TOKEN" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_SESSION_TOKEN'"
+
+    run_test "api-key mode unsets AWS_PROFILE" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'unset AWS_PROFILE'"
+
+    # IAM mode should unset API key var
+    run_test "iam mode unsets AWS_BEARER_TOKEN_BEDROCK" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep -q 'unset AWS_BEARER_TOKEN_BEDROCK'"
+
+    # Fish uses different syntax
+    run_test "fish api-key mode erases IAM vars" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_ACCESS_KEY_ID'"
+
+    run_test "fish api-key mode erases AWS_PROFILE" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_PROFILE'"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# Uninstall Script Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_uninstall() {
+    section "Uninstall Script"
+
+    run_test "uninstall.sh --help works" \
+        "$SCRIPT_DIR/uninstall.sh --help"
+
+    run_test "uninstall.sh syntax valid" \
+        "bash -n $SCRIPT_DIR/uninstall.sh"
+
+    # Running uninstall with no profile should exit gracefully
+    run_test "uninstall handles missing profile" \
+        "HOME=/nonexistent $SCRIPT_DIR/uninstall.sh 2>&1; [[ \$? -eq 0 ]]"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
 # Main
 #───────────────────────────────────────────────────────────────────────────────
 
@@ -767,6 +872,10 @@ main() {
     test_unified_entry_point
     test_version_sync
     test_preflight_checks
+    test_shellcheck_compliance
+    test_version_flags
+    test_credential_conflict_prevention
+    test_uninstall
 
     # Summary
     echo ""

--- a/test.sh
+++ b/test.sh
@@ -675,6 +675,51 @@ test_api_key_quoting() {
 }
 
 #───────────────────────────────────────────────────────────────────────────────
+# Version Sync Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_version_sync() {
+    section "Version Sync"
+
+    local file_version json_version
+
+    file_version=$(cat "$SCRIPT_DIR/VERSION" | tr -d '[:space:]')
+
+    # Use jq if available, fall back to python3
+    if command -v jq &>/dev/null; then
+        json_version=$(jq -r '.version' "$SCRIPT_DIR/bedrock-config.json" | tr -d '[:space:]')
+    elif command -v python3 &>/dev/null; then
+        json_version=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" "$SCRIPT_DIR/bedrock-config.json" | tr -d '[:space:]')
+    else
+        skip_test "VERSION matches bedrock-config.json" "jq or python3 required"
+        return
+    fi
+
+    run_test "VERSION matches bedrock-config.json" \
+        "[[ '$file_version' == '$json_version' ]]"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# Pre-flight Check Tests
+#───────────────────────────────────────────────────────────────────────────────
+
+test_preflight_checks() {
+    section "Pre-flight Dependency Checks"
+
+    # When both jq and python3 are missing, setup should fail
+    run_test "fails when neither jq nor python3 available" \
+        "! PATH=/usr/bin:/bin env -u JQ_PATH bash -c 'export PATH=\$(echo \$PATH | tr \":\" \"\n\" | grep -v -E \"(jq|python)\" | tr \"\n\" \":\"); $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force' 2>&1"
+
+    # When --auth=iam and aws CLI is missing, setup should fail
+    run_test "fails when --auth=iam and aws CLI missing" \
+        "! PATH=\$(echo \$PATH | tr ':' '\n' | grep -v aws | tr '\n' ':') $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1"
+
+    # Normal invocation should pass preflight (jq or python3 exists in CI)
+    run_test "passes preflight with normal PATH" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
 # Main
 #───────────────────────────────────────────────────────────────────────────────
 
@@ -710,6 +755,8 @@ main() {
     test_required_files
     test_json_validity
     test_unified_entry_point
+    test_version_sync
+    test_preflight_checks
 
     # Summary
     echo ""

--- a/test.sh
+++ b/test.sh
@@ -68,6 +68,27 @@ section() {
     echo -e "${CYAN}$1${NC}"
 }
 
+# Create a temporary bin directory with wrapper scripts for specified commands.
+# Uses wrappers (not symlinks) because ln -sf creates broken copies on MSYS/Git Bash.
+# Sets globals: _TMPBIN (temp directory path), _REAL_BASH (path to real bash binary).
+_tmpbin_create() {
+    _REAL_BASH=$(command -v bash)
+    _TMPBIN=$(mktemp -d)
+    for cmd in "$@"; do
+        local p
+        p=$(command -v "$cmd" 2>/dev/null)
+        if [ -n "$p" ]; then
+            printf '#!/bin/bash\nexec "%s" "$@"\n' "$p" > "$_TMPBIN/$cmd"
+            chmod +x "$_TMPBIN/$cmd"
+        fi
+    done
+}
+
+_tmpbin_cleanup() {
+    rm -rf "$_TMPBIN"
+    unset _TMPBIN _REAL_BASH
+}
+
 #───────────────────────────────────────────────────────────────────────────────
 # Test Cases
 #───────────────────────────────────────────────────────────────────────────────
@@ -706,26 +727,19 @@ test_preflight_checks() {
     section "Pre-flight Dependency Checks"
 
     # When both jq and python3 are missing, setup should fail with clear error
-    # Use TMPBIN with symlinks to essential tools, deliberately excluding jq and python3
+    # Uses _tmpbin_create wrapper pattern — deliberately excludes jq and python3
     run_test "fails when neither jq nor python3 available" \
-        "TMPBIN=\$(mktemp -d) &&
-         for cmd in bash grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename; do
-             p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
-         done &&
-         PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1 |
+        "_tmpbin_create grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename &&
+         PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1 |
          grep -q 'jq or python3 is required';
-         rc=\$?; rm -rf \"\$TMPBIN\"; [ \$rc -eq 0 ]"
+         rc=\$?; _tmpbin_cleanup; [ \$rc -eq 0 ]"
 
     # When --auth=iam and aws CLI is missing, setup should fail
-    # Create a temp PATH that has essential tools but not aws
     if command -v aws &>/dev/null; then
         run_test "fails when --auth=iam and aws CLI missing" \
-            "TMPBIN=\$(mktemp -d) &&
-             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname basename; do
-                 p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
-             done &&
-             PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1;
-             rc=\$?; rm -rf \"\$TMPBIN\"; [ \$rc -ne 0 ]"
+            "_tmpbin_create jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename &&
+             PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1;
+             rc=\$?; _tmpbin_cleanup; [ \$rc -ne 0 ]"
     else
         skip_test "fails when --auth=iam and aws CLI missing" "aws CLI not installed"
     fi
@@ -831,12 +845,9 @@ test_credential_conflict_prevention() {
     # api-key mode should warn (not fail) when aws is missing
     if command -v aws &>/dev/null; then
         run_test "api-key mode warns (not fails) without aws" \
-            "TMPBIN=\$(mktemp -d) &&
-             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname basename; do
-                 p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
-             done &&
-             PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1;
-             rc=\$?; rm -rf \"\$TMPBIN\"; [ \$rc -eq 0 ]"
+            "_tmpbin_create jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename &&
+             PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1;
+             rc=\$?; _tmpbin_cleanup; [ \$rc -eq 0 ]"
     else
         skip_test "api-key mode warns (not fails) without aws" "aws CLI not installed"
     fi

--- a/test.sh
+++ b/test.sh
@@ -683,7 +683,7 @@ test_version_sync() {
 
     local file_version json_version
 
-    file_version=$(cat "$SCRIPT_DIR/VERSION" | tr -d '[:space:]')
+    file_version=$(tr -d '[:space:]' < "$SCRIPT_DIR/VERSION")
 
     # Use jq if available, fall back to python3
     if command -v jq &>/dev/null; then

--- a/test.sh
+++ b/test.sh
@@ -706,15 +706,22 @@ test_preflight_checks() {
     section "Pre-flight Dependency Checks"
 
     # When both jq and python3 are missing, setup should fail with clear error
+    # Use TMPBIN with symlinks to essential tools, deliberately excluding jq and python3
     run_test "fails when neither jq nor python3 available" \
-        "PATH=/usr/bin:/bin env -u JQ_PATH bash -c 'export PATH=\$(echo \$PATH | tr \":\" \"\n\" | grep -v -E \"(jq|python)\" | tr \"\n\" \":\"); $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1' 2>&1 | grep -q 'jq or python3 is required'"
+        "TMPBIN=\$(mktemp -d) &&
+         for cmd in bash grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename; do
+             p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
+         done &&
+         PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1 |
+         grep -q 'jq or python3 is required';
+         rc=\$?; rm -rf \"\$TMPBIN\"; [ \$rc -eq 0 ]"
 
     # When --auth=iam and aws CLI is missing, setup should fail
     # Create a temp PATH that has essential tools but not aws
     if command -v aws &>/dev/null; then
         run_test "fails when --auth=iam and aws CLI missing" \
             "TMPBIN=\$(mktemp -d) &&
-             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname; do
+             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname basename; do
                  p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
              done &&
              PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1;
@@ -825,7 +832,7 @@ test_credential_conflict_prevention() {
     if command -v aws &>/dev/null; then
         run_test "api-key mode warns (not fails) without aws" \
             "TMPBIN=\$(mktemp -d) &&
-             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname; do
+             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname basename; do
                  p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
              done &&
              PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1;

--- a/test.sh
+++ b/test.sh
@@ -654,17 +654,23 @@ test_1m_context() {
 test_api_key_quoting() {
     section "API Key Quoting in Config Block"
 
-    run_test "bash config block quotes API key value" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q 'AWS_BEARER_TOKEN_BEDROCK=\"br-test123\"'"
+    # Single quotes prevent all shell expansion ($, backticks, etc.)
+    run_test "bash config block single-quotes API key" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q \"AWS_BEARER_TOKEN_BEDROCK='br-test123'\""
 
-    run_test "zsh config block quotes API key value" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh zsh --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q 'AWS_BEARER_TOKEN_BEDROCK=\"br-test123\"'"
+    run_test "zsh config block single-quotes API key" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh zsh --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q \"AWS_BEARER_TOKEN_BEDROCK='br-test123'\""
 
-    run_test "bash config block quotes API key with dollar sign" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test\$var' --storage=profile --dry-run --force 2>&1 | grep 'AWS_BEARER_TOKEN_BEDROCK=' | grep -q '\"'"
+    run_test "fish config block single-quotes API key" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q \"AWS_BEARER_TOKEN_BEDROCK 'br-test123'\""
 
-    run_test "fish config block quotes API key value" \
-        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key='br-test123' --storage=profile --dry-run --force 2>&1 | grep -q 'AWS_BEARER_TOKEN_BEDROCK \"br-test123\"'"
+    # Dollar sign must NOT be expanded in the generated config
+    run_test "bash config preserves literal dollar sign" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test\$var' --storage=profile --dry-run --force 2>&1 | grep 'AWS_BEARER_TOKEN_BEDROCK=' | grep -q '\\\$var'"
+
+    # Backtick must NOT be expanded in the generated config
+    run_test "bash config preserves literal backtick" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key='br-test\`id\`' --storage=profile --dry-run --force 2>&1 | grep 'AWS_BEARER_TOKEN_BEDROCK=' | grep -q '\`id\`'"
 }
 
 #───────────────────────────────────────────────────────────────────────────────
@@ -699,9 +705,9 @@ test_version_sync() {
 test_preflight_checks() {
     section "Pre-flight Dependency Checks"
 
-    # When both jq and python3 are missing, setup should fail
+    # When both jq and python3 are missing, setup should fail with clear error
     run_test "fails when neither jq nor python3 available" \
-        "! PATH=/usr/bin:/bin env -u JQ_PATH bash -c 'export PATH=\$(echo \$PATH | tr \":\" \"\n\" | grep -v -E \"(jq|python)\" | tr \"\n\" \":\"); $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force' 2>&1"
+        "PATH=/usr/bin:/bin env -u JQ_PATH bash -c 'export PATH=\$(echo \$PATH | tr \":\" \"\n\" | grep -v -E \"(jq|python)\" | tr \"\n\" \":\"); $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1' 2>&1 | grep -q 'jq or python3 is required'"
 
     # When --auth=iam and aws CLI is missing, setup should fail
     # Create a temp PATH that has essential tools but not aws
@@ -802,12 +808,31 @@ test_credential_conflict_prevention() {
     run_test "iam mode unsets AWS_BEARER_TOKEN_BEDROCK" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --dry-run --force 2>&1 | grep -qE 'unset[^#]*AWS_BEARER_TOKEN_BEDROCK'"
 
-    # Fish uses different syntax
-    run_test "fish api-key mode erases IAM vars" \
+    # Fish uses different syntax — verify all four vars
+    run_test "fish api-key erases AWS_ACCESS_KEY_ID" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_ACCESS_KEY_ID'"
 
-    run_test "fish api-key mode erases AWS_PROFILE" \
+    run_test "fish api-key erases AWS_SECRET_ACCESS_KEY" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_SECRET_ACCESS_KEY'"
+
+    run_test "fish api-key erases AWS_SESSION_TOKEN" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_SESSION_TOKEN'"
+
+    run_test "fish api-key erases AWS_PROFILE" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh fish --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1 | grep -q 'set -e AWS_PROFILE'"
+
+    # api-key mode should warn (not fail) when aws is missing
+    if command -v aws &>/dev/null; then
+        run_test "api-key mode warns (not fails) without aws" \
+            "TMPBIN=\$(mktemp -d) &&
+             for cmd in bash jq python3 grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink command id uname; do
+                 p=\$(command -v \$cmd 2>/dev/null) && [ -n \"\$p\" ] && ln -sf \"\$p\" \"\$TMPBIN/\$cmd\" 2>/dev/null;
+             done &&
+             PATH=\"\$TMPBIN\" \"\$TMPBIN/bash\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=api-key --bedrock-key=br-test --dry-run --force 2>&1;
+             rc=\$?; rm -rf \"\$TMPBIN\"; [ \$rc -eq 0 ]"
+    else
+        skip_test "api-key mode warns (not fails) without aws" "aws CLI not installed"
+    fi
 }
 
 #───────────────────────────────────────────────────────────────────────────────

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,8 @@
 # Juggernaut Test Suite
 # Runs tests to verify scripts work correctly
 
-# run_test passes command strings to eval — shellcheck can't trace into eval'd strings
+# SC2288 false positives: test commands use operators (!, |, &&) that shellcheck
+# misreads as argument-position typos because they're inside eval'd strings
 # shellcheck disable=SC2288
 
 #───────────────────────────────────────────────────────────────────────────────
@@ -78,7 +79,9 @@ section() {
 # Create a temporary bin directory with wrapper scripts for specified commands.
 # Uses wrappers (not symlinks) because ln -sf creates broken copies on MSYS/Git Bash.
 # Sets globals: _TMPBIN (temp directory path), _REAL_BASH (path to real bash binary).
-# shellcheck disable=SC2317,SC2329 # invoked indirectly via eval in run_test
+# SC2317: appears unreachable — invoked indirectly via eval in run_test
+# SC2329: unused function — same reason, eval-invoked
+# shellcheck disable=SC2317,SC2329
 _tmpbin_create() {
     _REAL_BASH=$(command -v bash)
     _TMPBIN=$(mktemp -d)
@@ -92,14 +95,18 @@ _tmpbin_create() {
     done
 }
 
-# shellcheck disable=SC2317,SC2329 # invoked indirectly via eval in run_test
+# SC2317: appears unreachable — invoked indirectly via eval in run_test
+# SC2329: unused function — same reason, eval-invoked
+# shellcheck disable=SC2317,SC2329
 _tmpbin_cleanup() {
     rm -rf "$_TMPBIN"
     unset _TMPBIN _REAL_BASH
 }
 
-# Core tools needed by setup-claude-bedrock.sh in restricted-PATH tests
-_TMPBIN_CORE_CMDS=(grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename)
+# Core tools needed by setup-claude-bedrock.sh in restricted-PATH tests.
+# Includes bash/python because some tools (e.g. python3) may be #!/usr/bin/env bash wrappers
+# that exec python (without the 3).
+_TMPBIN_CORE_CMDS=(bash python grep sed cat date dirname pwd mkdir cp chmod tr head printf readlink id uname basename)
 
 #───────────────────────────────────────────────────────────────────────────────
 # Test Cases
@@ -709,6 +716,7 @@ test_api_key_quoting() {
     # Use helper functions to avoid eval quoting nightmares with nested single quotes
 
     # bash/zsh: eval the export line and confirm the variable round-trips correctly
+    # SC2317: appears unreachable — invoked by name via run_test
     # shellcheck disable=SC2317
     _test_bash_quote_escape() {
         local line
@@ -719,6 +727,7 @@ test_api_key_quoting() {
     run_test "bash config escapes embedded single quote" "_test_bash_quote_escape"
 
     # fish: verify the output contains \' (backslash-quote) escape for the embedded quote
+    # SC2317: appears unreachable — invoked by name via run_test
     # shellcheck disable=SC2317
     _test_fish_quote_escape() {
         "$SCRIPT_DIR/setup-claude-bedrock.sh" fish --auth=api-key --bedrock-key="br-te'st" --storage=profile --dry-run --force 2>&1 \
@@ -779,6 +788,24 @@ test_preflight_checks() {
     # Normal invocation should pass preflight (jq or python3 exists in CI)
     run_test "passes preflight with normal PATH" \
         "$SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1"
+
+    # --skip-preflight bypasses aws CLI check (IAM mode would normally fail without aws)
+    if command -v aws &>/dev/null; then
+        run_test "--skip-preflight bypasses aws check" \
+            "_tmpbin_create jq python3 \"\${_TMPBIN_CORE_CMDS[@]}\" &&
+             PATH=\"\$_TMPBIN\" \"\$_REAL_BASH\" $SCRIPT_DIR/setup-claude-bedrock.sh bash --auth=iam --skip-preflight --dry-run --force 2>&1;
+             rc=\$?; _tmpbin_cleanup; [ \$rc -eq 0 ]"
+    else
+        skip_test "--skip-preflight bypasses aws check" "aws CLI not installed"
+    fi
+
+    # JUGGERNAUT_SKIP_PREFLIGHT=1 env var works the same as --skip-preflight
+    run_test "JUGGERNAUT_SKIP_PREFLIGHT=1 skips checks" \
+        "JUGGERNAUT_SKIP_PREFLIGHT=1 $SCRIPT_DIR/setup-claude-bedrock.sh bash --dry-run --force 2>&1"
+
+    # help text mentions --skip-preflight
+    run_test "help shows --skip-preflight" \
+        "$SCRIPT_DIR/setup-claude-bedrock.sh --help | grep -q 'skip-preflight'"
 }
 
 #───────────────────────────────────────────────────────────────────────────────
@@ -903,6 +930,21 @@ test_uninstall() {
         "HOME=/nonexistent $SCRIPT_DIR/uninstall.sh 2>&1"
 }
 
+test_apply_config() {
+    section "Apply Config Script"
+
+    # SC2317: appears unreachable — invoked by name via run_test
+    # shellcheck disable=SC2317
+    _test_apply_config_no_leak() {
+        # After sourcing apply-config.sh, internal helper functions should be cleaned up
+        local output
+        output=$(bash -c "source '$SCRIPT_DIR/apply-config.sh' 2>&1; type _juggernaut_apply_config 2>&1")
+        # Should NOT find the function (it was unset after running)
+        echo "$output" | grep -q "not found"
+    }
+    run_test "apply-config cleans up helper functions" "_test_apply_config_no_leak"
+}
+
 #───────────────────────────────────────────────────────────────────────────────
 # Main
 #───────────────────────────────────────────────────────────────────────────────
@@ -945,6 +987,7 @@ main() {
     test_version_flags
     test_credential_conflict_prevention
     test_uninstall
+    test_apply_config
 
     # Summary
     echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -86,7 +86,7 @@ cleanup_keychain() {
         return 0
     fi
 
-    local os=$(detect_os)
+    local os; os=$(detect_os)
     case "$os" in
         macos)
             security delete-generic-password -s "$keychain_service" -a "$keychain_account" 2>/dev/null || true

--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -200,7 +200,7 @@ check_credential_conflicts() {
             conflicts+=("AWS_PROFILE=$AWS_PROFILE")
         fi
         if [[ "$has_aws_creds_file" == true ]]; then
-            # Tilde is intentional in user-facing display string
+            # SC2088: tilde is intentional in user-facing display string, not a path to expand
             # shellcheck disable=SC2088
             conflicts+=("~/.aws/credentials file exists")
         fi
@@ -219,7 +219,7 @@ check_credential_conflicts() {
     else
         # IAM mode - check for credentials file
         if [[ "$has_aws_creds_file" == true ]]; then
-            # Tilde is intentional in user-facing display string
+            # SC2088: tilde is intentional in user-facing display string, not a path to expand
             # shellcheck disable=SC2088
             echo -e "${GREEN}INFO${NC} ~/.aws/credentials file found (may be used for auth)"
         fi

--- a/validate-setup.sh
+++ b/validate-setup.sh
@@ -200,6 +200,8 @@ check_credential_conflicts() {
             conflicts+=("AWS_PROFILE=$AWS_PROFILE")
         fi
         if [[ "$has_aws_creds_file" == true ]]; then
+            # Tilde is intentional in user-facing display string
+            # shellcheck disable=SC2088
             conflicts+=("~/.aws/credentials file exists")
         fi
 
@@ -217,6 +219,8 @@ check_credential_conflicts() {
     else
         # IAM mode - check for credentials file
         if [[ "$has_aws_creds_file" == true ]]; then
+            # Tilde is intentional in user-facing display string
+            # shellcheck disable=SC2088
             echo -e "${GREEN}INFO${NC} ~/.aws/credentials file found (may be used for auth)"
         fi
         if [[ "$has_aws_profile" == true ]]; then
@@ -267,7 +271,6 @@ check_api_key_validity() {
     # Make a minimal Bedrock API call to test the key
     # Using converse API with minimal input to test authentication
     local test_result
-    local http_code
 
     # Try to invoke the model with a minimal request
     # This will fail fast if the key is invalid


### PR DESCRIPTION
## Summary

- Add pre-flight dependency checks for `jq`/`python3` (hard requirement) and `aws` CLI (soft check with platform-specific install instructions)
- Add `--skip-preflight` flag and `JUGGERNAUT_SKIP_PREFLIGHT=1` env var to bypass aws CLI check
- Add CI lint job with shellcheck + version sync enforcement (with python3 fallback)
- Fix all shellcheck warnings with explanatory comments on every suppression
- Wrap `apply-config.sh` in a function to prevent variable/function leaks when sourced
- Add `.gitattributes` for cross-platform line endings (LF for shell scripts, CRLF for PowerShell)
- Add 6 new test sections (173 total tests, all passing): API key quoting, version sync, pre-flight checks, shellcheck compliance, version flags, credential conflict prevention, uninstall, apply-config leak prevention

## Test plan

- [x] `bash ./test.sh` — 173 passed, 0 failed, 8 skipped
- [x] CI green on all jobs (lint, ubuntu, macOS, Windows PowerShell, Windows Git Bash)
- [x] `--skip-preflight` tested in bash and PowerShell
- [x] shellcheck passes on all scripts