### PR TITLE
fix: PS profile encoding — replace non-ASCII dashes, force UTF-8 writes

### DIFF
--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -19,11 +19,11 @@
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
     "CLAUDE_CODE_SUBAGENT_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
 
-    "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME": "Opus 4.7 (New flagship – 1M context)",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_NAME": "Opus 4.7 (New flagship - 1M context)",
     "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME": "Sonnet 4.6 (Recommended)",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME": "Haiku 4.5 (Fast)",
 
-    "ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION": "Most capable model yet — 1M context, high-res vision (up to 2576px / ~3.75MP), xhigh effort by default, stronger agentic reasoning and self-verification.",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION": "Most capable model yet - 1M context, high-res vision (up to 2576px / ~3.75MP), xhigh effort by default, stronger agentic reasoning and self-verification.",
     "ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION": "Best balance of speed and intelligence",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION": "Fastest model for everyday tasks and subagents",
 

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -872,8 +872,8 @@ if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
         $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# Claude Code - Amazon Bedrock Configuration.*?`$env:ANTHROPIC_(?:SMALL_FAST_)?MODEL = `"[^`"]+`"\r?\n?", "`n"
         # Remove multiple consecutive blank lines
         $ProfileContent = $ProfileContent -replace "(\r?\n){3,}", "`n`n"
-        Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline
-        Add-Content -Path $ProfilePath -Value ""
+        Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline -Encoding utf8
+        Add-Content -Path $ProfilePath -Value "" -Encoding utf8
         Write-Host "Removed existing configuration" -ForegroundColor Gray
     }
 }
