### PR TITLE
chore(v2): tighten dormant cleanup paths

### DIFF
--- a/commands/apply.ps1
+++ b/commands/apply.ps1
@@ -116,7 +116,8 @@ if (-not $hasV2Block) {
             $hasMig = $false
             try { $hasMig = Test-MigratorHasV1Block -ProfileFile $candidate } catch {}
             if ($hasMig) {
-                Write-Host "apply: detected v1 block in $candidate — migrating..." -ForegroundColor DarkYellow
+                Write-Host "apply: found an existing v1 block in $candidate." -ForegroundColor DarkYellow
+                Write-Host "apply: migrating it to ~/.claude/settings.json, Claude Code's native config." -ForegroundColor DarkYellow
                 try {
                     $ok = Invoke-MigratorRun -ProfileFile $candidate `
                                              -SettingsPath $SettingsPath `
@@ -124,7 +125,8 @@ if (-not $hasV2Block) {
                     if ($ok) {
                         $existingSettings = Read-Settings -Path $SettingsPath
                         $hasV2Block = $true
-                        Write-Host 'apply: migration complete.' -ForegroundColor Green
+                        Write-Host "apply: migration complete. Your new settings are now in $SettingsPath." -ForegroundColor Green
+                        Write-Host 'apply: your shell profile was left in place as a fallback, so nothing is lost.' -ForegroundColor Green
                     } else {
                         Write-Warning "apply: migration from $candidate returned false — continuing with defaults."
                     }

--- a/commands/apply.sh
+++ b/commands/apply.sh
@@ -182,15 +182,15 @@ if [[ "$HAS_V2_BLOCK" == "false" ]]; then
   )
   for candidate in "${V1_CANDIDATES[@]}"; do
     if migrator_has_v1_block "$candidate" 2>/dev/null; then
-      echo "Juggernaut: found a v1 profile block in $candidate." >&2
-      echo "  Moving your configuration to ~/.claude/settings.json (Claude Code's native config)." >&2
+      echo "Juggernaut found an existing v1 profile block in $candidate." >&2
+      echo "  We are migrating it to ~/.claude/settings.json, Claude Code's native config." >&2
       if migrator_run "$candidate" "$SETTINGS_PATH" "$BEDROCK_CONFIG_PATH"; then
         # Re-read after migration.
         EXISTING_JSON="$(config_read "$SETTINGS_PATH")"
         HAS_V2_BLOCK=true
-        echo "  Migration complete — your configuration is now in $SETTINGS_PATH." >&2
-        echo "  Nothing was removed from your shell profile; the old block stays as a fallback." >&2
-        echo "  You can remove it later with: juggernaut migrate --clean" >&2
+        echo "  Migration complete. Your new settings are now in $SETTINGS_PATH." >&2
+        echo "  Your shell profile was left in place as a fallback, so nothing is lost." >&2
+        echo "  When you are ready, you can remove the old block with: juggernaut migrate --clean" >&2
       else
         echo "  Migration encountered an error — continuing with defaults. Your profile block is unchanged." >&2
       fi
@@ -423,7 +423,10 @@ echo ""
 echo "To apply changes in this shell, restart your terminal or run:"
 case "$SHELL_TYPE" in
   fish) echo "  source ~/.config/fish/config.fish" ;;
-  *)    echo "  source $(profile_writer_detect_shell_config_path "$SHELL_TYPE")" ;;
+  *)
+    _profile_path="$(profile_writer_detect_shell_config_path "$SHELL_TYPE")"
+    printf '  source %s\n' "$_profile_path"
+    ;;
 esac
 echo ""
 if [[ "$J_AUTH_MODE" == "iam" ]]; then

