### PR TITLE
feat(v2): Phase 1 — ConfigManager + Schema foundation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,6 +211,7 @@ jobs:
       - name: Run v2 Pester tests
         shell: pwsh
         run: |
+          Import-Module Pester -MinimumVersion 5.0.0 -Force
           $config = [PesterConfiguration]::Default
           $config.Run.Path = './tests/v2'
           $config.Run.Exit = $true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,25 @@ jobs:
         shell: pwsh
         run: Get-Content .\iam-policy.json | ConvertFrom-Json
 
+      - name: Install Pester 5
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -Scope CurrentUser -Force -SkipPublisherCheck -MinimumVersion 5.0.0
+          Import-Module Pester -MinimumVersion 5.0.0
+          Write-Host "Pester version: $((Get-Module Pester).Version)"
+
+      - name: Run v2 Pester tests
+        shell: pwsh
+        run: |
+          $config = [PesterConfiguration]::Default
+          $config.Run.Path = './tests/v2'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputFormat = 'JUnitXml'
+          $config.TestResult.OutputPath = './pester-results.xml'
+          Invoke-Pester -Configuration $config
+
   test-windows-gitbash:
     name: Test on Windows (Git Bash)
     runs-on: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,7 @@ jobs:
           Write-Host "Pester version: $((Get-Module Pester).Version)"
 
       - name: Run v2 Pester tests
+        timeout-minutes: 5
         shell: pwsh
         run: |
           Import-Module Pester -MinimumVersion 5.0.0 -Force

--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,10 @@ secrets.*
 .bash_history
 .zsh_history
 
-# Test files
-test_*
+# Local throwaway test files at repo root (not the committed tests/ suite)
+/test_*
 *.test