@@ -908,7 +908,7 @@ if ($DryRun) {
 }
 
 try {
-    Add-Content -Path $ProfilePath -Value $ConfigBlock -ErrorAction Stop
+    Add-Content -Path $ProfilePath -Value $ConfigBlock -Encoding utf8 -ErrorAction Stop
 } catch {
     Write-Host "" -ForegroundColor Red
     Write-Host "ERROR: Cannot write to $ProfilePath" -ForegroundColor Red

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -107,7 +107,7 @@ function Get-ExistingAuthMode {
     param([string]$ProfilePath)
 
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# Auth mode: (iam|api-key)") {
             return $Matches[1]
         }
@@ -120,7 +120,7 @@ function Get-ExistingModel {
     param([string]$ProfilePath)
 
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# Model: (.+)$" ) {
             return $Matches[1].Trim()
         }
@@ -133,7 +133,7 @@ function Get-ExistingFastModel {
     param([string]$ProfilePath)
 
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# FastModel: (.+)$") {
             return $Matches[1].Trim()
         }
@@ -144,7 +144,7 @@ function Get-ExistingFastModel {
 function Get-ExistingOpusModel {
     param([string]$ProfilePath)
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# OpusModel: (.+)$") {
             return $Matches[1].Trim()
         }
@@ -155,7 +155,7 @@ function Get-ExistingOpusModel {
 function Get-ExistingSonnetModel {
     param([string]$ProfilePath)
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# SonnetModel: (.+)$") {
             return $Matches[1].Trim()
         }
@@ -166,7 +166,7 @@ function Get-ExistingSonnetModel {
 function Get-ExistingHaikuModel {
     param([string]$ProfilePath)
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# HaikuModel: (.+)$") {
             return $Matches[1].Trim()
         }
@@ -180,7 +180,7 @@ function Get-ExistingStorageMode {
     param([string]$ProfilePath)
 
     if (Test-Path $ProfilePath) {
-        $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+        $content = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
         if ($content -match "# Storage: keychain") {
             return "keychain"
         }
@@ -342,7 +342,7 @@ if (-not $StorageExplicit) {
 
 # Detect existing 1M context flag
 if (-not $OneM -and -not $NoOneM) {
-    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -Encoding utf8 -ErrorAction SilentlyContinue
     if ($profileContent -match '# 1MContext: true') {
         $OneM = $true
         Write-Host "Preserving existing 1M context setting"
@@ -351,7 +351,7 @@ if (-not $OneM -and -not $NoOneM) {
 
 # Detect existing opusplan setting
 if (-not $OpusPlanExplicit) {
-    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -Encoding utf8 -ErrorAction SilentlyContinue
     if ($profileContent -match '# OpusPlan: true') {
         $OpusPlan = $true
         Write-Host "Preserving existing opusplan setting"
@@ -360,7 +360,7 @@ if (-not $OpusPlanExplicit) {
 
 # Detect existing effort level
 if (-not $EffortExplicit) {
-    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -Encoding utf8 -ErrorAction SilentlyContinue
     if ($profileContent -match '# EffortLevel: (.+)') {
         $Effort = $Matches[1].Trim()
         Write-Host "Preserving existing effort level: $Effort"
@@ -370,7 +370,7 @@ if (-not $EffortExplicit) {
 # Platform-aware storage default for new installs (Windows defaults to keychain)
 if (-not $StorageExplicit -and $Storage -eq "profile") {
     # On Windows, Credential Manager is always available
-    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -Encoding utf8 -ErrorAction SilentlyContinue
     if (-not ($profileContent -match "CLAUDE_CODE_USE_BEDROCK")) {
         # New install — default to keychain on Windows
         $Storage = "keychain"
@@ -379,7 +379,7 @@ if (-not $StorageExplicit -and $Storage -eq "profile") {
 
 # Offer to migrate plaintext API keys to Credential Manager
 if ($Auth -eq "api-key" -and -not $StorageExplicit -and $Storage -eq "profile") {
-    $profileContent = Get-Content $ProfilePathForDetection -Raw -ErrorAction SilentlyContinue
+    $profileContent = Get-Content $ProfilePathForDetection -Raw -Encoding utf8 -ErrorAction SilentlyContinue
     if ($profileContent -match "CLAUDE_CODE_USE_BEDROCK" -and $profileContent -notmatch "# Storage: keychain") {
         if ($Force) {
             $Storage = "keychain"
@@ -852,7 +852,7 @@ if ((Test-Path $ProfilePath) -and -not $DryRun) {
 }
 
 # Check if configuration already exists
-$ProfileContent = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+$ProfileContent = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
 if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
     Write-Host "Existing configuration found" -ForegroundColor Yellow
 

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -14,7 +14,7 @@ if (-not (Test-Path $ProfilePath)) {
     exit 0
 }
 
-$ProfileContent = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+$ProfileContent = Get-Content $ProfilePath -Raw -Encoding utf8 -ErrorAction SilentlyContinue
 
 if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
     # Clean up keychain credentials before removing config (needs the markers to detect storage mode)
@@ -28,8 +28,8 @@ if ($ProfileContent -match "CLAUDE_CODE_USE_BEDROCK") {
     $ProfileContent = $ProfileContent -replace "(?ms)\r?\n?# Claude Code - Amazon Bedrock Configuration.*?`$env:ANTHROPIC_(?:SMALL_FAST_)?MODEL = `"[^`"]+`"\r?\n?", "`n"
     # Remove multiple consecutive blank lines
     $ProfileContent = $ProfileContent -replace "(\r?\n){3,}", "`n`n"
-    Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline
-    Add-Content -Path $ProfilePath -Value ""
+    Set-Content -Path $ProfilePath -Value $ProfileContent.TrimEnd() -NoNewline -Encoding utf8
+    Add-Content -Path $ProfilePath -Value "" -Encoding utf8
     Write-Host "Configuration removed from $ProfilePath" -ForegroundColor Green
 } else {
     Write-Host "No configuration found in $ProfilePath" -ForegroundColor Yellow


### PR DESCRIPTION
## Summary

- Non-ASCII en/em dashes (`–`, `—`) in `bedrock-config.json` caused `ParseException` errors when the generated PowerShell profile was loaded on Windows
- Root cause: `Set-Content`/`Add-Content`/`Get-Content` default to Windows-1252 on Windows PowerShell 5.1; UTF-8 byte `0x93` (part of the en dash sequence `E2 80 93`) decodes as `"` in Windows-1252, closing the `$env:` string assignment early
- Replace en dash and em dash with plain hyphens in `ANTHROPIC_DEFAULT_OPUS_MODEL_NAME` and `ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION`
- Add `-Encoding utf8` to every `Set-Content`/`Add-Content`/`Get-Content` profile I/O in `setup-claude-bedrock.ps1` and `uninstall.ps1`

## Test plan

- [x] CI `Test on Windows (PowerShell)` passes — dry-run setup covers the write path
- [x] CI `Test on Windows (Git Bash)` passes — unified entry point / keychain paths unaffected
- [x] CI `Lint` + shellcheck passes — no regressions in bash scripts
- [x] All read/write profile I/O in setup + uninstall now explicitly uses `-Encoding utf8` (verified via grep)