--- a/lib/profile_writer.sh
+++ b/lib/profile_writer.sh
@@ -37,7 +37,7 @@ profile_writer_export_syntax() {
 # ---------------------------------------------------------------------------
 profile_writer_has_block() {
   local f="$1"
-  [[ -f "$f" ]] && grep -q "$PROFILE_WRITER_BEGIN_MARKER" "$f" 2>/dev/null
+  [[ -f "$f" ]] && grep -Fq -- "$PROFILE_WRITER_BEGIN_MARKER" "$f" 2>/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -210,7 +210,7 @@ profile_writer_write() {
     return 0
   fi
 
-  mkdir -p "$(dirname "$f")"
+  mkdir -p -- "$(dirname -- "$f")"
   [[ ! -f "$f" ]] && touch "$f"
 
   # Remove existing block first (idempotent).

--- a/tests/v2/Apply.Tests.ps1
+++ b/tests/v2/Apply.Tests.ps1
@@ -2,14 +2,14 @@
 # Run with: Invoke-Pester -Path tests/v2/Apply.Tests.ps1
 
 BeforeAll {
-    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
-    . (Join-Path $repoRoot 'lib\schema.ps1')
-    . (Join-Path $repoRoot 'lib\config_manager.ps1')
-    . (Join-Path $repoRoot 'lib\migrator.ps1')
-    . (Join-Path $repoRoot 'lib\keychain.ps1')
-    . (Join-Path $repoRoot 'lib\profile_writer.ps1')
-    $script:BedrockConfigPath = Join-Path $repoRoot 'bedrock-config.json'
-    $script:Fixtures          = Join-Path $repoRoot 'tests\v2\fixtures'
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    . (Join-Path $script:repoRoot 'lib\schema.ps1')
+    . (Join-Path $script:repoRoot 'lib\config_manager.ps1')
+    . (Join-Path $script:repoRoot 'lib\migrator.ps1')
+    . (Join-Path $script:repoRoot 'lib\keychain.ps1')
+    . (Join-Path $script:repoRoot 'lib\profile_writer.ps1')
+    $script:BedrockConfigPath = Join-Path $script:repoRoot 'bedrock-config.json'
+    $script:Fixtures          = Join-Path $script:repoRoot 'tests\v2\fixtures'
     $env:JUGGERNAUT_USE_V2    = '1'
     $env:BEDROCK_CONFIG_PATH  = $script:BedrockConfigPath
 }
@@ -341,6 +341,43 @@ Describe 'Invoke-MigratorRun — region from v1 AWS_REGION' {
     It 'meta.migratedFrom is v1.7.x' {
         $s = Read-Settings -Path $script:mig3Settings
         $s['juggernaut']['meta']['migratedFrom'] | Should -Be 'v1.7.x'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Implicit migration with project scope
+# ---------------------------------------------------------------------------
+Describe 'Invoke-MigratorRun — project scope with v1 profile' {
+    BeforeAll {
+        $tmpDir = Join-Path ([IO.Path]::GetTempPath()) ("jug-mig4-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+        $script:mig4Project = Join-Path $tmpDir 'project'
+        $script:mig4Home    = Join-Path $tmpDir 'home'
+        New-Item -ItemType Directory -Path (Join-Path $script:mig4Project '.claude') -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:mig4Home -Force | Out-Null
+        Copy-Item (Join-Path $script:Fixtures 'v1_iam_default.sh') (Join-Path $script:mig4Home '.bashrc')
+
+        $oldHome = $env:HOME
+        Push-Location $script:mig4Project
+        try {
+            $env:HOME = $script:mig4Home
+            & (Join-Path $script:repoRoot 'commands\apply.ps1') -Auth 'iam' -Scope 'project' -NoShellFallback | Out-Null
+        } finally {
+            Pop-Location
+            $env:HOME = $oldHome
+        }
+    }
+    AfterAll {
+        Remove-Item -Path (Split-Path $script:mig4Project -Parent) -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'writes project settings.json' {
+        Test-Path (Join-Path (Join-Path $script:mig4Project '.claude') 'settings.json') | Should -BeTrue
+    }
+    It 'migrates the v1 block into the project settings' {
+        $s = Read-Settings -Path (Join-Path (Join-Path $script:mig4Project '.claude') 'settings.json')
+        $s['juggernaut']['meta']['managedBy'] | Should -Be 'juggernaut'
+        $s['juggernaut']['auth']['region']    | Should -Be 'us-east-1'
     }
 }
 

--- a/tests/v2/test_apply.sh
+++ b/tests/v2/test_apply.sh
@@ -231,21 +231,33 @@ fi
 rm -rf "$TMP_DIR" "$FAKE_HOME"
 
 # ---------------------------------------------------------------------------
-# scope=project: write target changes but content is the same
+# scope=project + implicit migration
 # ---------------------------------------------------------------------------
-section "scope=project writes to \$PWD/.claude/settings.json"
-TMP_DIR="$(mktemp -d)"
-mkdir -p "$TMP_DIR/.claude"
+section "--scope=project with implicit migration"
+TMP_PROJECT="$(mktemp -d)"
+FAKE_HOME2="$(mktemp -d)"
+mkdir -p "$TMP_PROJECT/.claude"
+cp "$FIXTURES/v1_iam_default.sh" "$FAKE_HOME2/.bashrc"
 
-# Build a block and write it directly — tests the config_resolve_target logic.
-SCOPE_PATH="$(J_SCOPE=project bash -c '. "$0"/lib/config_manager.sh && config_resolve_target project' "$REPO_ROOT" 2>/dev/null || echo "")"
-# config_resolve_target project uses $PWD, so just verify the suffix is right.
-if [[ -n "$SCOPE_PATH" ]]; then
-  assert_eq "project path suffix" "${SCOPE_PATH##*/}" "settings.json"
+(
+  cd "$TMP_PROJECT" &&
+  BEDROCK_CONFIG_PATH="$BEDROCK_CONFIG_PATH" JUGGERNAUT_USE_V2=1 \
+    HOME="$FAKE_HOME2" bash "$REPO_ROOT/commands/apply.sh" \
+    --auth=iam --scope=project --no-shell-fallback \
+    >/dev/null 2>&1
+)
+RC=$?
+if [[ "$RC" -eq 0 ]]; then pass; else fail "--scope=project implicit migration should exit 0 (got $RC)"; fi
+
+if [[ -f "$TMP_PROJECT/.claude/settings.json" ]]; then
+  PROJECT_READ="$(cat "$TMP_PROJECT/.claude/settings.json")"
+  assert_eq "project/mig managedBy" "$(printf '%s' "$PROJECT_READ" | jq -r '.juggernaut.meta.managedBy')" "juggernaut"
+  assert_eq "project/mig auth.region" "$(printf '%s' "$PROJECT_READ" | jq -r '.juggernaut.auth.region')" "us-east-1"
+else
+  fail "--scope=project implicit migration did not write project settings.json"
 fi
-pass  # Non-fatal: scope path depends on CWD at runtime.
 
-rm -rf "$TMP_DIR"
+rm -rf "$TMP_PROJECT" "$FAKE_HOME2"
 
 # ---------------------------------------------------------------------------
 # profile_writer_build_block — output contains correct region and auth vars


### PR DESCRIPTION
Small v2-only cleanup for the dormant --v2 flow.

Changes:
- tighten quoting in v2 bash helpers
- soften implicit migration messaging
- add project-scope implicit migration coverage

v1 behavior remains unchanged.