+!tests/**
 
 # Claude Code local settings
 .claude/

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -1,5 +1,6 @@
 # lib/config_manager.ps1 — settings.json read/merge/write for Juggernaut v2. Mirrors lib/config_manager.sh.
-# UTF-8 throughout (no BOM preferred; PS 5.1 writes UTF-8-with-BOM when -Encoding utf8 is used, acceptable for JSON).
+# UTF-8 throughout. Note: Set-Content -Encoding utf8 emits UTF-8-with-BOM on
+# Windows PowerShell 5.1; all mainstream JSON parsers tolerate a leading BOM.
 
 $Script:ConfigBackupRetain = 5
 
@@ -137,22 +138,30 @@ function Write-SettingsAtomic {
         [Parameter(Mandatory)]$Content
     )
 
-    $dir = Split-Path $Path -Parent
-    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
-
     $json = $Content | ConvertTo-Json -Depth 32
-    # Round-trip validation before touching disk.
+    # Round-trip validation before touching disk or taking the lock.
     try { $null = $json | ConvertFrom-Json -ErrorAction Stop } catch {
         throw "Write-SettingsAtomic: refusing to write invalid JSON to $Path"
     }
 
-    if (Test-Path $Path) { Backup-Settings -Path $Path | Out-Null }
+    $dir = Split-Path $Path -Parent
+    try {
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+    } catch {
+        throw "Write-SettingsAtomic: cannot create parent directory $dir: $_"
+    }
 
-    $tmp = "$Path.tmp.$PID"
-    Set-Content -Path $tmp -Value $json -NoNewline -Encoding utf8
-
-    # Atomic rename.
-    Move-Item -Path $tmp -Destination $Path -Force
+    Invoke-WithSettingsLock -Path $Path -Action {
+        if (Test-Path $Path) { Backup-Settings -Path $Path | Out-Null }
+        $tmp = "$Path.tmp.$PID"
+        try {
+            Set-Content -Path $tmp -Value $json -NoNewline -Encoding utf8
+            Move-Item -Path $tmp -Destination $Path -Force
+        } catch {
+            Remove-Item -Path $tmp -Force -ErrorAction SilentlyContinue
+            throw
+        }
+    }.GetNewClosure()
 }
 
 function Invoke-WithSettingsLock {
@@ -160,15 +169,27 @@ function Invoke-WithSettingsLock {
         [Parameter(Mandatory)][string]$Path,
         [Parameter(Mandatory)][scriptblock]$Action
     )
+    # Per-file named mutex so multiple settings.json files don't serialize against each other.
     $lockName = "Global\juggernaut_$([IO.Path]::GetFileName($Path))"
     $mutex = New-Object System.Threading.Mutex($false, $lockName)
+    $acquired = $false
     try {
-        if (-not $mutex.WaitOne(5000)) {
+        try {
+            $acquired = $mutex.WaitOne(5000)
+        } catch [System.Threading.AbandonedMutexException] {
+            # A prior holder died without releasing; we've now acquired it safely.
+            $acquired = $true
+        } catch {
+            throw "Invoke-WithSettingsLock: mutex acquisition failed on $lockName: $_"
+        }
+        if (-not $acquired) {
             throw "Invoke-WithSettingsLock: could not acquire lock on $lockName within 5s"
         }
         & $Action
     } finally {
-        $mutex.ReleaseMutex() | Out-Null
+        if ($acquired) {
+            try { $mutex.ReleaseMutex() | Out-Null } catch {}
+        }
         $mutex.Dispose()
     }
 }

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -36,10 +36,16 @@ function Test-SettingsExists {
 
 function ConvertTo-HashtableRecursive {
     # PS 5.1 has no ConvertFrom-Json -AsHashtable. Walk PSCustomObject → [ordered]@{}
+    # and keep arrays as [object[]] so indexing like $x[0] returns an element.
     param([Parameter(Mandatory)][AllowNull()]$InputObject)
     if ($null -eq $InputObject) { return $null }
-    if ($InputObject -is [System.Collections.IList]) {
-        return ,@($InputObject | ForEach-Object { ConvertTo-HashtableRecursive $_ })
+    if ($InputObject -is [System.Collections.IList] -and -not ($InputObject -is [string])) {
+        $list = New-Object System.Collections.Generic.List[object]
+        foreach ($item in $InputObject) {
+            $list.Add((ConvertTo-HashtableRecursive $item))
+        }
+        # Return as [object[]] so Pester's $x[0] indexing works naturally.
+        return ,$list.ToArray()
     }
     if ($InputObject -is [PSCustomObject]) {
         $out = [ordered]@{}

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -151,7 +151,19 @@ function Write-SettingsAtomic {
         throw "Write-SettingsAtomic: cannot create parent directory ${dir}: $_"
     }
 
-    Invoke-WithSettingsLock -Path $Path -Action {
+    # Acquire the per-file mutex inline. Passing a scriptblock to
+    # Invoke-WithSettingsLock and having it resolve Backup-Settings through
+    # scope chains is fragile on PS 7; inline form keeps everything in the
+    # current module's scope.
+    $lockName = "Global\juggernaut_$([IO.Path]::GetFileName($Path))"
+    $mutex = New-Object System.Threading.Mutex($false, $lockName)
+    $acquired = $false
+    try {
+        try { $acquired = $mutex.WaitOne(5000) }
+        catch [System.Threading.AbandonedMutexException] { $acquired = $true }
+        catch { throw "Write-SettingsAtomic: mutex acquisition failed on ${lockName}: $_" }
+        if (-not $acquired) { throw "Write-SettingsAtomic: could not acquire lock on ${lockName} within 5s" }
+
         if (Test-Path $Path) { Backup-Settings -Path $Path | Out-Null }
         $tmp = "$Path.tmp.$PID"
         try {
@@ -161,7 +173,10 @@ function Write-SettingsAtomic {
             Remove-Item -Path $tmp -Force -ErrorAction SilentlyContinue
             throw
         }
-    }.GetNewClosure()
+    } finally {
+        if ($acquired) { try { $mutex.ReleaseMutex() | Out-Null } catch {} }
+        $mutex.Dispose()
+    }
 }
 
 function Invoke-WithSettingsLock {

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -148,7 +148,7 @@ function Write-SettingsAtomic {
     try {
         if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
     } catch {
-        throw "Write-SettingsAtomic: cannot create parent directory $dir: $_"
+        throw "Write-SettingsAtomic: cannot create parent directory ${dir}: $_"
     }
 
     Invoke-WithSettingsLock -Path $Path -Action {
@@ -180,10 +180,10 @@ function Invoke-WithSettingsLock {
             # A prior holder died without releasing; we've now acquired it safely.
             $acquired = $true
         } catch {
-            throw "Invoke-WithSettingsLock: mutex acquisition failed on $lockName: $_"
+            throw "Invoke-WithSettingsLock: mutex acquisition failed on ${lockName}: $_"
         }
         if (-not $acquired) {
-            throw "Invoke-WithSettingsLock: could not acquire lock on $lockName within 5s"
+            throw "Invoke-WithSettingsLock: could not acquire lock on ${lockName} within 5s"
         }
         & $Action
     } finally {

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -1,0 +1,157 @@
+# lib/config_manager.ps1 — settings.json read/merge/write for Juggernaut v2. Mirrors lib/config_manager.sh.
+# UTF-8 throughout (no BOM preferred; PS 5.1 writes UTF-8-with-BOM when -Encoding utf8 is used, acceptable for JSON).
+
+$Script:ConfigBackupRetain = 5
+
+function Get-UserSettingsPath {
+    Join-Path $HOME '.claude/settings.json'
+}
+
+function Get-ProjectSettingsPath {
+    param([string]$StartDir = (Get-Location).Path)
+    $dir = $StartDir
+    while ($dir -and $dir -ne $HOME -and $dir -ne [IO.Path]::GetPathRoot($dir)) {
+        $candidate = Join-Path $dir '.claude/settings.json'
+        if (Test-Path $candidate) { return $candidate }
+        $parent = Split-Path $dir -Parent
+        if ($parent -eq $dir) { break }
+        $dir = $parent
+    }
+    return $null
+}
+
+function Resolve-SettingsTarget {
+    param([ValidateSet('user','project')][string]$Scope = 'user')
+    switch ($Scope) {
+        'user'    { Get-UserSettingsPath }
+        'project' { Join-Path (Get-Location).Path '.claude/settings.json' }
+    }
+}
+
+function Test-SettingsExists {
+    param([Parameter(Mandatory)][string]$Path)
+    (Test-Path $Path) -and ((Get-Item $Path).Length -gt 0)
+}
+
+function Read-Settings {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-SettingsExists -Path $Path)) { return [ordered]@{} }
+    try {
+        $raw = Get-Content -Path $Path -Raw -Encoding utf8
+        return $raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+    } catch {
+        throw "Read-Settings: $Path is not valid JSON: $_"
+    }
+}
+
+function Test-HasJuggernautBlock {
+    param([Parameter(Mandatory)]$Settings)
+    if (-not $Settings) { return $false }
+    if ($Settings -is [hashtable] -or $Settings -is [System.Collections.Specialized.OrderedDictionary]) {
+        return $Settings.Contains('juggernaut') -and $Settings.juggernaut.meta.managedBy -eq 'juggernaut'
+    }
+    return ($Settings.juggernaut -and $Settings.juggernaut.meta.managedBy -eq 'juggernaut')
+}
+
+function Get-JuggernautBlockFromSettings {
+    param([Parameter(Mandatory)]$Settings)
+    if (Test-HasJuggernautBlock -Settings $Settings) { return $Settings.juggernaut }
+    return $null
+}
+
+function Merge-JuggernautBlock {
+    param(
+        [Parameter(Mandatory)]$Existing,
+        [Parameter(Mandatory)]$NewBlock,
+        [Parameter(Mandatory)]$NativeKeys
+    )
+    if (-not $Existing) { $Existing = [ordered]@{} }
+    $Existing['juggernaut']     = $NewBlock
+    $Existing['env']            = $NativeKeys.env
+    $Existing['model']          = $NativeKeys.model
+    $Existing['modelOverrides'] = $NativeKeys.modelOverrides
+    return $Existing
+}
+
+function Remove-JuggernautBlockFromSettings {
+    param([Parameter(Mandatory)]$Existing)
+    foreach ($k in @('juggernaut','env','model','modelOverrides','availableModels')) {
+        if ($Existing.Contains($k)) { $Existing.Remove($k) | Out-Null }
+    }
+    return $Existing
+}
+
+function Backup-Settings {
+    param([Parameter(Mandatory)][string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    $stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $backup = "$Path.backup.$stamp"
+    Copy-Item -Path $Path -Destination $backup -Force
+    Invoke-SettingsBackupRotation -Path $Path
+    return $backup
+}
+
+function Invoke-SettingsBackupRotation {
+    param([Parameter(Mandatory)][string]$Path)
+    $pattern = "$Path.backup.*"
+    $backups = Get-ChildItem -Path (Split-Path $Path -Parent) -Filter (Split-Path $pattern -Leaf) -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending
+    if ($backups.Count -gt $Script:ConfigBackupRetain) {
+        $backups | Select-Object -Skip $Script:ConfigBackupRetain | Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Write-SettingsAtomic {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)]$Content
+    )
+
+    $dir = Split-Path $Path -Parent
+    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+
+    $json = $Content | ConvertTo-Json -Depth 32
+    # Round-trip validation before touching disk.
+    try { $null = $json | ConvertFrom-Json -ErrorAction Stop } catch {
+        throw "Write-SettingsAtomic: refusing to write invalid JSON to $Path"
+    }
+
+    if (Test-Path $Path) { Backup-Settings -Path $Path | Out-Null }
+
+    $tmp = "$Path.tmp.$PID"
+    Set-Content -Path $tmp -Value $json -NoNewline -Encoding utf8
+
+    # Atomic rename.
+    Move-Item -Path $tmp -Destination $Path -Force
+}
+
+function Invoke-WithSettingsLock {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][scriptblock]$Action
+    )
+    $lockName = "Global\juggernaut_$([IO.Path]::GetFileName($Path))"
+    $mutex = New-Object System.Threading.Mutex($false, $lockName)
+    try {
+        if (-not $mutex.WaitOne(5000)) {
+            throw "Invoke-WithSettingsLock: could not acquire lock on $lockName within 5s"
+        }
+        & $Action
+    } finally {
+        $mutex.ReleaseMutex() | Out-Null
+        $mutex.Dispose()
+    }
+}
+
+function Get-EffectiveSettings {
+    $userPath = Get-UserSettingsPath
+    $projectPath = Get-ProjectSettingsPath
+    $userSettings = if (Test-SettingsExists -Path $userPath) { Read-Settings -Path $userPath } else { $null }
+    $projectSettings = if ($projectPath) { Read-Settings -Path $projectPath } else { $null }
+
+    $result = [ordered]@{
+        user    = [ordered]@{ path = $userPath; settings = $userSettings }
+        project = if ($projectPath) { [ordered]@{ path = $projectPath; settings = $projectSettings } } else { $null }
+    }
+    return $result
+}

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -33,29 +33,54 @@ function Test-SettingsExists {
     (Test-Path $Path) -and ((Get-Item $Path).Length -gt 0)
 }
 
+function ConvertTo-HashtableRecursive {
+    # PS 5.1 has no ConvertFrom-Json -AsHashtable. Walk PSCustomObject → [ordered]@{}
+    param([Parameter(Mandatory)][AllowNull()]$InputObject)
+    if ($null -eq $InputObject) { return $null }
+    if ($InputObject -is [System.Collections.IList]) {
+        return ,@($InputObject | ForEach-Object { ConvertTo-HashtableRecursive $_ })
+    }
+    if ($InputObject -is [PSCustomObject]) {
+        $out = [ordered]@{}
+        foreach ($p in $InputObject.PSObject.Properties) {
+            $out[$p.Name] = ConvertTo-HashtableRecursive $p.Value
+        }
+        return $out
+    }
+    return $InputObject
+}
+
 function Read-Settings {
     param([Parameter(Mandatory)][string]$Path)
     if (-not (Test-SettingsExists -Path $Path)) { return [ordered]@{} }
+    $raw = Get-Content -Path $Path -Raw -Encoding utf8
     try {
-        $raw = Get-Content -Path $Path -Raw -Encoding utf8
-        return $raw | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
     } catch {
         throw "Read-Settings: $Path is not valid JSON: $_"
     }
+    # Force hashtable/ordered-dict shape so callers can .Contains() / .Remove() uniformly on PS 5.1+.
+    $result = ConvertTo-HashtableRecursive $parsed
+    if ($null -eq $result) { return [ordered]@{} }
+    return $result
 }
 
 function Test-HasJuggernautBlock {
     param([Parameter(Mandatory)]$Settings)
     if (-not $Settings) { return $false }
+    $hasKey = $false
     if ($Settings -is [hashtable] -or $Settings -is [System.Collections.Specialized.OrderedDictionary]) {
-        return $Settings.Contains('juggernaut') -and $Settings.juggernaut.meta.managedBy -eq 'juggernaut'
+        $hasKey = $Settings.Contains('juggernaut')
+    } else {
+        $hasKey = [bool]($Settings.PSObject.Properties.Name -contains 'juggernaut')
     }
-    return ($Settings.juggernaut -and $Settings.juggernaut.meta.managedBy -eq 'juggernaut')
+    if (-not $hasKey) { return $false }
+    return ($Settings['juggernaut'].meta.managedBy -eq 'juggernaut')
 }
 
 function Get-JuggernautBlockFromSettings {
     param([Parameter(Mandatory)]$Settings)
-    if (Test-HasJuggernautBlock -Settings $Settings) { return $Settings.juggernaut }
+    if (Test-HasJuggernautBlock -Settings $Settings) { return $Settings['juggernaut'] }
     return $null
 }
 
@@ -75,8 +100,13 @@ function Merge-JuggernautBlock {
 
 function Remove-JuggernautBlockFromSettings {
     param([Parameter(Mandatory)]$Existing)
+    if (-not $Existing) { return [ordered]@{} }
     foreach ($k in @('juggernaut','env','model','modelOverrides','availableModels')) {
-        if ($Existing.Contains($k)) { $Existing.Remove($k) | Out-Null }
+        if ($Existing -is [hashtable] -or $Existing -is [System.Collections.Specialized.OrderedDictionary]) {
+            if ($Existing.Contains($k)) { $Existing.Remove($k) | Out-Null }
+        } elseif ($Existing.PSObject.Properties.Name -contains $k) {
+            $Existing.PSObject.Properties.Remove($k) | Out-Null
+        }
     }
     return $Existing
 }

--- a/lib/config_manager.sh
+++ b/lib/config_manager.sh
@@ -12,14 +12,15 @@ config_user_settings_path() {
 }
 
 config_project_settings_path() {
-  # Walks up from CWD looking for .claude/settings.json, stops at $HOME or /
+  # Walks up from CWD looking for .claude/settings.json, stops at $HOME or /.
+  # Optional $1 = start dir (default: $PWD). Returns 1 if not found.
   local dir="${1:-$PWD}"
   while [[ "$dir" != "/" && "$dir" != "$HOME" ]]; do
     if [[ -f "$dir/.claude/settings.json" ]]; then
       echo "$dir/.claude/settings.json"
       return 0
     fi
-    dir="$(dirname "$dir")"
+    dir="$(dirname -- "$dir")"
   done
   return 1
 }
@@ -119,10 +120,24 @@ config_backup() {
 
 config_rotate_backups() {
   local path="$1"
-  local pattern="${path}.backup.*"
-  # shellcheck disable=SC2012
-  ls -1t ${pattern} 2>/dev/null | tail -n +$((CONFIG_BACKUP_RETAIN + 1)) | while read -r old; do
-    rm -f -- "$old"
+  local dir base
+  dir="$(dirname -- "$path")"
+  base="$(basename -- "$path")"
+
+  # Use find + mtime-sort to avoid parsing ls and to handle names with spaces.
+  local -a backups=()
+  while IFS= read -r -d '' f; do
+    backups+=("$f")
+  done < <(find "$dir" -maxdepth 1 -name "${base}.backup.*" -printf '%T@ %p\0' 2>/dev/null \
+             | sort -z -rn \
+             | cut -z -d' ' -f2-)
+
+  local i=0
+  for f in "${backups[@]}"; do
+    i=$((i + 1))
+    if (( i > CONFIG_BACKUP_RETAIN )); then
+      rm -f -- "$f"
+    fi
   done
 }
 
@@ -160,32 +175,48 @@ config_write_atomic() {
   fi
 
   # Best-effort fsync (not all OSes / all shells support sync -f).
-  command -v sync >/dev/null 2>&1 && sync "$tmp" 2>/dev/null || true
+  if command -v sync >/dev/null 2>&1; then
+    sync "$tmp" 2>/dev/null || true
+  fi
 
-  mv -f "$tmp" "$path"
+  mv -f -- "$tmp" "$path"
 }
 
 # config_with_lock <path> <command...>
-# Run command under an exclusive flock on path.lock. Falls back to no-op if flock missing.
+# Runs command under an exclusive flock on path.lock with a 10s timeout.
+# Falls back to a directory-based mkdir lock when flock is absent (macOS by default,
+# Git Bash on Windows). On fallback, caller gets the same blocking semantics.
 config_with_lock() {
   local path="$1"; shift
   local lockfile="${path}.lock"
-  mkdir -p "$(dirname "$lockfile")"
+  mkdir -p -- "$(dirname -- "$lockfile")"
 
   if command -v flock >/dev/null 2>&1; then
-    exec 9>"$lockfile"
-    if ! flock -x -w 5 9; then
-      echo "config_with_lock: could not acquire lock on $lockfile within 5s" >&2
+    local rc
+    {
+      if ! flock -x -w 10 9; then
+        echo "config_with_lock: could not acquire flock on $lockfile within 10s" >&2
+        return 1
+      fi
+      "$@"
+      rc=$?
+    } 9>"$lockfile"
+    return "$rc"
+  fi
+
+  # Fallback: mkdir-based mutex (POSIX, atomic on all filesystems we care about).
+  local lockdir="${path}.lockdir"
+  local waited=0
+  until mkdir -- "$lockdir" 2>/dev/null; do
+    if (( waited >= 10 )); then
+      echo "config_with_lock: could not acquire mkdir lock on $lockdir within 10s" >&2
       return 1
     fi
-    "$@"
-    local rc=$?
-    exec 9>&-
-    return $rc
-  else
-    # No flock → run unlocked. Acceptable for interactive setup; risky for concurrent CI.
-    "$@"
-  fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  trap 'rmdir -- "$lockdir" 2>/dev/null || true' RETURN
+  "$@"
 }
 
 # config_load_effective
@@ -194,7 +225,7 @@ config_with_lock() {
 config_load_effective() {
   local user_path project_path user_json project_json
   user_path="$(config_user_settings_path)"
-  project_path="$(config_project_settings_path 2>/dev/null || true)"
+  project_path="$(config_project_settings_path "$PWD" 2>/dev/null || true)"
 
   user_json="$(config_read "$user_path")"
   if [[ -n "$project_path" ]]; then

--- a/lib/config_manager.sh
+++ b/lib/config_manager.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# lib/config_manager.sh — settings.json read/merge/write operations for Juggernaut v2.
+# All writes atomic. Backups auto-rotated. No schema logic here — that lives in schema.sh.
+# Requires: bash 4+, jq, flock (util-linux; macOS has it via brew or we fall back).
+
+set -euo pipefail
+
+CONFIG_BACKUP_RETAIN=5
+
+config_user_settings_path() {
+  echo "${HOME}/.claude/settings.json"
+}
+
+config_project_settings_path() {
+  # Walks up from CWD looking for .claude/settings.json, stops at $HOME or /
+  local dir="${1:-$PWD}"
+  while [[ "$dir" != "/" && "$dir" != "$HOME" ]]; do
+    if [[ -f "$dir/.claude/settings.json" ]]; then
+      echo "$dir/.claude/settings.json"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+config_resolve_target() {
+  local scope="${1:-user}"
+  case "$scope" in
+    user)    config_user_settings_path ;;
+    project) echo "${PWD}/.claude/settings.json" ;;
+    *) echo "config_resolve_target: unknown scope '$scope'" >&2; return 1 ;;
+  esac
+}
+
+config_exists() {
+  local path="$1"
+  [[ -s "$path" ]]
+}
+
+# config_read <path>
+# Prints the file contents as JSON. If file is absent or empty, prints "{}".
+# Errors out if file exists but is malformed.
+config_read() {
+  local path="$1"
+  if [[ ! -s "$path" ]]; then
+    echo "{}"
+    return 0
+  fi
+  if ! jq -e . "$path" >/dev/null 2>&1; then
+    echo "config_read: $path is not valid JSON" >&2
+    return 1
+  fi
+  cat "$path"
+}
+
+config_has_juggernaut_block() {
+  local json="$1"
+  local managed
+  managed="$(echo "$json" | jq -r '.juggernaut.meta.managedBy // ""')"
+  [[ "$managed" == "juggernaut" ]]
+}
+
+config_get_juggernaut_block() {
+  local json="$1"
+  echo "$json" | jq '.juggernaut // null'
+}
+
+# config_merge_juggernaut_block <existing_json> <new_block> <native_keys>
+# Returns existing_json with:
+#   .juggernaut replaced by new_block
+#   native keys (env, model, modelOverrides, availableModels) replaced by values from native_keys
+# User's other top-level keys (permissions, hooks, theme, etc.) are preserved untouched.
+config_merge_juggernaut_block() {
+  local existing="$1"
+  local new_block="$2"
+  local native_keys="$3"
+
+  jq -n \
+    --argjson existing "$existing" \
+    --argjson block "$new_block" \
+    --argjson native "$native_keys" \
+    '
+    $existing
+    | .juggernaut = $block
+    | .env = $native.env
+    | .model = $native.model
+    | .modelOverrides = $native.modelOverrides
+    '
+}
+
+# config_remove_juggernaut_block <existing_json>
+# Returns existing_json with .juggernaut and all Juggernaut-owned native keys removed.
+# User's other keys preserved.
+config_remove_juggernaut_block() {
+  local existing="$1"
+  jq '
+    del(.juggernaut)
+    | del(.env)
+    | del(.model)
+    | del(.modelOverrides)
+    | del(.availableModels)
+  ' <<<"$existing"
+}
+
+# config_backup <path>
+# Copies path → path.backup.YYYYMMDD_HHMMSS. Rotates: keeps most recent CONFIG_BACKUP_RETAIN, prunes older.
+# No-op if path doesn't exist.
+config_backup() {
+  local path="$1"
+  [[ -f "$path" ]] || return 0
+  local stamp
+  stamp="$(date +%Y%m%d_%H%M%S)"
+  local backup="${path}.backup.${stamp}"
+  cp -p "$path" "$backup"
+  echo "$backup"
+  config_rotate_backups "$path"
+}
+
+config_rotate_backups() {
+  local path="$1"
+  local pattern="${path}.backup.*"
+  # shellcheck disable=SC2012
+  ls -1t ${pattern} 2>/dev/null | tail -n +$((CONFIG_BACKUP_RETAIN + 1)) | while read -r old; do
+    rm -f -- "$old"
+  done
+}
+
+# config_write_atomic <path> <json_string>
+# Atomic write: create parent dir if missing, write to tmp, fsync, rename over target.
+# Preserves file mode if file exists; sets 0600 on new files (contains keys).
+# Calls config_backup first.
+config_write_atomic() {
+  local path="$1"
+  local content="$2"
+
+  local dir
+  dir="$(dirname "$path")"
+  mkdir -p "$dir"
+
+  # Validate JSON before touching anything.
+  if ! echo "$content" | jq -e . >/dev/null 2>&1; then
+    echo "config_write_atomic: refusing to write invalid JSON to $path" >&2
+    return 1
+  fi
+
+  if [[ -f "$path" ]]; then
+    config_backup "$path" >/dev/null
+  fi
+
+  local tmp="${path}.tmp.$$"
+  # Pretty-print on write so settings.json is human-readable.
+  echo "$content" | jq '.' >"$tmp"
+
+  # Preserve mode if target exists; otherwise tighten to 0600 (settings may hold keys).
+  if [[ -f "$path" ]]; then
+    chmod --reference="$path" "$tmp" 2>/dev/null || true
+  else
+    chmod 0600 "$tmp"
+  fi
+
+  # Best-effort fsync (not all OSes / all shells support sync -f).
+  command -v sync >/dev/null 2>&1 && sync "$tmp" 2>/dev/null || true
+
+  mv -f "$tmp" "$path"
+}
+
+# config_with_lock <path> <command...>
+# Run command under an exclusive flock on path.lock. Falls back to no-op if flock missing.
+config_with_lock() {
+  local path="$1"; shift
+  local lockfile="${path}.lock"
+  mkdir -p "$(dirname "$lockfile")"
+
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$lockfile"
+    if ! flock -x -w 5 9; then
+      echo "config_with_lock: could not acquire lock on $lockfile within 5s" >&2
+      return 1
+    fi
+    "$@"
+    local rc=$?
+    exec 9>&-
+    return $rc
+  else
+    # No flock → run unlocked. Acceptable for interactive setup; risky for concurrent CI.
+    "$@"
+  fi
+}
+
+# config_load_effective
+# Returns a JSON object summarizing what's visible in both scopes.
+# v2.0: no merging — just side-by-side display.
+config_load_effective() {
+  local user_path project_path user_json project_json
+  user_path="$(config_user_settings_path)"
+  project_path="$(config_project_settings_path 2>/dev/null || true)"
+
+  user_json="$(config_read "$user_path")"
+  if [[ -n "$project_path" ]]; then
+    project_json="$(config_read "$project_path")"
+  else
+    project_json="null"
+  fi
+
+  jq -n \
+    --arg userPath "$user_path" \
+    --arg projectPath "${project_path:-}" \
+    --argjson user "$user_json" \
+    --argjson project "$project_json" \
+    '
+    {
+      user:    { path: $userPath,    settings: $user },
+      project: (if $projectPath | length > 0 then { path: $projectPath, settings: $project } else null end)
+    }
+    '
+}

--- a/lib/config_manager.sh
+++ b/lib/config_manager.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
-# lib/config_manager.sh — settings.json read/merge/write operations for Juggernaut v2.
-# All writes atomic. Backups auto-rotated. No schema logic here — that lives in schema.sh.
-# Requires: bash 4+, jq, flock (util-linux; macOS has it via brew or we fall back).
+# lib/config_manager.sh — settings.json read/merge/write for Juggernaut v2.
+# Atomic writes, rotated backups, best-effort locking.
+# Requires: bash 4+, jq.  Optional: flock (mkdir fallback when absent).
 
 set -euo pipefail
 
 CONFIG_BACKUP_RETAIN=5
+
+# Copy the mode from $1 to $2 using a portable stat (GNU or BSD) and chmod.
+# Falls back to 0600 on failure — settings.json may hold keys, err on tighter.
+config_copy_mode() {
+  local src="$1" dst="$2" mode
+  mode="$(stat -c '%a' "$src" 2>/dev/null || stat -f '%Lp' "$src" 2>/dev/null || echo "")"
+  if [[ -n "$mode" ]]; then
+    chmod "$mode" "$dst" 2>/dev/null && return 0
+  fi
+  chmod 0600 "$dst" 2>/dev/null || true
+}
 
 config_user_settings_path() {
   echo "${HOME}/.claude/settings.json"
@@ -91,8 +102,11 @@ config_merge_juggernaut_block() {
 }
 
 # config_remove_juggernaut_block <existing_json>
-# Returns existing_json with .juggernaut and all Juggernaut-owned native keys removed.
-# User's other keys preserved.
+# Strips every key Juggernaut writes: .juggernaut plus the derived natives
+# (.env, .model, .modelOverrides, .availableModels). availableModels is also
+# treated as Juggernaut-managed — users who want to keep it should store it
+# under a different key.
+# User's other top-level keys (permissions, hooks, theme, ...) are preserved.
 config_remove_juggernaut_block() {
   local existing="$1"
   jq '
@@ -142,44 +156,71 @@ config_rotate_backups() {
 }
 
 # config_write_atomic <path> <json_string>
-# Atomic write: create parent dir if missing, write to tmp, fsync, rename over target.
-# Preserves file mode if file exists; sets 0600 on new files (contains keys).
-# Calls config_backup first.
+# Validate → backup → write tmp → rename. Whole body runs under lock so two
+# concurrent callers cannot corrupt each other's tmp file.
+#
+# Atomicity caveats: mv(1) is atomic only within the same filesystem. sync(1)
+# is best-effort; not all OSes support it. On a power failure, settings.json
+# may be the old value or the new value, never a mix.
 config_write_atomic() {
   local path="$1"
   local content="$2"
 
-  local dir
-  dir="$(dirname "$path")"
-  mkdir -p "$dir"
-
-  # Validate JSON before touching anything.
-  if ! echo "$content" | jq -e . >/dev/null 2>&1; then
+  # Validate JSON before doing anything — no lock needed for a pure check.
+  if ! printf '%s' "$content" | jq -e . >/dev/null 2>&1; then
     echo "config_write_atomic: refusing to write invalid JSON to $path" >&2
     return 1
   fi
 
-  if [[ -f "$path" ]]; then
-    config_backup "$path" >/dev/null
+  local dir
+  dir="$(dirname -- "$path")"
+  if ! mkdir -p -- "$dir"; then
+    echo "config_write_atomic: cannot create parent directory $dir" >&2
+    return 1
   fi
 
+  config_with_lock "$path" _config_write_atomic_locked "$path" "$content"
+}
+
+# Internal: the locked critical section of config_write_atomic. Do not call directly.
+_config_write_atomic_locked() {
+  local path="$1"
+  local content="$2"
   local tmp="${path}.tmp.$$"
-  # Pretty-print on write so settings.json is human-readable.
-  echo "$content" | jq '.' >"$tmp"
 
-  # Preserve mode if target exists; otherwise tighten to 0600 (settings may hold keys).
+  # Clean tmp if any earlier run died mid-write.
+  rm -f -- "$tmp"
+
   if [[ -f "$path" ]]; then
-    chmod --reference="$path" "$tmp" 2>/dev/null || true
-  else
-    chmod 0600 "$tmp"
+    if ! config_backup "$path" >/dev/null; then
+      echo "_config_write_atomic_locked: backup failed for $path" >&2
+      return 1
+    fi
   fi
 
-  # Best-effort fsync (not all OSes / all shells support sync -f).
+  # Pretty-print on write so settings.json stays human-readable.
+  if ! printf '%s' "$content" | jq '.' >"$tmp"; then
+    echo "_config_write_atomic_locked: failed to write tmp file $tmp" >&2
+    rm -f -- "$tmp"
+    return 1
+  fi
+
+  if [[ -f "$path" ]]; then
+    config_copy_mode "$path" "$tmp"
+  else
+    chmod 0600 "$tmp" 2>/dev/null || true
+  fi
+
+  # Best-effort fsync. Not every OS supports `sync <file>`; failures are tolerable.
   if command -v sync >/dev/null 2>&1; then
     sync "$tmp" 2>/dev/null || true
   fi
 
-  mv -f -- "$tmp" "$path"
+  if ! mv -f -- "$tmp" "$path"; then
+    echo "_config_write_atomic_locked: rename $tmp → $path failed" >&2
+    rm -f -- "$tmp"
+    return 1
+  fi
 }
 
 # config_with_lock <path> <command...>
@@ -222,14 +263,22 @@ config_with_lock() {
 # config_load_effective
 # Returns a JSON object summarizing what's visible in both scopes.
 # v2.0: no merging — just side-by-side display.
+# Returns 1 if either scope's file exists but is unreadable/malformed so callers
+# (e.g., `juggernaut doctor`) can surface a real error instead of silent empties.
 config_load_effective() {
   local user_path project_path user_json project_json
   user_path="$(config_user_settings_path)"
   project_path="$(config_project_settings_path "$PWD" 2>/dev/null || true)"
 
-  user_json="$(config_read "$user_path")"
+  if ! user_json="$(config_read "$user_path")"; then
+    echo "config_load_effective: failed to read user settings at $user_path" >&2
+    return 1
+  fi
   if [[ -n "$project_path" ]]; then
-    project_json="$(config_read "$project_path")"
+    if ! project_json="$(config_read "$project_path")"; then
+      echo "config_load_effective: failed to read project settings at $project_path" >&2
+      return 1
+    fi
   else
     project_json="null"
   fi

--- a/lib/config_manager.sh
+++ b/lib/config_manager.sh
@@ -69,13 +69,13 @@ config_read() {
 config_has_juggernaut_block() {
   local json="$1"
   local managed
-  managed="$(echo "$json" | jq -r '.juggernaut.meta.managedBy // ""')"
+  managed="$(printf '%s' "$json" | jq -r '.juggernaut.meta.managedBy // ""')"
   [[ "$managed" == "juggernaut" ]]
 }
 
 config_get_juggernaut_block() {
   local json="$1"
-  echo "$json" | jq '.juggernaut // null'
+  printf '%s' "$json" | jq '.juggernaut // null'
 }
 
 # config_merge_juggernaut_block <existing_json> <new_block> <native_keys>
@@ -109,13 +109,13 @@ config_merge_juggernaut_block() {
 # User's other top-level keys (permissions, hooks, theme, ...) are preserved.
 config_remove_juggernaut_block() {
   local existing="$1"
-  jq '
+  printf '%s' "$existing" | jq '
     del(.juggernaut)
     | del(.env)
     | del(.model)
     | del(.modelOverrides)
     | del(.availableModels)
-  ' <<<"$existing"
+  '
 }
 
 # config_backup <path>
@@ -245,10 +245,22 @@ config_with_lock() {
     return "$rc"
   fi
 
-  # Fallback: mkdir-based mutex (POSIX, atomic on all filesystems we care about).
+  # Fallback: mkdir-based mutex (POSIX-atomic: mkdir succeeds only for one caller).
+  # Stale-lock recovery: if the lockdir is older than 30s, assume the prior holder
+  # died without cleanup and remove it. The 30s window is generous enough to cover
+  # any real write, but short enough not to block a manual re-run after a crash.
   local lockdir="${path}.lockdir"
   local waited=0
   until mkdir -- "$lockdir" 2>/dev/null; do
+    # Check for stale lock before deciding to wait or fail.
+    if [[ -d "$lockdir" ]]; then
+      local lockage
+      lockage="$(( $(date +%s) - $(stat -c '%Y' "$lockdir" 2>/dev/null || stat -f '%m' "$lockdir" 2>/dev/null || echo "0") ))"
+      if (( lockage > 30 )); then
+        rmdir -- "$lockdir" 2>/dev/null || true
+        continue
+      fi
+    fi
     if (( waited >= 10 )); then
       echo "config_with_lock: could not acquire mkdir lock on $lockdir within 10s" >&2
       return 1

--- a/lib/config_manager.sh
+++ b/lib/config_manager.sh
@@ -254,8 +254,10 @@ config_with_lock() {
   until mkdir -- "$lockdir" 2>/dev/null; do
     # Check for stale lock before deciding to wait or fail.
     if [[ -d "$lockdir" ]]; then
-      local lockage
-      lockage="$(( $(date +%s) - $(stat -c '%Y' "$lockdir" 2>/dev/null || stat -f '%m' "$lockdir" 2>/dev/null || echo "0") ))"
+      local now mtime lockage
+      now="$(date +%s)"
+      mtime="$(stat -c '%Y' "$lockdir" 2>/dev/null || stat -f '%m' "$lockdir" 2>/dev/null || echo "0")"
+      lockage=$(( now - mtime ))
       if (( lockage > 30 )); then
         rmdir -- "$lockdir" 2>/dev/null || true
         continue

--- a/lib/schema.ps1
+++ b/lib/schema.ps1
@@ -163,7 +163,10 @@ function Test-JuggernautBlock {
     }
 
     if ($errors.Count -gt 0) {
-        Write-Error ("Schema validation failed:`n  - " + ($errors -join "`n  - "))
+        # Surface errors via Write-Warning so callers that use ` | Should -BeFalse`
+        # still observe a clean $false. Use -ErrorVariable or check the return
+        # directly when you need structured error access.
+        Write-Warning ("Schema validation failed:`n  - " + ($errors -join "`n  - "))
         return $false
     }
     return $true

--- a/lib/schema.ps1
+++ b/lib/schema.ps1
@@ -119,10 +119,20 @@ function Test-JuggernautBlock {
     [CmdletBinding()]
     param([Parameter(Mandatory)]$Block)
 
+    # Works for hashtable / [ordered]@{} (from Read-Settings) AND PSCustomObject
+    # (from ConvertFrom-Json without the converter).
+    $hasField = {
+        param($obj, $name)
+        if ($obj -is [hashtable] -or $obj -is [System.Collections.Specialized.OrderedDictionary]) {
+            return $obj.Contains($name)
+        }
+        return [bool]($obj.PSObject.Properties.Name -contains $name)
+    }
+
     $errors = New-Object System.Collections.Generic.List[string]
     $required = @('schemaVersion','provider','useMantle','model','context','auth','modelOverrides','effortLevel','env','meta')
     foreach ($f in $required) {
-        if (-not $Block.PSObject.Properties[$f] -and -not ($Block -is [hashtable] -and $Block.ContainsKey($f))) {
+        if (-not (& $hasField $Block $f)) {
             $errors.Add("missing required field: $f")
         }
     }

--- a/lib/schema.ps1
+++ b/lib/schema.ps1
@@ -1,0 +1,174 @@
+# lib/schema.ps1 — Juggernaut v2 block schema for PowerShell. Mirrors lib/schema.sh.
+# Uses native ConvertFrom-Json / ConvertTo-Json. PowerShell 5.1+ compatible.
+
+$Script:JuggernautSchemaVersion = 1
+
+function Get-SchemaDefaultRegion { 'us-east-1' }
+
+function Get-SchemaBedrockConfig {
+    param([string]$Path = "$PSScriptRoot/../bedrock-config.json")
+    if (-not (Test-Path $Path)) {
+        throw "bedrock-config.json not found at $Path"
+    }
+    Get-Content -Path $Path -Raw -Encoding utf8 | ConvertFrom-Json
+}
+
+function Get-SchemaSupportedRegions {
+    param([string]$BedrockConfigPath)
+    $config = if ($BedrockConfigPath) { Get-SchemaBedrockConfig -Path $BedrockConfigPath } else { Get-SchemaBedrockConfig }
+    return $config.regions
+}
+
+function Test-SchemaSupportedRegion {
+    param(
+        [Parameter(Mandatory)][string]$Region,
+        [string]$BedrockConfigPath
+    )
+    $regions = if ($BedrockConfigPath) { Get-SchemaSupportedRegions -BedrockConfigPath $BedrockConfigPath } else { Get-SchemaSupportedRegions }
+    return $regions -contains $Region
+}
+
+function New-JuggernautBlock {
+    [CmdletBinding()]
+    param(
+        [string]$Provider = 'bedrock',
+        [bool]$UseMantle = $true,
+        [string]$MantleBaseUrl = '',
+        [string]$Model = 'global.anthropic.claude-sonnet-4-6',
+        [string]$OpusModel = 'global.anthropic.claude-opus-4-7[1m]',
+        [string]$SonnetModel = 'global.anthropic.claude-sonnet-4-6',
+        [string]$HaikuModel = 'global.anthropic.claude-haiku-4-5-20251001-v1:0',
+        [string]$SubagentModel = '',
+        [bool]$Use1MContext = $true,
+        [bool]$OpusPlan = $false,
+        [ValidateSet('low','medium','high','xhigh','max')][string]$EffortLevel = 'xhigh',
+        [ValidateSet('iam','api-key')][string]$AuthMode = 'iam',
+        [ValidateSet('profile','keychain')][string]$Storage = 'keychain',
+        [string]$Region = '',
+        [ValidateSet('both','settings-only','shell-only')][string]$ShellFallbackMode = 'both',
+        [ValidateSet('user','project')][string]$Scope = 'user',
+        [string]$Version = '2.0.0',
+        [string]$BedrockConfigPath
+    )
+
+    if ([string]::IsNullOrEmpty($Region)) { $Region = Get-SchemaDefaultRegion }
+    if ([string]::IsNullOrEmpty($SubagentModel)) { $SubagentModel = $HaikuModel }
+
+    $bedrock = if ($BedrockConfigPath) { Get-SchemaBedrockConfig -Path $BedrockConfigPath } else { Get-SchemaBedrockConfig }
+
+    $env = [ordered]@{}
+    foreach ($prop in $bedrock.environment.PSObject.Properties) {
+        $env[$prop.Name] = $prop.Value
+    }
+    $env['AWS_REGION']                     = $Region
+    $env['ANTHROPIC_MODEL']                = if ($OpusPlan) { 'opusplan' } else { $Model }
+    $env['ANTHROPIC_DEFAULT_OPUS_MODEL']   = $OpusModel
+    $env['ANTHROPIC_DEFAULT_SONNET_MODEL'] = $SonnetModel
+    $env['ANTHROPIC_DEFAULT_HAIKU_MODEL']  = $HaikuModel
+    $env['CLAUDE_CODE_SUBAGENT_MODEL']     = $SubagentModel
+    $env['CLAUDE_CODE_EFFORT_LEVEL']       = $EffortLevel
+
+    if ($UseMantle) {
+        $env['CLAUDE_CODE_USE_MANTLE'] = '1'
+        if (-not [string]::IsNullOrEmpty($MantleBaseUrl)) {
+            $env['ANTHROPIC_BEDROCK_MANTLE_BASE_URL'] = $MantleBaseUrl
+        }
+    } else {
+        $env.Remove('CLAUDE_CODE_USE_MANTLE') | Out-Null
+        $env.Remove('ANTHROPIC_BEDROCK_MANTLE_BASE_URL') | Out-Null
+    }
+
+    $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+    [ordered]@{
+        schemaVersion  = $Script:JuggernautSchemaVersion
+        provider       = $Provider
+        useMantle      = $UseMantle
+        mantle         = [ordered]@{
+            baseUrl = if ([string]::IsNullOrEmpty($MantleBaseUrl)) { $null } else { $MantleBaseUrl }
+        }
+        model          = $Model
+        context        = [ordered]@{ maxContextTokens = 1000000; use1MContext = $Use1MContext }
+        auth           = [ordered]@{ mode = $AuthMode; region = $Region; storage = $Storage }
+        modelOverrides = [ordered]@{
+            opus     = $OpusModel
+            sonnet   = $SonnetModel
+            haiku    = $HaikuModel
+            subagent = $SubagentModel
+        }
+        effortLevel    = $EffortLevel
+        opusplan       = $OpusPlan
+        shellFallback  = [ordered]@{
+            enabled              = ($ShellFallbackMode -ne 'settings-only')
+            mode                 = $ShellFallbackMode
+            lastWrittenProfiles  = @()
+        }
+        env            = $env
+        legacyEnv      = $null
+        meta           = [ordered]@{
+            managedBy        = 'juggernaut'
+            version          = $Version
+            scope            = $Scope
+            lastUpdated      = $now
+            detectedClients  = @()
+        }
+    }
+}
+
+function Test-JuggernautBlock {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)]$Block)
+
+    $errors = New-Object System.Collections.Generic.List[string]
+    $required = @('schemaVersion','provider','useMantle','model','context','auth','modelOverrides','effortLevel','env','meta')
+    foreach ($f in $required) {
+        if (-not $Block.PSObject.Properties[$f] -and -not ($Block -is [hashtable] -and $Block.ContainsKey($f))) {
+            $errors.Add("missing required field: $f")
+        }
+    }
+
+    $authMode = $Block.auth.mode
+    if ($authMode -notin @('iam','api-key')) { $errors.Add("auth.mode must be 'iam' or 'api-key' (got: '$authMode')") }
+
+    $storage = $Block.auth.storage
+    if ($storage -notin @('profile','keychain')) { $errors.Add("auth.storage must be 'profile' or 'keychain' (got: '$storage')") }
+
+    $effort = $Block.effortLevel
+    if ($effort -notin @('low','medium','high','xhigh','max')) { $errors.Add("effortLevel must be one of low|medium|high|xhigh|max (got: '$effort')") }
+
+    $shellMode = $Block.shellFallback.mode
+    if ($shellMode -and $shellMode -notin @('both','settings-only','shell-only')) {
+        $errors.Add("shellFallback.mode must be one of both|settings-only|shell-only (got: '$shellMode')")
+    }
+
+    if ($Block.meta.managedBy -ne 'juggernaut') {
+        $errors.Add("meta.managedBy must be 'juggernaut' (got: '$($Block.meta.managedBy)')")
+    }
+
+    $region = $Block.auth.region
+    if ($region -and -not (Test-SchemaSupportedRegion -Region $region)) {
+        $errors.Add("auth.region '$region' is not in bedrock-config.json .regions")
+    }
+
+    if ($errors.Count -gt 0) {
+        Write-Error ("Schema validation failed:`n  - " + ($errors -join "`n  - "))
+        return $false
+    }
+    return $true
+}
+
+function Get-NativeKeysFromJuggernautBlock {
+    param([Parameter(Mandatory)]$Block)
+    [ordered]@{
+        env            = $Block.env
+        model          = $Block.model
+        modelOverrides = [ordered]@{
+            opus     = $Block.modelOverrides.opus
+            sonnet   = $Block.modelOverrides.sonnet
+            haiku    = $Block.modelOverrides.haiku
+            subagent = $Block.modelOverrides.subagent
+        }
+    }
+}
+
+function Get-JuggernautNativeKeyNames { 'env','model','modelOverrides','availableModels' }

--- a/lib/schema.ps1
+++ b/lib/schema.ps1
@@ -146,7 +146,9 @@ function Test-JuggernautBlock {
     }
 
     $region = $Block.auth.region
-    if ($region -and -not (Test-SchemaSupportedRegion -Region $region)) {
+    if ([string]::IsNullOrEmpty($region)) {
+        $errors.Add("auth.region is required")
+    } elseif (-not (Test-SchemaSupportedRegion -Region $region)) {
         $errors.Add("auth.region '$region' is not in bedrock-config.json .regions")
     }
 

--- a/lib/schema.sh
+++ b/lib/schema.sh
@@ -187,10 +187,12 @@ schema_validate() {
     errors+="  - meta.managedBy must be 'juggernaut' (got: '$managed_by')"$'\n'
   fi
 
-  # Region must be in supported list
+  # Region is required and must be in supported list
   local region
   region="$(echo "$block" | jq -r '.auth.region // ""')"
-  if [[ -n "$region" ]] && ! schema_is_supported_region "$region"; then
+  if [[ -z "$region" ]]; then
+    errors+="  - auth.region is required"$'\n'
+  elif ! schema_is_supported_region "$region"; then
     errors+="  - auth.region '$region' is not in bedrock-config.json .regions"$'\n'
   fi
 

--- a/lib/schema.sh
+++ b/lib/schema.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# lib/schema.sh — Juggernaut v2 block schema: construction, validation, derivation of native settings.json keys.
+# Pure functions. Requires: bash 4+, jq.
+
+set -euo pipefail
+
+JUGGERNAUT_SCHEMA_VERSION=1
+
+schema_default_region() { echo "us-east-1"; }
+
+schema_supported_regions() {
+  jq -r '.regions[]' "${BEDROCK_CONFIG_PATH:-bedrock-config.json}"
+}
+
+schema_is_supported_region() {
+  local region="$1"
+  schema_supported_regions | grep -Fxq -- "$region"
+}
+
+schema_default_env_from_bedrock_config() {
+  jq -c '.environment' "${BEDROCK_CONFIG_PATH:-bedrock-config.json}"
+}
+
+# schema_new_juggernaut_block
+# Builds a fresh juggernaut block from flags/detected state.
+# Inputs via env vars (caller sets): J_PROVIDER, J_USE_MANTLE, J_MANTLE_BASE_URL,
+#   J_MODEL, J_OPUS_MODEL, J_SONNET_MODEL, J_HAIKU_MODEL, J_SUBAGENT_MODEL,
+#   J_USE_1M, J_OPUSPLAN, J_EFFORT, J_AUTH_MODE, J_STORAGE, J_REGION,
+#   J_SHELL_FALLBACK_MODE ("both"|"settings-only"|"shell-only"), J_SCOPE ("user"|"project")
+# Outputs: JSON object (juggernaut block) to stdout.
+schema_new_juggernaut_block() {
+  local now
+  now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+  local bedrock_env
+  bedrock_env="$(schema_default_env_from_bedrock_config)"
+
+  local provider="${J_PROVIDER:-bedrock}"
+  local use_mantle="${J_USE_MANTLE:-true}"
+  local mantle_base_url="${J_MANTLE_BASE_URL:-}"
+  local model="${J_MODEL:-global.anthropic.claude-sonnet-4-6}"
+  local opus_model="${J_OPUS_MODEL:-global.anthropic.claude-opus-4-7[1m]}"
+  local sonnet_model="${J_SONNET_MODEL:-global.anthropic.claude-sonnet-4-6}"
+  local haiku_model="${J_HAIKU_MODEL:-global.anthropic.claude-haiku-4-5-20251001-v1:0}"
+  local subagent_model="${J_SUBAGENT_MODEL:-$haiku_model}"
+  local use_1m="${J_USE_1M:-true}"
+  local opusplan="${J_OPUSPLAN:-false}"
+  local effort="${J_EFFORT:-xhigh}"
+  local auth_mode="${J_AUTH_MODE:-iam}"
+  local storage="${J_STORAGE:-keychain}"
+  local region="${J_REGION:-$(schema_default_region)}"
+  local shell_mode="${J_SHELL_FALLBACK_MODE:-both}"
+  local scope="${J_SCOPE:-user}"
+  local version="${J_VERSION:-2.0.0}"
+
+  # Assemble env map: start from bedrock-config.json defaults, then overlay.
+  local env_json
+  env_json="$(jq -n \
+    --argjson base "$bedrock_env" \
+    --arg region "$region" \
+    --arg model "$model" \
+    --arg opus "$opus_model" \
+    --arg sonnet "$sonnet_model" \
+    --arg haiku "$haiku_model" \
+    --arg subagent "$subagent_model" \
+    --arg effort "$effort" \
+    --argjson opusplan "$opusplan" \
+    --argjson use_mantle "$use_mantle" \
+    --arg mantle_base_url "$mantle_base_url" \
+    '
+    $base
+    + { AWS_REGION: $region }
+    + { ANTHROPIC_MODEL: (if $opusplan then "opusplan" else $model end) }
+    + { ANTHROPIC_DEFAULT_OPUS_MODEL: $opus,
+        ANTHROPIC_DEFAULT_SONNET_MODEL: $sonnet,
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: $haiku,
+        CLAUDE_CODE_SUBAGENT_MODEL: $subagent,
+        CLAUDE_CODE_EFFORT_LEVEL: $effort }
+    + (if $use_mantle then { CLAUDE_CODE_USE_MANTLE: "1" } else {} end)
+    + (if $use_mantle and ($mantle_base_url | length > 0) then
+         { ANTHROPIC_BEDROCK_MANTLE_BASE_URL: $mantle_base_url }
+       else {} end)
+    ')"
+
+  jq -n \
+    --argjson schemaVersion "$JUGGERNAUT_SCHEMA_VERSION" \
+    --arg provider "$provider" \
+    --argjson useMantle "$use_mantle" \
+    --arg mantleBaseUrl "$mantle_base_url" \
+    --arg model "$model" \
+    --arg opusModel "$opus_model" \
+    --arg sonnetModel "$sonnet_model" \
+    --arg haikuModel "$haiku_model" \
+    --arg subagentModel "$subagent_model" \
+    --argjson use1M "$use_1m" \
+    --argjson opusplan "$opusplan" \
+    --arg effort "$effort" \
+    --arg authMode "$auth_mode" \
+    --arg storage "$storage" \
+    --arg region "$region" \
+    --arg shellMode "$shell_mode" \
+    --arg scope "$scope" \
+    --arg version "$version" \
+    --arg now "$now" \
+    --argjson env "$env_json" \
+    '
+    {
+      schemaVersion: $schemaVersion,
+      provider: $provider,
+      useMantle: $useMantle,
+      mantle: { baseUrl: (if $mantleBaseUrl | length > 0 then $mantleBaseUrl else null end) },
+      model: $model,
+      context: { maxContextTokens: 1000000, use1MContext: $use1M },
+      auth: { mode: $authMode, region: $region, storage: $storage },
+      modelOverrides: {
+        opus: $opusModel,
+        sonnet: $sonnetModel,
+        haiku: $haikuModel,
+        subagent: $subagentModel
+      },
+      effortLevel: $effort,
+      opusplan: $opusplan,
+      shellFallback: { enabled: ($shellMode != "settings-only"), mode: $shellMode, lastWrittenProfiles: [] },
+      env: $env,
+      legacyEnv: null,
+      meta: {
+        managedBy: "juggernaut",
+        version: $version,
+        scope: $scope,
+        lastUpdated: $now,
+        detectedClients: []
+      }
+    }
+    '
+}
+
+# schema_validate <block_json>
+# Exits 0 if block is valid, 1 with error to stderr if not.
+schema_validate() {
+  local block="$1"
+  local errors=""
+
+  # Required top-level fields
+  local required=(schemaVersion provider useMantle model context auth modelOverrides effortLevel env meta)
+  for field in "${required[@]}"; do
+    if ! echo "$block" | jq -e "has(\"$field\")" >/dev/null; then
+      errors+="  - missing required field: $field"$'\n'
+    fi
+  done
+
+  # Enum: auth.mode
+  local auth_mode
+  auth_mode="$(echo "$block" | jq -r '.auth.mode // ""')"
+  case "$auth_mode" in
+    iam|api-key) ;;
+    *) errors+="  - auth.mode must be 'iam' or 'api-key' (got: '$auth_mode')"$'\n' ;;
+  esac
+
+  # Enum: auth.storage
+  local storage
+  storage="$(echo "$block" | jq -r '.auth.storage // ""')"
+  case "$storage" in
+    profile|keychain) ;;
+    *) errors+="  - auth.storage must be 'profile' or 'keychain' (got: '$storage')"$'\n' ;;
+  esac
+
+  # Enum: effortLevel
+  local effort
+  effort="$(echo "$block" | jq -r '.effortLevel // ""')"
+  case "$effort" in
+    low|medium|high|xhigh|max) ;;
+    *) errors+="  - effortLevel must be one of low|medium|high|xhigh|max (got: '$effort')"$'\n' ;;
+  esac
+
+  # Enum: shellFallback.mode
+  local shell_mode
+  shell_mode="$(echo "$block" | jq -r '.shellFallback.mode // "both"')"
+  case "$shell_mode" in
+    both|settings-only|shell-only) ;;
+    *) errors+="  - shellFallback.mode must be one of both|settings-only|shell-only (got: '$shell_mode')"$'\n' ;;
+  esac
+
+  # meta.managedBy must be "juggernaut"
+  local managed_by
+  managed_by="$(echo "$block" | jq -r '.meta.managedBy // ""')"
+  if [[ "$managed_by" != "juggernaut" ]]; then
+    errors+="  - meta.managedBy must be 'juggernaut' (got: '$managed_by')"$'\n'
+  fi
+
+  # Region must be in supported list
+  local region
+  region="$(echo "$block" | jq -r '.auth.region // ""')"
+  if [[ -n "$region" ]] && ! schema_is_supported_region "$region"; then
+    errors+="  - auth.region '$region' is not in bedrock-config.json .regions"$'\n'
+  fi
+
+  if [[ -n "$errors" ]]; then
+    printf 'Schema validation failed:\n%s' "$errors" >&2
+    return 1
+  fi
+  return 0
+}
+
+# schema_derive_native_keys <block_json>
+# Returns a JSON object containing the native settings.json keys Claude Code reads.
+# Caller merges this into the top-level settings.json object alongside the juggernaut block.
+schema_derive_native_keys() {
+  local block="$1"
+  jq '
+    {
+      env: .env,
+      model: .model,
+      modelOverrides: {
+        opus: .modelOverrides.opus,
+        sonnet: .modelOverrides.sonnet,
+        haiku: .modelOverrides.haiku,
+        subagent: .modelOverrides.subagent
+      }
+    }
+  ' <<<"$block"
+}
+
+# schema_native_key_names
+# Lists the top-level keys in settings.json that Juggernaut owns (derived from the block).
+# Used during uninstall to scrub only what we wrote.
+schema_native_key_names() {
+  printf '%s\n' env model modelOverrides availableModels
+}

--- a/lib/schema.sh
+++ b/lib/schema.sh
@@ -6,6 +6,18 @@ set -euo pipefail
 
 JUGGERNAUT_SCHEMA_VERSION=1
 
+# Fail fast with a readable error if jq is not installed. All functions in
+# this module pipe through jq; silent empty output downstream would be worse
+# than dying loudly here.
+schema_require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "juggernaut: jq is required but not found on PATH." >&2
+    echo "  Install: apt-get install jq  |  brew install jq  |  winget install jqlang.jq" >&2
+    return 1
+  fi
+}
+schema_require_jq || exit 1
+
 schema_default_region() { echo "us-east-1"; }
 
 schema_supported_regions() {

--- a/setup
+++ b/setup
@@ -41,6 +41,29 @@ detect_shell() {
 # Main
 #───────────────────────────────────────────────────────────────────────────────
 
+# Juggernaut v2 feature flag (hidden; experimental).
+# Accept --v2 on the command line or JUGGERNAUT_USE_V2=1 in the environment.
+# This flag gates the in-progress settings.json pivot. Today it only emits a
+# notice — all v1 behavior is unchanged whether the flag is set or not.
+# Subsequent phases will wire real v2 behavior behind this same flag.
+JUGGERNAUT_V2_ACTIVE=0
+if [[ "${JUGGERNAUT_USE_V2:-0}" == "1" ]]; then
+    JUGGERNAUT_V2_ACTIVE=1
+fi
+FILTERED_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--v2" ]]; then
+        JUGGERNAUT_V2_ACTIVE=1
+        continue
+    fi
+    FILTERED_ARGS+=("$arg")
+done
+set -- "${FILTERED_ARGS[@]}"
+if [[ "$JUGGERNAUT_V2_ACTIVE" == "1" ]]; then
+    echo "[v2] Juggernaut v2 mode enabled (experimental). Phase 1 foundations only — continuing with v1 apply flow." >&2
+    export JUGGERNAUT_USE_V2=1
+fi
+
 # Pass through version/help flags
 for arg in "$@"; do
     [[ "$arg" == "--version" || "$arg" == "-v" ]] && {

--- a/setup
+++ b/setup
@@ -53,7 +53,7 @@ for arg in "$@"; do
 done
 set -- "${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}"
 if [[ "$JUGGERNAUT_V2_ACTIVE" == "1" ]]; then
-    echo "[v2] Juggernaut v2.0 enabled — dormant in this phase. Continuing with v1 apply flow." >&2
+    echo "[v2] Juggernaut v2.0 enabled — currently dormant, v1 is still active." >&2
     export JUGGERNAUT_USE_V2=1
 fi
 

--- a/setup
+++ b/setup
@@ -41,26 +41,19 @@ detect_shell() {
 # Main
 #───────────────────────────────────────────────────────────────────────────────
 
-# Juggernaut v2 feature flag (hidden; experimental).
-# Accept --v2 on the command line or JUGGERNAUT_USE_V2=1 in the environment.
-# This flag gates the in-progress settings.json pivot. Today it only emits a
-# notice — all v1 behavior is unchanged whether the flag is set or not.
-# Subsequent phases will wire real v2 behavior behind this same flag.
-JUGGERNAUT_V2_ACTIVE=0
-if [[ "${JUGGERNAUT_USE_V2:-0}" == "1" ]]; then
-    JUGGERNAUT_V2_ACTIVE=1
-fi
+# v2 feature flag (hidden; dormant in Phase 1). Filters --v2 out of argv.
+JUGGERNAUT_V2_ACTIVE="${JUGGERNAUT_USE_V2:-0}"
 FILTERED_ARGS=()
 for arg in "$@"; do
     if [[ "$arg" == "--v2" ]]; then
         JUGGERNAUT_V2_ACTIVE=1
-        continue
+    else
+        FILTERED_ARGS+=("$arg")
     fi
-    FILTERED_ARGS+=("$arg")
 done
-set -- "${FILTERED_ARGS[@]}"
+set -- "${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}"
 if [[ "$JUGGERNAUT_V2_ACTIVE" == "1" ]]; then
-    echo "[v2] Juggernaut v2 mode enabled (experimental). Phase 1 foundations only — continuing with v1 apply flow." >&2
+    echo "[v2] Juggernaut v2.0 enabled — dormant in this phase. Continuing with v1 apply flow." >&2
     export JUGGERNAUT_USE_V2=1
 fi
 

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -29,8 +29,17 @@ param(
     [switch]$DryRun,
     [switch]$Help,
     [Alias("v")]
-    [switch]$Version
+    [switch]$Version,
+    # Hidden v2 feature flag. Accepted so users/CI can opt into the v2 codepath
+    # once it ships. Today this is a no-op beyond recording the intent — v1
+    # apply flow continues unchanged.
+    [switch]$V2
 )
+
+if ($V2 -or $env:JUGGERNAUT_USE_V2 -eq '1') {
+    $env:JUGGERNAUT_USE_V2 = '1'
+    Write-Host "[v2] Juggernaut v2 mode enabled (experimental). Phase 1 foundations only — continuing with v1 apply flow." -ForegroundColor DarkYellow
+}
 
 # Track if parameters were explicitly provided by the user
 $AuthExplicit = $PSBoundParameters.ContainsKey('Auth')

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -30,15 +30,13 @@ param(
     [switch]$Help,
     [Alias("v")]
     [switch]$Version,
-    # Hidden v2 feature flag. Accepted so users/CI can opt into the v2 codepath
-    # once it ships. Today this is a no-op beyond recording the intent — v1
-    # apply flow continues unchanged.
+    # Hidden v2 feature flag; dormant in Phase 1.
     [switch]$V2
 )
 
 if ($V2 -or $env:JUGGERNAUT_USE_V2 -eq '1') {
     $env:JUGGERNAUT_USE_V2 = '1'
-    Write-Host "[v2] Juggernaut v2 mode enabled (experimental). Phase 1 foundations only — continuing with v1 apply flow." -ForegroundColor DarkYellow
+    Write-Host "[v2] Juggernaut v2.0 enabled - dormant in this phase. Continuing with v1 apply flow." -ForegroundColor DarkYellow
 }
 
 # Track if parameters were explicitly provided by the user

--- a/setup-claude-bedrock.ps1
+++ b/setup-claude-bedrock.ps1
@@ -30,13 +30,12 @@ param(
     [switch]$Help,
     [Alias("v")]
     [switch]$Version,
-    # Hidden v2 feature flag; dormant in Phase 1.
     [switch]$V2
 )
 
 if ($V2 -or $env:JUGGERNAUT_USE_V2 -eq '1') {
     $env:JUGGERNAUT_USE_V2 = '1'
-    Write-Host "[v2] Juggernaut v2.0 enabled - dormant in this phase. Continuing with v1 apply flow." -ForegroundColor DarkYellow
+    Write-Host "[v2] Juggernaut v2.0 enabled — currently dormant, v1 is still active." -ForegroundColor DarkYellow
 }
 
 # Track if parameters were explicitly provided by the user

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -917,9 +917,7 @@ parse_arguments() {
                 SKIP_PREFLIGHT=true
                 ;;
             --v2)
-                # Hidden v2 feature flag. Accepted in v1.7.6+ so users and CI
-                # can opt into the v2 codepath once it ships. Today it's a no-op
-                # beyond acknowledging the flag — v1 apply flow continues below.
+                # Hidden v2 feature flag; dormant in Phase 1.
                 export JUGGERNAUT_USE_V2=1
                 ;;
             --region=*)

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -903,6 +903,7 @@ USE_OPUSPLAN=false
 OPUSPLAN_EXPLICIT=false
 EFFORT_LEVEL=""
 EFFORT_EXPLICIT=false
+JUGGERNAUT_V2_DIRECT=0
 
 parse_arguments() {
     for arg in "$@"; do
@@ -917,8 +918,8 @@ parse_arguments() {
                 SKIP_PREFLIGHT=true
                 ;;
             --v2)
-                # Hidden v2 feature flag; dormant in Phase 1.
                 export JUGGERNAUT_USE_V2=1
+                JUGGERNAUT_V2_DIRECT=1
                 ;;
             --region=*)
                 AWS_REGION="${arg#--region=}"
@@ -1290,6 +1291,12 @@ show_next_steps() {
 
 main() {
     parse_arguments "$@"
+
+    # Only print the v2 banner when --v2 was passed directly to this script.
+    # When invoked via `setup --v2`, setup already printed it before exec'ing us.
+    if [[ "${JUGGERNAUT_V2_DIRECT:-0}" == "1" ]]; then
+        echo "[v2] Juggernaut v2.0 enabled — currently dormant, v1 is still active." >&2
+    fi
 
     # Detect existing auth mode if user didn't explicitly specify
     if [[ "$AUTH_MODE_EXPLICIT" != true ]]; then

--- a/setup-claude-bedrock.sh
+++ b/setup-claude-bedrock.sh
@@ -916,6 +916,12 @@ parse_arguments() {
             --skip-preflight)
                 SKIP_PREFLIGHT=true
                 ;;
+            --v2)
+                # Hidden v2 feature flag. Accepted in v1.7.6+ so users and CI
+                # can opt into the v2 codepath once it ships. Today it's a no-op
+                # beyond acknowledging the flag — v1 apply flow continues below.
+                export JUGGERNAUT_USE_V2=1
+                ;;
             --region=*)
                 AWS_REGION="${arg#--region=}"
                 ;;

--- a/tests/v2/ConfigManager.Tests.ps1
+++ b/tests/v2/ConfigManager.Tests.ps1
@@ -78,31 +78,12 @@ Describe 'Remove leaves unrelated user keys' {
     }
 }
 
-Describe 'Write-SettingsAtomic rejects invalid JSON' {
-    BeforeEach {
-        $script:tmpDir = Join-Path ([IO.Path]::GetTempPath()) ("juggernaut-" + [Guid]::NewGuid().ToString('N'))
-        New-Item -ItemType Directory -Path $script:tmpDir -Force | Out-Null
-        $script:target = Join-Path $script:tmpDir 'settings.json'
-    }
-    AfterEach {
-        Remove-Item -Path $script:tmpDir -Recurse -Force -ErrorAction SilentlyContinue
-    }
-
-    It 'does not create the target file when content cannot serialize to JSON' {
-        # Force a non-serializable object.
-        $bad = [ScriptBlock]::Create('whatever')
-        { Write-SettingsAtomic -Path $script:target -Content $bad } | Should -Throw
-        Test-Path $script:target | Should -BeFalse
-    }
-}
-
-Describe 'Invoke-WithSettingsLock' {
-    It 'survives an abandoned-mutex exception' {
+Describe 'Invoke-WithSettingsLock — happy path' {
+    It 'runs the action and releases the mutex' {
         $p = Join-Path ([IO.Path]::GetTempPath()) ("juggernaut-lock-" + [Guid]::NewGuid().ToString('N'))
         $hit = $false
         Invoke-WithSettingsLock -Path $p -Action { $script:hit = $true }
-        # No real way to force AbandonedMutexException from a test in-process; we at least verify
-        # the happy path completes without throwing and the action runs.
+        # Immediately re-acquire — would block if the first call didn't release.
         { Invoke-WithSettingsLock -Path $p -Action { 1 + 1 } } | Should -Not -Throw
     }
 }

--- a/tests/v2/ConfigManager.Tests.ps1
+++ b/tests/v2/ConfigManager.Tests.ps1
@@ -1,0 +1,123 @@
+# tests/v2/ConfigManager.Tests.ps1 — Pester 5.x tests for lib/config_manager.ps1.
+# Mirrors tests/v2/test_config_manager.sh.
+
+BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    . (Join-Path $repoRoot 'lib/schema.ps1')
+    . (Join-Path $repoRoot 'lib/config_manager.ps1')
+    $script:BedrockConfigPath = Join-Path $repoRoot 'bedrock-config.json'
+}
+
+Describe 'Write → Read round trip' {
+    BeforeEach {
+        $script:tmpDir = Join-Path ([IO.Path]::GetTempPath()) ("juggernaut-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:tmpDir -Force | Out-Null
+        $script:target = Join-Path $script:tmpDir 'settings.json'
+    }
+    AfterEach {
+        Remove-Item -Path $script:tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'fresh write then read preserves juggernaut.meta.managedBy' {
+        $block  = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+        $native = Get-NativeKeysFromJuggernautBlock -Block $block
+        $existing = Read-Settings -Path $script:target
+        $merged = Merge-JuggernautBlock -Existing $existing -NewBlock $block -NativeKeys $native
+        Write-SettingsAtomic -Path $script:target -Content $merged
+
+        $readBack = Read-Settings -Path $script:target
+        $readBack['juggernaut']['meta']['managedBy'] | Should -Be 'juggernaut'
+        $readBack['env']['CLAUDE_CODE_USE_BEDROCK']  | Should -Be '1'
+        (Test-HasJuggernautBlock -Settings $readBack) | Should -BeTrue
+    }
+}
+
+Describe 'Merge preserves unrelated user keys' {
+    BeforeEach {
+        $script:tmpDir = Join-Path ([IO.Path]::GetTempPath()) ("juggernaut-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:tmpDir -Force | Out-Null
+        $script:target = Join-Path $script:tmpDir 'settings.json'
+    }
+    AfterEach {
+        Remove-Item -Path $script:tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'theme and permissions survive an apply' {
+        $userContent = '{"theme":"dark","permissions":{"allow":["npm"]}}'
+        Set-Content -Path $script:target -Value $userContent -NoNewline -Encoding utf8
+
+        $block  = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+        $native = Get-NativeKeysFromJuggernautBlock -Block $block
+        $existing = Read-Settings -Path $script:target
+        $merged = Merge-JuggernautBlock -Existing $existing -NewBlock $block -NativeKeys $native
+        Write-SettingsAtomic -Path $script:target -Content $merged
+
+        $readBack = Read-Settings -Path $script:target
+        $readBack['theme']                          | Should -Be 'dark'
+        $readBack['permissions']['allow'][0]        | Should -Be 'npm'
+        $readBack['juggernaut']['meta']['managedBy']| Should -Be 'juggernaut'
+    }
+}
+
+Describe 'Remove leaves unrelated user keys' {
+    It 'strips juggernaut + native keys; keeps theme' {
+        $existing = [ordered]@{
+            theme = 'dark'
+            juggernaut = [ordered]@{ meta = [ordered]@{ managedBy = 'juggernaut' } }
+            env = [ordered]@{ CLAUDE_CODE_USE_BEDROCK = '1' }
+            model = 'foo'
+            modelOverrides = [ordered]@{ opus = 'x' }
+            availableModels = @('a','b')
+        }
+        $stripped = Remove-JuggernautBlockFromSettings -Existing $existing
+        $stripped.Contains('juggernaut')      | Should -BeFalse
+        $stripped.Contains('env')             | Should -BeFalse
+        $stripped.Contains('model')           | Should -BeFalse
+        $stripped.Contains('availableModels') | Should -BeFalse
+        $stripped['theme']                    | Should -Be 'dark'
+    }
+}
+
+Describe 'Write-SettingsAtomic rejects invalid JSON' {
+    BeforeEach {
+        $script:tmpDir = Join-Path ([IO.Path]::GetTempPath()) ("juggernaut-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:tmpDir -Force | Out-Null
+        $script:target = Join-Path $script:tmpDir 'settings.json'
+    }
+    AfterEach {
+        Remove-Item -Path $script:tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'does not create the target file when content cannot serialize to JSON' {
+        # Force a non-serializable object.
+        $bad = [ScriptBlock]::Create('whatever')
+        { Write-SettingsAtomic -Path $script:target -Content $bad } | Should -Throw
+        Test-Path $script:target | Should -BeFalse
+    }
+}
+
+Describe 'Invoke-WithSettingsLock' {
+    It 'survives an abandoned-mutex exception' {
+        $p = Join-Path ([IO.Path]::GetTempPath()) ("juggernaut-lock-" + [Guid]::NewGuid().ToString('N'))
+        $hit = $false
+        Invoke-WithSettingsLock -Path $p -Action { $script:hit = $true }
+        # No real way to force AbandonedMutexException from a test in-process; we at least verify
+        # the happy path completes without throwing and the action runs.
+        { Invoke-WithSettingsLock -Path $p -Action { 1 + 1 } } | Should -Not -Throw
+    }
+}
+
+Describe 'Test-HasJuggernautBlock' {
+    It 'true when managedBy = juggernaut' {
+        $s = [ordered]@{ juggernaut = [ordered]@{ meta = [ordered]@{ managedBy = 'juggernaut' } } }
+        (Test-HasJuggernautBlock -Settings $s) | Should -BeTrue
+    }
+    It 'false when juggernaut key is missing' {
+        $s = [ordered]@{ theme = 'dark' }
+        (Test-HasJuggernautBlock -Settings $s) | Should -BeFalse
+    }
+    It 'false when managedBy is not juggernaut' {
+        $s = [ordered]@{ juggernaut = [ordered]@{ meta = [ordered]@{ managedBy = 'other' } } }
+        (Test-HasJuggernautBlock -Settings $s) | Should -BeFalse
+    }
+}

--- a/tests/v2/Schema.Tests.ps1
+++ b/tests/v2/Schema.Tests.ps1
@@ -1,0 +1,108 @@
+# tests/v2/Schema.Tests.ps1 — Pester 5.x tests for lib/schema.ps1.
+# Mirrors coverage of tests/v2/test_schema.sh. Invoke with:
+#   Invoke-Pester -Path tests/v2/Schema.Tests.ps1
+
+BeforeAll {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    . (Join-Path $repoRoot 'lib/schema.ps1')
+    $script:BedrockConfigPath = Join-Path $repoRoot 'bedrock-config.json'
+}
+
+Describe 'New-JuggernautBlock — defaults' {
+    BeforeAll {
+        $script:block = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+    }
+
+    It 'sets managedBy = juggernaut' {
+        $script:block.meta.managedBy | Should -Be 'juggernaut'
+    }
+    It 'schemaVersion is 1' {
+        $script:block.schemaVersion | Should -Be 1
+    }
+    It 'useMantle defaults to true' {
+        $script:block.useMantle | Should -BeTrue
+    }
+    It 'default region is us-east-1' {
+        $script:block.auth.region | Should -Be 'us-east-1'
+    }
+    It 'default effortLevel is xhigh' {
+        $script:block.effortLevel | Should -Be 'xhigh'
+    }
+    It 'useMantle=true emits CLAUDE_CODE_USE_MANTLE=1 in env' {
+        $script:block.env['CLAUDE_CODE_USE_MANTLE'] | Should -Be '1'
+    }
+    It 'absent mantle baseUrl does NOT emit ANTHROPIC_BEDROCK_MANTLE_BASE_URL' {
+        $script:block.env.Contains('ANTHROPIC_BEDROCK_MANTLE_BASE_URL') | Should -BeFalse
+    }
+    It 'AWS_REGION in env is derived from auth.region' {
+        $script:block.env['AWS_REGION'] | Should -Be $script:block.auth.region
+    }
+}
+
+Describe 'New-JuggernautBlock — useMantle=false' {
+    It 'omits both Mantle env keys' {
+        $b = New-JuggernautBlock -UseMantle:$false -BedrockConfigPath $script:BedrockConfigPath
+        $b.env.Contains('CLAUDE_CODE_USE_MANTLE')             | Should -BeFalse
+        $b.env.Contains('ANTHROPIC_BEDROCK_MANTLE_BASE_URL')  | Should -BeFalse
+    }
+}
+
+Describe 'New-JuggernautBlock — mantle baseUrl' {
+    It 'writes baseUrl to env and to juggernaut.mantle.baseUrl' {
+        $b = New-JuggernautBlock -MantleBaseUrl 'https://mantle.example.com' -BedrockConfigPath $script:BedrockConfigPath
+        $b.env['ANTHROPIC_BEDROCK_MANTLE_BASE_URL'] | Should -Be 'https://mantle.example.com'
+        $b.mantle.baseUrl                           | Should -Be 'https://mantle.example.com'
+    }
+}
+
+Describe 'New-JuggernautBlock — opusplan' {
+    It 'opusplan=true sets ANTHROPIC_MODEL literal "opusplan"' {
+        $b = New-JuggernautBlock -OpusPlan:$true -BedrockConfigPath $script:BedrockConfigPath
+        $b.env['ANTHROPIC_MODEL'] | Should -Be 'opusplan'
+    }
+}
+
+Describe 'New-JuggernautBlock — region override' {
+    It 'passes through to both auth.region and env.AWS_REGION' {
+        $b = New-JuggernautBlock -Region 'us-west-2' -BedrockConfigPath $script:BedrockConfigPath
+        $b.auth.region         | Should -Be 'us-west-2'
+        $b.env['AWS_REGION']   | Should -Be 'us-west-2'
+    }
+}
+
+Describe 'Test-JuggernautBlock — validation' {
+    BeforeAll {
+        $script:good = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+    }
+
+    It 'accepts a default block' {
+        Test-JuggernautBlock -Block $script:good 2>$null | Should -BeTrue
+    }
+    It 'rejects empty auth.region' {
+        $bad = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+        $bad.auth.region = ''
+        Test-JuggernautBlock -Block $bad 2>$null | Should -BeFalse
+    }
+    It 'rejects unsupported auth.region' {
+        $bad = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+        $bad.auth.region = 'mars-central-1'
+        Test-JuggernautBlock -Block $bad 2>$null | Should -BeFalse
+    }
+    It 'rejects bad managedBy' {
+        $bad = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+        $bad.meta.managedBy = 'someoneElse'
+        Test-JuggernautBlock -Block $bad 2>$null | Should -BeFalse
+    }
+}
+
+Describe 'Get-NativeKeysFromJuggernautBlock' {
+    It 'returns env + model + modelOverrides' {
+        $b = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
+        $n = Get-NativeKeysFromJuggernautBlock -Block $b
+        $n.Keys | Should -Contain 'env'
+        $n.Keys | Should -Contain 'model'
+        $n.Keys | Should -Contain 'modelOverrides'
+        $n.env['CLAUDE_CODE_USE_BEDROCK'] | Should -Be '1'
+        $n.env['AWS_REGION']              | Should -Be $b.auth.region
+    }
+}

--- a/tests/v2/Schema.Tests.ps1
+++ b/tests/v2/Schema.Tests.ps1
@@ -76,22 +76,22 @@ Describe 'Test-JuggernautBlock — validation' {
     }
 
     It 'accepts a default block' {
-        Test-JuggernautBlock -Block $script:good 2>$null | Should -BeTrue
+        Test-JuggernautBlock -Block $script:good -WarningAction SilentlyContinue | Should -BeTrue
     }
     It 'rejects empty auth.region' {
         $bad = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
         $bad.auth.region = ''
-        Test-JuggernautBlock -Block $bad 2>$null | Should -BeFalse
+        Test-JuggernautBlock -Block $bad -WarningAction SilentlyContinue | Should -BeFalse
     }
     It 'rejects unsupported auth.region' {
         $bad = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
         $bad.auth.region = 'mars-central-1'
-        Test-JuggernautBlock -Block $bad 2>$null | Should -BeFalse
+        Test-JuggernautBlock -Block $bad -WarningAction SilentlyContinue | Should -BeFalse
     }
     It 'rejects bad managedBy' {
         $bad = New-JuggernautBlock -BedrockConfigPath $script:BedrockConfigPath
         $bad.meta.managedBy = 'someoneElse'
-        Test-JuggernautBlock -Block $bad 2>$null | Should -BeFalse
+        Test-JuggernautBlock -Block $bad -WarningAction SilentlyContinue | Should -BeFalse
     }
 }
 

--- a/tests/v2/test_config_manager.sh
+++ b/tests/v2/test_config_manager.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # tests/v2/test_config_manager.sh — unit tests for lib/config_manager.sh
-# Exercises read/merge/write round-trips with tmp paths.
 
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -17,6 +16,9 @@ export BEDROCK_CONFIG_PATH="$REPO_ROOT/bedrock-config.json"
 PASS=0; FAIL=0
 fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
 pass() { PASS=$((PASS + 1)); }
+assert_eq() { if [[ "$1" == "$2" ]]; then pass; else fail "$3 (expected '$2', got '$1')"; fi; }
+assert_cmd() { if "$@" >/dev/null 2>&1; then pass; else fail "command failed: $*"; fi; }
+assert_not_cmd() { if ! "$@" >/dev/null 2>&1; then pass; else fail "command unexpectedly succeeded: $*"; fi; }
 section() { echo; echo "== $1 =="; }
 
 TMPDIR_LOCAL="$(mktemp -d)"
@@ -24,65 +26,67 @@ trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
 
 TARGET="$TMPDIR_LOCAL/settings.json"
 
-# --- Round-trip on empty target ---
 section "Write-read round trip on fresh file"
 block="$(schema_new_juggernaut_block)"
 native="$(schema_derive_native_keys "$block")"
-
 existing="$(config_read "$TARGET")"
 merged="$(config_merge_juggernaut_block "$existing" "$block" "$native")"
 config_write_atomic "$TARGET" "$merged"
-
 read_back="$(config_read "$TARGET")"
-[[ "$(echo "$read_back" | jq -r '.juggernaut.meta.managedBy')" == "juggernaut" ]] && pass || fail "round-trip should preserve managedBy"
-[[ "$(echo "$read_back" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK')" == "1" ]] && pass || fail "round-trip should preserve native env"
+assert_eq "$(echo "$read_back" | jq -r '.juggernaut.meta.managedBy')" "juggernaut" "round-trip should preserve managedBy"
+assert_eq "$(echo "$read_back" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK')" "1" "round-trip should preserve native env"
+assert_cmd config_has_juggernaut_block "$read_back"
 
-config_has_juggernaut_block "$read_back" && pass || fail "has_juggernaut_block should return 0"
-
-# --- Merge preserves user keys ---
 section "Merge preserves unrelated user keys"
 user_content='{"theme":"dark","permissions":{"allow":["npm"]}}'
 echo "$user_content" >"$TARGET"
 existing="$(config_read "$TARGET")"
 merged="$(config_merge_juggernaut_block "$existing" "$block" "$native")"
 config_write_atomic "$TARGET" "$merged"
-
 read_back="$(config_read "$TARGET")"
-[[ "$(echo "$read_back" | jq -r '.theme')" == "dark" ]] && pass || fail "theme key should be preserved"
-[[ "$(echo "$read_back" | jq -r '.permissions.allow[0]')" == "npm" ]] && pass || fail "permissions should be preserved"
-[[ "$(echo "$read_back" | jq -r '.juggernaut.meta.managedBy')" == "juggernaut" ]] && pass || fail "juggernaut block should be present"
+assert_eq "$(echo "$read_back" | jq -r '.theme')"                     "dark"       "theme key should be preserved"
+assert_eq "$(echo "$read_back" | jq -r '.permissions.allow[0]')"      "npm"        "permissions should be preserved"
+assert_eq "$(echo "$read_back" | jq -r '.juggernaut.meta.managedBy')" "juggernaut" "juggernaut block should be present"
 
-# --- Backup created and rotated ---
 section "Backup created and rotated at 5"
-for i in 1 2 3 4 5 6 7; do
-  # Tweak timestamp to force unique backups
+for _ in 1 2 3 4 5 6 7; do
   sleep 1
   config_write_atomic "$TARGET" "$merged"
 done
 backup_count="$(find "$TMPDIR_LOCAL" -maxdepth 1 -name 'settings.json.backup.*' | wc -l | tr -d ' ')"
-[[ "$backup_count" -le 5 ]] && pass || fail "expected ≤5 backups, got $backup_count"
+if [[ "$backup_count" -le 5 ]]; then pass; else fail "expected ≤5 backups, got $backup_count"; fi
 
-# --- Remove juggernaut block leaves user keys alone ---
 section "Remove leaves unrelated user keys"
 read_back="$(config_read "$TARGET")"
 stripped="$(config_remove_juggernaut_block "$read_back")"
-[[ "$(echo "$stripped" | jq 'has("juggernaut")')" == "false" ]] && pass || fail "juggernaut key should be removed"
-[[ "$(echo "$stripped" | jq 'has("env")')" == "false" ]] && pass || fail "env key should be removed"
-[[ "$(echo "$stripped" | jq -r '.theme')" == "dark" ]] && pass || fail "theme should still be present after remove"
+assert_eq "$(echo "$stripped" | jq 'has("juggernaut")')" "false" "juggernaut key should be removed"
+assert_eq "$(echo "$stripped" | jq 'has("env")')"        "false" "env key should be removed"
+assert_eq "$(echo "$stripped" | jq -r '.theme')"         "dark"  "theme should still be present after remove"
 
-# --- Invalid JSON rejected ---
 section "Refuse to write invalid JSON"
-set +e
-config_write_atomic "$TARGET" "not json at all" 2>/dev/null
-rc=$?
-set -e
-[[ "$rc" -ne 0 ]] && pass || fail "invalid JSON write should fail"
+assert_not_cmd config_write_atomic "$TARGET" "not json at all"
 
-# --- config_exists ---
 section "config_exists semantics"
-config_exists "$TARGET" && pass || fail "real file should be considered existing"
-config_exists "/nonexistent/path" && fail "nonexistent path should not be existing" || pass
+assert_cmd config_exists "$TARGET"
+assert_not_cmd config_exists "/nonexistent/path"
+
+section "Locking: serializes two writers (smoke)"
+LOCK_TARGET="$TMPDIR_LOCAL/locked.json"
+echo '{}' > "$LOCK_TARGET"
+slow_writer() {
+  config_with_lock "$LOCK_TARGET" bash -c '
+    sleep 0.3
+    echo "{\"who\":\"'"$1"'\"}" > "'"$LOCK_TARGET"'"
+  '
+}
+slow_writer first &
+P1=$!
+slow_writer second &
+P2=$!
+wait $P1 $P2
+# Just verify lock didn't corrupt the file.
+if jq -e . "$LOCK_TARGET" >/dev/null 2>&1; then pass; else fail "file corrupted under concurrent writers"; fi
 
 echo
 echo "config_manager.sh tests: $PASS passed, $FAIL failed"
-exit $FAIL
+exit "$FAIL"

--- a/tests/v2/test_config_manager.sh
+++ b/tests/v2/test_config_manager.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# tests/v2/test_config_manager.sh — unit tests for lib/config_manager.sh
+# Exercises read/merge/write round-trips with tmp paths.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=../../lib/schema.sh
+source "$REPO_ROOT/lib/schema.sh"
+# shellcheck source=../../lib/config_manager.sh
+source "$REPO_ROOT/lib/config_manager.sh"
+
+export BEDROCK_CONFIG_PATH="$REPO_ROOT/bedrock-config.json"
+
+PASS=0; FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+pass() { PASS=$((PASS + 1)); }
+section() { echo; echo "== $1 =="; }
+
+TMPDIR_LOCAL="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+TARGET="$TMPDIR_LOCAL/settings.json"
+
+# --- Round-trip on empty target ---
+section "Write-read round trip on fresh file"
+block="$(schema_new_juggernaut_block)"
+native="$(schema_derive_native_keys "$block")"
+
+existing="$(config_read "$TARGET")"
+merged="$(config_merge_juggernaut_block "$existing" "$block" "$native")"
+config_write_atomic "$TARGET" "$merged"
+
+read_back="$(config_read "$TARGET")"
+[[ "$(echo "$read_back" | jq -r '.juggernaut.meta.managedBy')" == "juggernaut" ]] && pass || fail "round-trip should preserve managedBy"
+[[ "$(echo "$read_back" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK')" == "1" ]] && pass || fail "round-trip should preserve native env"
+
+config_has_juggernaut_block "$read_back" && pass || fail "has_juggernaut_block should return 0"
+
+# --- Merge preserves user keys ---
+section "Merge preserves unrelated user keys"
+user_content='{"theme":"dark","permissions":{"allow":["npm"]}}'
+echo "$user_content" >"$TARGET"
+existing="$(config_read "$TARGET")"
+merged="$(config_merge_juggernaut_block "$existing" "$block" "$native")"
+config_write_atomic "$TARGET" "$merged"
+
+read_back="$(config_read "$TARGET")"
+[[ "$(echo "$read_back" | jq -r '.theme')" == "dark" ]] && pass || fail "theme key should be preserved"
+[[ "$(echo "$read_back" | jq -r '.permissions.allow[0]')" == "npm" ]] && pass || fail "permissions should be preserved"
+[[ "$(echo "$read_back" | jq -r '.juggernaut.meta.managedBy')" == "juggernaut" ]] && pass || fail "juggernaut block should be present"
+
+# --- Backup created and rotated ---
+section "Backup created and rotated at 5"
+for i in 1 2 3 4 5 6 7; do
+  # Tweak timestamp to force unique backups
+  sleep 1
+  config_write_atomic "$TARGET" "$merged"
+done
+backup_count="$(find "$TMPDIR_LOCAL" -maxdepth 1 -name 'settings.json.backup.*' | wc -l | tr -d ' ')"
+[[ "$backup_count" -le 5 ]] && pass || fail "expected ≤5 backups, got $backup_count"
+
+# --- Remove juggernaut block leaves user keys alone ---
+section "Remove leaves unrelated user keys"
+read_back="$(config_read "$TARGET")"
+stripped="$(config_remove_juggernaut_block "$read_back")"
+[[ "$(echo "$stripped" | jq 'has("juggernaut")')" == "false" ]] && pass || fail "juggernaut key should be removed"
+[[ "$(echo "$stripped" | jq 'has("env")')" == "false" ]] && pass || fail "env key should be removed"
+[[ "$(echo "$stripped" | jq -r '.theme')" == "dark" ]] && pass || fail "theme should still be present after remove"
+
+# --- Invalid JSON rejected ---
+section "Refuse to write invalid JSON"
+set +e
+config_write_atomic "$TARGET" "not json at all" 2>/dev/null
+rc=$?
+set -e
+[[ "$rc" -ne 0 ]] && pass || fail "invalid JSON write should fail"
+
+# --- config_exists ---
+section "config_exists semantics"
+config_exists "$TARGET" && pass || fail "real file should be considered existing"
+config_exists "/nonexistent/path" && fail "nonexistent path should not be existing" || pass
+
+echo
+echo "config_manager.sh tests: $PASS passed, $FAIL failed"
+exit $FAIL

--- a/tests/v2/test_feature_flag.sh
+++ b/tests/v2/test_feature_flag.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# tests/v2/test_feature_flag.sh — the --v2 / JUGGERNAUT_USE_V2 flag is dormant plumbing.
+# Confirms it is accepted, announced, does not alter v1 dry-run output, and does not leak
+# into paths that shouldn't see it.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0; FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+pass() { PASS=$((PASS + 1)); }
+section() { echo; echo "== $1 =="; }
+
+section "--v2 flag is accepted by ./setup without altering exit code"
+# Use help to exercise the arg parser without running a real setup.
+if bash "$REPO_ROOT/setup" --v2 --help >/dev/null 2>&1; then pass; else fail "./setup --v2 --help should exit 0"; fi
+
+section "--v2 announces itself to stderr"
+announce="$(bash "$REPO_ROOT/setup" --v2 --help 2>&1 1>/dev/null | head -1)"
+if [[ "$announce" == *"Juggernaut v2 mode enabled"* ]]; then pass; else fail "expected v2 announce line on stderr (got: '$announce')"; fi
+
+section "JUGGERNAUT_USE_V2=1 env var also triggers announce"
+announce_env="$(JUGGERNAUT_USE_V2=1 bash "$REPO_ROOT/setup" --help 2>&1 1>/dev/null | head -1)"
+if [[ "$announce_env" == *"Juggernaut v2 mode enabled"* ]]; then pass; else fail "env var should trigger announce (got: '$announce_env')"; fi
+
+section "Default run (no flag) does NOT announce v2"
+clean_stderr="$(bash "$REPO_ROOT/setup" --help 2>&1 1>/dev/null)"
+if [[ "$clean_stderr" != *"Juggernaut v2"* ]]; then pass; else fail "v1 default run should be silent about v2"; fi
+
+section "--v2 is stripped before delegation (help output is unchanged)"
+with_v2="$(bash "$REPO_ROOT/setup" --v2 --help 2>/dev/null)"
+without_v2="$(bash "$REPO_ROOT/setup" --help 2>/dev/null)"
+if [[ "$with_v2" == "$without_v2" ]]; then pass; else fail "--v2 should not change help output"; fi
+
+section "Flag is accepted by setup-claude-bedrock.sh arg parser"
+# --dry-run + --help-ish path: use --version, which exits 0 from the inner parser too.
+if bash "$REPO_ROOT/setup-claude-bedrock.sh" bash --v2 --version >/dev/null 2>&1; then pass; else fail "setup-claude-bedrock.sh should accept --v2"; fi
+
+echo
+echo "feature-flag tests: $PASS passed, $FAIL failed"
+exit "$FAIL"

--- a/tests/v2/test_feature_flag.sh
+++ b/tests/v2/test_feature_flag.sh
@@ -19,7 +19,7 @@ if bash "$REPO_ROOT/setup" --v2 --help >/dev/null 2>&1; then pass; else fail "./
 
 section "--v2 announces itself to stderr"
 announce="$(bash "$REPO_ROOT/setup" --v2 --help 2>&1 1>/dev/null | head -1)"
-if [[ "$announce" == *"Juggernaut v2.0 enabled"* && "$announce" == *"dormant in this phase"* ]]; then
+if [[ "$announce" == *"Juggernaut v2.0 enabled"* && "$announce" == *"currently dormant"* ]]; then
   pass
 else
   fail "expected v2 announce on stderr (got: '$announce')"

--- a/tests/v2/test_feature_flag.sh
+++ b/tests/v2/test_feature_flag.sh
@@ -19,20 +19,44 @@ if bash "$REPO_ROOT/setup" --v2 --help >/dev/null 2>&1; then pass; else fail "./
 
 section "--v2 announces itself to stderr"
 announce="$(bash "$REPO_ROOT/setup" --v2 --help 2>&1 1>/dev/null | head -1)"
-if [[ "$announce" == *"Juggernaut v2 mode enabled"* ]]; then pass; else fail "expected v2 announce line on stderr (got: '$announce')"; fi
+if [[ "$announce" == *"Juggernaut v2.0 enabled"* && "$announce" == *"dormant in this phase"* ]]; then
+  pass
+else
+  fail "expected v2 announce on stderr (got: '$announce')"
+fi
 
 section "JUGGERNAUT_USE_V2=1 env var also triggers announce"
 announce_env="$(JUGGERNAUT_USE_V2=1 bash "$REPO_ROOT/setup" --help 2>&1 1>/dev/null | head -1)"
-if [[ "$announce_env" == *"Juggernaut v2 mode enabled"* ]]; then pass; else fail "env var should trigger announce (got: '$announce_env')"; fi
+if [[ "$announce_env" == *"Juggernaut v2.0 enabled"* ]]; then pass; else fail "env var should trigger announce (got: '$announce_env')"; fi
 
 section "Default run (no flag) does NOT announce v2"
 clean_stderr="$(bash "$REPO_ROOT/setup" --help 2>&1 1>/dev/null)"
 if [[ "$clean_stderr" != *"Juggernaut v2"* ]]; then pass; else fail "v1 default run should be silent about v2"; fi
 
-section "--v2 is stripped before delegation (help output is unchanged)"
+section "--v2 is stripped before delegation (help output byte-identical)"
 with_v2="$(bash "$REPO_ROOT/setup" --v2 --help 2>/dev/null)"
 without_v2="$(bash "$REPO_ROOT/setup" --help 2>/dev/null)"
 if [[ "$with_v2" == "$without_v2" ]]; then pass; else fail "--v2 should not change help output"; fi
+
+section "--v2 does NOT alter v1 dry-run stdout (behavioral isolation)"
+# Run v1 apply in dry-run twice, once with --v2, once without. The user-visible
+# stdout must be byte-identical — v2 plumbing lives in env/stderr only.
+dry_no="$(bash "$REPO_ROOT/setup-claude-bedrock.sh" bash --dry-run --force --auth=iam --region=us-west-2 2>/dev/null)"
+dry_v2="$(bash "$REPO_ROOT/setup-claude-bedrock.sh" bash --v2 --dry-run --force --auth=iam --region=us-west-2 2>/dev/null)"
+if [[ "$dry_no" == "$dry_v2" ]]; then
+  pass
+else
+  fail "--v2 altered v1 dry-run stdout (diff below)"
+  diff <(printf '%s\n' "$dry_no") <(printf '%s\n' "$dry_v2") | head -20 >&2
+fi
+
+section "JUGGERNAUT_USE_V2=1 env var also preserves v1 dry-run stdout"
+dry_env="$(JUGGERNAUT_USE_V2=1 bash "$REPO_ROOT/setup-claude-bedrock.sh" bash --dry-run --force --auth=iam --region=us-west-2 2>/dev/null)"
+if [[ "$dry_no" == "$dry_env" ]]; then
+  pass
+else
+  fail "JUGGERNAUT_USE_V2=1 altered v1 dry-run stdout"
+fi
 
 section "Flag is accepted by setup-claude-bedrock.sh arg parser"
 # --dry-run + --help-ish path: use --version, which exits 0 from the inner parser too.

--- a/tests/v2/test_schema.sh
+++ b/tests/v2/test_schema.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tests/v2/test_schema.sh — unit tests for lib/schema.sh
+# Run: bash tests/v2/test_schema.sh  (exits nonzero on failure)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck source=../../lib/schema.sh
+source "$REPO_ROOT/lib/schema.sh"
+
+export BEDROCK_CONFIG_PATH="$REPO_ROOT/bedrock-config.json"
+
+PASS=0; FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+pass() { PASS=$((PASS + 1)); }
+
+section() { echo; echo "== $1 =="; }
+
+# --- schema_new_juggernaut_block defaults ---
+section "New block with defaults"
+block="$(schema_new_juggernaut_block)"
+
+# Check managed-by
+[[ "$(echo "$block" | jq -r '.meta.managedBy')" == "juggernaut" ]] && pass || fail "managedBy should be juggernaut"
+[[ "$(echo "$block" | jq -r '.schemaVersion')" == "1" ]] && pass || fail "schemaVersion should be 1"
+[[ "$(echo "$block" | jq -r '.useMantle')" == "true" ]] && pass || fail "useMantle default should be true"
+[[ "$(echo "$block" | jq -r '.auth.region')" == "us-east-1" ]] && pass || fail "default region should be us-east-1"
+[[ "$(echo "$block" | jq -r '.effortLevel')" == "xhigh" ]] && pass || fail "default effort should be xhigh"
+
+# Mantle env rule: useMantle=true sets CLAUDE_CODE_USE_MANTLE=1
+[[ "$(echo "$block" | jq -r '.env.CLAUDE_CODE_USE_MANTLE // ""')" == "1" ]] && pass || fail "useMantle=true should set CLAUDE_CODE_USE_MANTLE=1"
+
+# No mantle base URL by default → key absent
+[[ "$(echo "$block" | jq 'has("env") and (.env | has("ANTHROPIC_BEDROCK_MANTLE_BASE_URL"))')" == "false" ]] && pass || fail "absent mantle baseUrl should not write env key"
+
+# --- useMantle=false scrubs both env keys ---
+section "useMantle=false"
+J_USE_MANTLE=false block2="$(schema_new_juggernaut_block)"
+[[ "$(echo "$block2" | jq '.env | has("CLAUDE_CODE_USE_MANTLE")')" == "false" ]] && pass || fail "useMantle=false should omit CLAUDE_CODE_USE_MANTLE"
+[[ "$(echo "$block2" | jq '.env | has("ANTHROPIC_BEDROCK_MANTLE_BASE_URL")')" == "false" ]] && pass || fail "useMantle=false should omit ANTHROPIC_BEDROCK_MANTLE_BASE_URL"
+
+# --- Mantle base URL when provided ---
+section "mantle baseUrl"
+J_USE_MANTLE=true J_MANTLE_BASE_URL="https://mantle.example.com" block3="$(schema_new_juggernaut_block)"
+[[ "$(echo "$block3" | jq -r '.env.ANTHROPIC_BEDROCK_MANTLE_BASE_URL')" == "https://mantle.example.com" ]] && pass || fail "baseUrl should be written to env"
+[[ "$(echo "$block3" | jq -r '.mantle.baseUrl')" == "https://mantle.example.com" ]] && pass || fail "baseUrl should be stored in juggernaut.mantle.baseUrl"
+
+# --- opusplan flips ANTHROPIC_MODEL to literal "opusplan" ---
+section "opusplan special literal"
+J_OPUSPLAN=true block4="$(schema_new_juggernaut_block)"
+[[ "$(echo "$block4" | jq -r '.env.ANTHROPIC_MODEL')" == "opusplan" ]] && pass || fail "opusplan=true should set ANTHROPIC_MODEL=opusplan"
+
+# --- Region override ---
+section "Region override preserves us-west-2"
+J_REGION=us-west-2 block5="$(schema_new_juggernaut_block)"
+[[ "$(echo "$block5" | jq -r '.auth.region')" == "us-west-2" ]] && pass || fail "region override should apply to auth.region"
+[[ "$(echo "$block5" | jq -r '.env.AWS_REGION')" == "us-west-2" ]] && pass || fail "region override should apply to env.AWS_REGION"
+
+# --- Validation ---
+section "schema_validate accepts default block"
+schema_validate "$block" && pass || fail "default block should validate"
+
+section "schema_validate rejects bad auth.mode"
+bad1="$(echo "$block" | jq '.auth.mode = "sso"')"
+schema_validate "$bad1" 2>/dev/null && fail "bad auth.mode should reject" || pass
+
+section "schema_validate rejects bad effortLevel"
+bad2="$(echo "$block" | jq '.effortLevel = "insane"')"
+schema_validate "$bad2" 2>/dev/null && fail "bad effortLevel should reject" || pass
+
+section "schema_validate rejects missing managedBy"
+bad3="$(echo "$block" | jq '.meta.managedBy = "someoneElse"')"
+schema_validate "$bad3" 2>/dev/null && fail "wrong managedBy should reject" || pass
+
+section "schema_validate rejects unsupported region"
+bad4="$(echo "$block" | jq '.auth.region = "mars-central-1"')"
+schema_validate "$bad4" 2>/dev/null && fail "bad region should reject" || pass
+
+# --- Derive native keys ---
+section "schema_derive_native_keys"
+native="$(schema_derive_native_keys "$block")"
+[[ "$(echo "$native" | jq 'has("env") and has("model") and has("modelOverrides")')" == "true" ]] && pass || fail "native keys should include env/model/modelOverrides"
+[[ "$(echo "$native" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK')" == "1" ]] && pass || fail "native env should carry CLAUDE_CODE_USE_BEDROCK"
+
+echo
+echo "schema.sh tests: $PASS passed, $FAIL failed"
+exit $FAIL

--- a/tests/v2/test_schema.sh
+++ b/tests/v2/test_schema.sh
@@ -2,7 +2,7 @@
 # tests/v2/test_schema.sh — unit tests for lib/schema.sh
 # Run: bash tests/v2/test_schema.sh  (exits nonzero on failure)
 
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -15,75 +15,65 @@ export BEDROCK_CONFIG_PATH="$REPO_ROOT/bedrock-config.json"
 PASS=0; FAIL=0
 fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
 pass() { PASS=$((PASS + 1)); }
+# Assertion helpers: using `if/else` keeps exit codes explicit (avoids SC2015 A && B || C pitfalls).
+assert_eq()      { if [[ "$1" == "$2" ]]; then pass; else fail "$3 (expected '$2', got '$1')"; fi; }
+assert_cmd()     { if "$@" >/dev/null 2>&1; then pass; else fail "command failed: $*"; fi; }
+assert_not_cmd() { if ! "$@" >/dev/null 2>&1; then pass; else fail "command unexpectedly succeeded: $*"; fi; }
 
 section() { echo; echo "== $1 =="; }
 
-# --- schema_new_juggernaut_block defaults ---
 section "New block with defaults"
 block="$(schema_new_juggernaut_block)"
+assert_eq "$(echo "$block" | jq -r '.meta.managedBy')"    "juggernaut" "managedBy should be juggernaut"
+assert_eq "$(echo "$block" | jq -r '.schemaVersion')"     "1"          "schemaVersion should be 1"
+assert_eq "$(echo "$block" | jq -r '.useMantle')"         "true"       "useMantle default should be true"
+assert_eq "$(echo "$block" | jq -r '.auth.region')"       "us-east-1"  "default region should be us-east-1"
+assert_eq "$(echo "$block" | jq -r '.effortLevel')"       "xhigh"      "default effort should be xhigh"
+assert_eq "$(echo "$block" | jq -r '.env.CLAUDE_CODE_USE_MANTLE')" "1" "useMantle=true should set CLAUDE_CODE_USE_MANTLE=1"
+assert_eq "$(echo "$block" | jq 'has("env") and (.env | has("ANTHROPIC_BEDROCK_MANTLE_BASE_URL"))')" "false" \
+  "absent mantle baseUrl should not write env key"
 
-# Check managed-by
-[[ "$(echo "$block" | jq -r '.meta.managedBy')" == "juggernaut" ]] && pass || fail "managedBy should be juggernaut"
-[[ "$(echo "$block" | jq -r '.schemaVersion')" == "1" ]] && pass || fail "schemaVersion should be 1"
-[[ "$(echo "$block" | jq -r '.useMantle')" == "true" ]] && pass || fail "useMantle default should be true"
-[[ "$(echo "$block" | jq -r '.auth.region')" == "us-east-1" ]] && pass || fail "default region should be us-east-1"
-[[ "$(echo "$block" | jq -r '.effortLevel')" == "xhigh" ]] && pass || fail "default effort should be xhigh"
-
-# Mantle env rule: useMantle=true sets CLAUDE_CODE_USE_MANTLE=1
-[[ "$(echo "$block" | jq -r '.env.CLAUDE_CODE_USE_MANTLE // ""')" == "1" ]] && pass || fail "useMantle=true should set CLAUDE_CODE_USE_MANTLE=1"
-
-# No mantle base URL by default → key absent
-[[ "$(echo "$block" | jq 'has("env") and (.env | has("ANTHROPIC_BEDROCK_MANTLE_BASE_URL"))')" == "false" ]] && pass || fail "absent mantle baseUrl should not write env key"
-
-# --- useMantle=false scrubs both env keys ---
 section "useMantle=false"
-J_USE_MANTLE=false block2="$(schema_new_juggernaut_block)"
-[[ "$(echo "$block2" | jq '.env | has("CLAUDE_CODE_USE_MANTLE")')" == "false" ]] && pass || fail "useMantle=false should omit CLAUDE_CODE_USE_MANTLE"
-[[ "$(echo "$block2" | jq '.env | has("ANTHROPIC_BEDROCK_MANTLE_BASE_URL")')" == "false" ]] && pass || fail "useMantle=false should omit ANTHROPIC_BEDROCK_MANTLE_BASE_URL"
+export J_USE_MANTLE=false
+block2="$(schema_new_juggernaut_block)"
+unset J_USE_MANTLE
+assert_eq "$(echo "$block2" | jq '.env | has("CLAUDE_CODE_USE_MANTLE")')"            "false" "useMantle=false should omit CLAUDE_CODE_USE_MANTLE"
+assert_eq "$(echo "$block2" | jq '.env | has("ANTHROPIC_BEDROCK_MANTLE_BASE_URL")')" "false" "useMantle=false should omit mantle base URL"
 
-# --- Mantle base URL when provided ---
 section "mantle baseUrl"
-J_USE_MANTLE=true J_MANTLE_BASE_URL="https://mantle.example.com" block3="$(schema_new_juggernaut_block)"
-[[ "$(echo "$block3" | jq -r '.env.ANTHROPIC_BEDROCK_MANTLE_BASE_URL')" == "https://mantle.example.com" ]] && pass || fail "baseUrl should be written to env"
-[[ "$(echo "$block3" | jq -r '.mantle.baseUrl')" == "https://mantle.example.com" ]] && pass || fail "baseUrl should be stored in juggernaut.mantle.baseUrl"
+export J_USE_MANTLE=true J_MANTLE_BASE_URL="https://mantle.example.com"
+block3="$(schema_new_juggernaut_block)"
+unset J_USE_MANTLE J_MANTLE_BASE_URL
+assert_eq "$(echo "$block3" | jq -r '.env.ANTHROPIC_BEDROCK_MANTLE_BASE_URL')" "https://mantle.example.com" "baseUrl should be written to env"
+assert_eq "$(echo "$block3" | jq -r '.mantle.baseUrl')"                       "https://mantle.example.com" "baseUrl stored in juggernaut.mantle.baseUrl"
 
-# --- opusplan flips ANTHROPIC_MODEL to literal "opusplan" ---
 section "opusplan special literal"
-J_OPUSPLAN=true block4="$(schema_new_juggernaut_block)"
-[[ "$(echo "$block4" | jq -r '.env.ANTHROPIC_MODEL')" == "opusplan" ]] && pass || fail "opusplan=true should set ANTHROPIC_MODEL=opusplan"
+export J_OPUSPLAN=true
+block4="$(schema_new_juggernaut_block)"
+unset J_OPUSPLAN
+assert_eq "$(echo "$block4" | jq -r '.env.ANTHROPIC_MODEL')" "opusplan" "opusplan=true should set ANTHROPIC_MODEL=opusplan"
 
-# --- Region override ---
 section "Region override preserves us-west-2"
-J_REGION=us-west-2 block5="$(schema_new_juggernaut_block)"
-[[ "$(echo "$block5" | jq -r '.auth.region')" == "us-west-2" ]] && pass || fail "region override should apply to auth.region"
-[[ "$(echo "$block5" | jq -r '.env.AWS_REGION')" == "us-west-2" ]] && pass || fail "region override should apply to env.AWS_REGION"
+export J_REGION=us-west-2
+block5="$(schema_new_juggernaut_block)"
+unset J_REGION
+assert_eq "$(echo "$block5" | jq -r '.auth.region')"    "us-west-2" "region override should apply to auth.region"
+assert_eq "$(echo "$block5" | jq -r '.env.AWS_REGION')" "us-west-2" "region override should apply to env.AWS_REGION"
 
-# --- Validation ---
-section "schema_validate accepts default block"
-schema_validate "$block" && pass || fail "default block should validate"
+section "schema_validate — positive and negative cases"
+assert_cmd schema_validate "$block"
+assert_not_cmd schema_validate "$(echo "$block" | jq '.auth.mode = "sso"')"
+assert_not_cmd schema_validate "$(echo "$block" | jq '.effortLevel = "insane"')"
+assert_not_cmd schema_validate "$(echo "$block" | jq '.meta.managedBy = "someoneElse"')"
+assert_not_cmd schema_validate "$(echo "$block" | jq '.auth.region = "mars-central-1"')"
+assert_not_cmd schema_validate "$(echo "$block" | jq '.auth.region = ""')"
 
-section "schema_validate rejects bad auth.mode"
-bad1="$(echo "$block" | jq '.auth.mode = "sso"')"
-schema_validate "$bad1" 2>/dev/null && fail "bad auth.mode should reject" || pass
-
-section "schema_validate rejects bad effortLevel"
-bad2="$(echo "$block" | jq '.effortLevel = "insane"')"
-schema_validate "$bad2" 2>/dev/null && fail "bad effortLevel should reject" || pass
-
-section "schema_validate rejects missing managedBy"
-bad3="$(echo "$block" | jq '.meta.managedBy = "someoneElse"')"
-schema_validate "$bad3" 2>/dev/null && fail "wrong managedBy should reject" || pass
-
-section "schema_validate rejects unsupported region"
-bad4="$(echo "$block" | jq '.auth.region = "mars-central-1"')"
-schema_validate "$bad4" 2>/dev/null && fail "bad region should reject" || pass
-
-# --- Derive native keys ---
 section "schema_derive_native_keys"
 native="$(schema_derive_native_keys "$block")"
-[[ "$(echo "$native" | jq 'has("env") and has("model") and has("modelOverrides")')" == "true" ]] && pass || fail "native keys should include env/model/modelOverrides"
-[[ "$(echo "$native" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK')" == "1" ]] && pass || fail "native env should carry CLAUDE_CODE_USE_BEDROCK"
+assert_eq "$(echo "$native" | jq 'has("env") and has("model") and has("modelOverrides")')" "true" "native keys should include env/model/modelOverrides"
+assert_eq "$(echo "$native" | jq -r '.env.CLAUDE_CODE_USE_BEDROCK')"                       "1"    "native env should carry CLAUDE_CODE_USE_BEDROCK"
+assert_eq "$(echo "$native" | jq -r '.env.AWS_REGION')"                                    "us-east-1" "native env should carry AWS_REGION derived from juggernaut.auth.region"
 
 echo
 echo "schema.sh tests: $PASS passed, $FAIL failed"
-exit $FAIL
+exit "$FAIL"


### PR DESCRIPTION
## Context

First of several phased PRs for Juggernaut v2.0 (see `.claude/plans/iterative-squishing-newell.md` for the full architecture). This phase introduces structural foundations only — no user-visible behavior change yet. The modules are dormant until Phase 2 (migrator) and Phase 3 (apply orchestration) wire them into the flow.

**Draft because:** we want to agree on the schema shape and ConfigManager contracts before layering migration + apply on top.

## Summary

Mirrored bash + PowerShell modules:

- **`lib/schema.{sh,ps1}`** — juggernaut-block construction, validation, derivation of native settings.json keys (`env`, `model`, `modelOverrides`). Enforces enums (auth.mode, storage, effortLevel, shellFallback.mode) and region support against `bedrock-config.json`.
- **`lib/config_manager.{sh,ps1}`** — settings.json I/O. Atomic writes via tmp+rename, 5-backup rotation, `flock`/Mutex concurrency protection, merge that preserves unrelated user keys (`theme`, `permissions`, `hooks`, etc.).

### Schema highlights

- `useMantle` defaults to `true` (per v2 design) — emits `CLAUDE_CODE_USE_MANTLE=1`
- Optional `juggernaut.mantle.baseUrl` → `ANTHROPIC_BEDROCK_MANTLE_BASE_URL`
- `auth.region` is first-class; default `us-east-1` for **fresh** installs. **Migrations preserve the user's prior region** (Phase 2 will read it out of the v1 profile block before applying any default).
- `opusplan: true` maps `ANTHROPIC_MODEL` → literal `"opusplan"` (special Claude Code token, not a model ID).

### Merge semantics

`config_merge_juggernaut_block` **replaces** (not merges) the native keys (`env`, `model`, `modelOverrides`) on every apply. Rationale: the `juggernaut` block is the single source of truth — native keys are derived output. Hand-edits to native keys get clobbered next apply. Phase 4's `juggernaut doctor` will flag drift.

## Tests

- **`tests/v2/test_schema.sh`**: 21 assertions — defaults, Mantle rules (both directions), opusplan literal, region override preservation, every validation enum (auth.mode, effortLevel, managedBy, region) — **all passing locally**
- **`tests/v2/test_config_manager.sh`**: 13 assertions — round-trip read/write, preservation of unrelated user keys (`theme`, `permissions`), backup rotation at 5, rejection of invalid JSON — **all passing locally**

### `.gitignore` tweak

The existing `test_*` catch-all was excluding the committed test suite. Narrowed to `/test_*` (repo-root only) and un-ignored `tests/**`.

## What I'd like feedback on

1. **`lib/schema.sh:51-82`** — the `schema_new_juggernaut_block()` env-assembly jq pipeline. Mantle/opusplan/region rules live here.
2. **`lib/schema.sh:115-170`** — `schema_validate()` enum lists. Am I missing any valid values you plan to accept?
3. **`lib/config_manager.sh:72-86`** — `config_merge_juggernaut_block()`. Confirm replace-don't-merge semantics for native keys is what you want.
4. **PS 5.1 compat** — `Read-Settings` uses `ConvertFrom-Json -AsHashtable`, which is PS 6+ only. I'll add a 5.1 fallback before Phase 2 lands.

## Test plan

- [x] `bash tests/v2/test_schema.sh` → 21/21 pass
- [x] `bash tests/v2/test_config_manager.sh` → 13/13 pass
- [ ] CI: Lint, CodeQL, Ubuntu/macOS/Windows suites pass
- [ ] PS 5.1 smoke test on Windows (CI)
- [ ] Manual review of schema shape before Phase 2