### PR TITLE
feat(v2): add uninstall command

### DIFF
--- a/commands/uninstall.sh
+++ b/commands/uninstall.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# commands/uninstall.sh — Juggernaut v2 uninstall subcommand.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BEDROCK_CONFIG_PATH="${BEDROCK_CONFIG_PATH:-$SCRIPT_DIR/bedrock-config.json}"
+export BEDROCK_CONFIG_PATH
+
+v2_active="${JUGGERNAUT_USE_V2:-0}"
+DRY_RUN=false
+FORCE=false
+REQUESTED_SCOPE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --v2)         v2_active=1 ;;
+    --dry-run)    DRY_RUN=true ;;
+    --force|-f)   FORCE=true ;;
+    --scope=*)    REQUESTED_SCOPE="${arg#--scope=}" ;;
+    --version|-v) cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"; exit 0 ;;
+    --help|-h)
+      cat <<'EOF'
+juggernaut uninstall - remove Juggernaut v2 configuration
+
+Usage: juggernaut uninstall [--scope=user|project] [--dry-run] [--force]
+
+Options:
+  --scope=user|project  Limit removal to one scope (default: all scopes with a block)
+  --dry-run             Preview changes without writing files
+  --force, -f           Skip confirmation prompt
+EOF
+      exit 0 ;;
+    *) echo "uninstall: unknown option '$arg'" >&2; exit 1 ;;
+  esac
+done
+
+if [[ "$v2_active" != "1" ]]; then
+  echo "Juggernaut v2 is not active. Use --v2 to enable v2 commands." >&2
+  exit 0
+fi
+
+case "${REQUESTED_SCOPE:-}" in
+  ""|user|project) ;;
+  *) echo "uninstall: --scope must be 'user' or 'project' (got: '$REQUESTED_SCOPE')" >&2; exit 1 ;;
+esac
+
+. "$SCRIPT_DIR/lib/config_manager.sh"
+. "$SCRIPT_DIR/lib/profile_writer.sh"
+. "$SCRIPT_DIR/lib/keychain.sh"
+
+# ---------------------------------------------------------------------------
+# Detect what's installed
+# ---------------------------------------------------------------------------
+user_path="$(config_user_settings_path)"
+project_path="${PWD}/.claude/settings.json"
+
+has_user=false
+has_project=false
+
+if [[ -f "$user_path" ]]; then
+  _json="$(config_read "$user_path" 2>/dev/null || true)"
+  [[ -n "$_json" ]] && config_has_juggernaut_block "$_json" && has_user=true
+fi
+if [[ -f "$project_path" ]]; then
+  _json="$(config_read "$project_path" 2>/dev/null || true)"
+  [[ -n "$_json" ]] && config_has_juggernaut_block "$_json" && has_project=true
+fi
+
+# Apply explicit scope filter
+[[ "$REQUESTED_SCOPE" == "user" ]]    && has_project=false
+[[ "$REQUESTED_SCOPE" == "project" ]] && has_user=false
+
+# Scan all known shell profiles for the marker block
+profile_targets=()
+for _p in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.config/fish/config.fish"; do
+  profile_writer_has_block "$_p" && profile_targets+=("$_p")
+done
+
+# Detect keychain
+has_keychain=false
+if keychain_available; then
+  _key="$(keychain_get 2>/dev/null || true)"
+  [[ -n "$_key" ]] && has_keychain=true
+fi
+
+if [[ "$has_user" == "false" && "$has_project" == "false" \
+      && ${#profile_targets[@]} -eq 0 && "$has_keychain" == "false" ]]; then
+  echo "Nothing to uninstall."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Confirmation (skipped for --force and --dry-run)
+# ---------------------------------------------------------------------------
+if [[ "$FORCE" != "true" && "$DRY_RUN" != "true" ]]; then
+  echo "The following will be removed:"
+  [[ "$has_user"    == "true" ]] && printf '  - Juggernaut block from %s\n' "$user_path"
+  [[ "$has_project" == "true" ]] && printf '  - Juggernaut block from %s\n' "$project_path"
+  for _p in "${profile_targets[@]}"; do
+    printf '  - Juggernaut block from %s\n' "$_p"
+  done
+  [[ "$has_keychain" == "true" ]] && printf '  - Keychain entry: %s/%s\n' "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT"
+  echo ""
+  read -r -p "Proceed? [y/N] " _answer
+  case "$_answer" in
+    [Yy]|[Yy][Ee][Ss]) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# Execute
+# ---------------------------------------------------------------------------
+_remove_settings() {
+  local path="$1"
+  local json
+  json="$(config_read "$path")"
+  local cleaned
+  cleaned="$(config_remove_juggernaut_block "$json")"
+  config_write_atomic "$path" "$cleaned"
+  printf 'Removed Juggernaut block from %s\n' "$path"
+}
+
+if [[ "$has_user" == "true" ]]; then
+  if [[ "$DRY_RUN" == "true" ]]; then printf '[dry-run] Would remove Juggernaut block from %s\n' "$user_path"
+  else _remove_settings "$user_path"; fi
+fi
+
+if [[ "$has_project" == "true" ]]; then
+  if [[ "$DRY_RUN" == "true" ]]; then printf '[dry-run] Would remove Juggernaut block from %s\n' "$project_path"
+  else _remove_settings "$project_path"; fi
+fi
+
+for _p in "${profile_targets[@]}"; do
+  if [[ "$DRY_RUN" == "true" ]]; then printf '[dry-run] Would remove Juggernaut block from %s\n' "$_p"
+  else profile_writer_remove_block "$_p"; printf 'Removed Juggernaut block from %s\n' "$_p"; fi
+done
+
+if [[ "$has_keychain" == "true" ]]; then
+  if [[ "$DRY_RUN" == "true" ]]; then
+    printf '[dry-run] Would remove keychain entry: %s/%s\n' "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT"
+  else
+    keychain_delete
+    printf 'Removed keychain entry: %s/%s\n' "$KEYCHAIN_SERVICE" "$KEYCHAIN_ACCOUNT"
+  fi
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "No files were changed."
+else
+  echo ""
+  echo "Uninstall complete."
+fi

--- a/juggernaut
+++ b/juggernaut
@@ -50,7 +50,7 @@ Subcommands:
   migrate     Migrate a v1 profile block to settings.json
   show        Print current Juggernaut configuration
   doctor      Verify configuration and connectivity (not yet implemented)
-  uninstall   Remove Juggernaut configuration (not yet implemented)
+  uninstall   Remove Juggernaut configuration
 
 Common options (apply):
   --auth=iam|api-key       Authentication mode (default: iam)
@@ -100,8 +100,7 @@ case "$SUBCMD" in
     exec "$SCRIPT_DIR/commands/doctor.sh" "$@"
     ;;
   uninstall)
-    echo "juggernaut uninstall: not yet implemented in Phase 3" >&2
-    exit 1
+    exec "$SCRIPT_DIR/commands/uninstall.sh" "$@"
     ;;
   --version|-v)
     cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"

--- a/tests/v2/test_uninstall.sh
+++ b/tests/v2/test_uninstall.sh
@@ -33,14 +33,15 @@ unset AWS_BEARER_TOKEN_BEDROCK 2>/dev/null || true
 . "$REPO_ROOT/lib/keychain.sh"
 set +e
 
-# Stash and clear any real keychain entry so tests run in isolation.
-_saved_keychain_key="$(keychain_get 2>/dev/null || true)"
-if [[ -n "$_saved_keychain_key" ]]; then keychain_delete 2>/dev/null || true; fi
-trap '_trap_exit' EXIT
 _trap_exit() {
   rm -rf "$TMP_HOME" "$TMP_WORK"
   if [[ -n "$_saved_keychain_key" ]]; then keychain_store "$_saved_keychain_key" 2>/dev/null || true; fi
 }
+
+# Stash and clear any real keychain entry so tests run in isolation.
+_saved_keychain_key="$(keychain_get 2>/dev/null || true)"
+if [[ -n "$_saved_keychain_key" ]]; then keychain_delete 2>/dev/null || true; fi
+trap '_trap_exit' EXIT
 
 write_settings() {
   local path="$1" region="${2:-us-west-2}"

--- a/tests/v2/test_uninstall.sh
+++ b/tests/v2/test_uninstall.sh
@@ -35,8 +35,12 @@ set +e
 
 # Stash and clear any real keychain entry so tests run in isolation.
 _saved_keychain_key="$(keychain_get 2>/dev/null || true)"
-[[ -n "$_saved_keychain_key" ]] && keychain_delete 2>/dev/null || true
-trap 'rm -rf "$TMP_HOME" "$TMP_WORK"; [[ -n "$_saved_keychain_key" ]] && keychain_store "$_saved_keychain_key" 2>/dev/null || true' EXIT
+if [[ -n "$_saved_keychain_key" ]]; then keychain_delete 2>/dev/null || true; fi
+trap '_trap_exit' EXIT
+_trap_exit() {
+  rm -rf "$TMP_HOME" "$TMP_WORK"
+  if [[ -n "$_saved_keychain_key" ]]; then keychain_store "$_saved_keychain_key" 2>/dev/null || true; fi
+}
 
 write_settings() {
   local path="$1" region="${2:-us-west-2}"

--- a/tests/v2/test_uninstall.sh
+++ b/tests/v2/test_uninstall.sh
@@ -33,15 +33,10 @@ unset AWS_BEARER_TOKEN_BEDROCK 2>/dev/null || true
 . "$REPO_ROOT/lib/keychain.sh"
 set +e
 
-_trap_exit() {
-  rm -rf "$TMP_HOME" "$TMP_WORK"
-  if [[ -n "$_saved_keychain_key" ]]; then keychain_store "$_saved_keychain_key" 2>/dev/null || true; fi
-}
-
 # Stash and clear any real keychain entry so tests run in isolation.
 _saved_keychain_key="$(keychain_get 2>/dev/null || true)"
 if [[ -n "$_saved_keychain_key" ]]; then keychain_delete 2>/dev/null || true; fi
-trap '_trap_exit' EXIT
+trap 'rm -rf "$TMP_HOME" "$TMP_WORK"; if [[ -n "$_saved_keychain_key" ]]; then keychain_store "$_saved_keychain_key" 2>/dev/null || true; fi' EXIT
 
 write_settings() {
   local path="$1" region="${2:-us-west-2}"

--- a/tests/v2/test_uninstall.sh
+++ b/tests/v2/test_uninstall.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# tests/v2/test_uninstall.sh — integration tests for commands/uninstall.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PASS=0; FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+pass() { PASS=$((PASS + 1)); }
+section() { echo; echo "== $1 =="; }
+
+# ── v2 gate ──────────────────────────────────────────────────────────────────
+section "v2 gate"
+output="$(bash "$REPO_ROOT/commands/uninstall.sh" 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$output" == *"Juggernaut v2 is not active"* ]]; then pass
+else fail "expected inactive msg (rc=$rc): $output"; fi
+
+# ── Setup fixtures ────────────────────────────────────────────────────────────
+TMP_HOME="$(mktemp -d)"
+TMP_WORK="$(mktemp -d)"
+mkdir -p "$TMP_HOME/.claude" "$TMP_WORK/.claude"
+
+export HOME="$TMP_HOME"
+export BEDROCK_CONFIG_PATH="$REPO_ROOT/bedrock-config.json"
+export JUGGERNAUT_USE_V2=1
+export SHELL="/bin/bash"
+unset AWS_BEARER_TOKEN_BEDROCK 2>/dev/null || true
+
+. "$REPO_ROOT/lib/schema.sh"
+. "$REPO_ROOT/lib/config_manager.sh"
+. "$REPO_ROOT/lib/keychain.sh"
+set +e
+
+# Stash and clear any real keychain entry so tests run in isolation.
+_saved_keychain_key="$(keychain_get 2>/dev/null || true)"
+[[ -n "$_saved_keychain_key" ]] && keychain_delete 2>/dev/null || true
+trap 'rm -rf "$TMP_HOME" "$TMP_WORK"; [[ -n "$_saved_keychain_key" ]] && keychain_store "$_saved_keychain_key" 2>/dev/null || true' EXIT
+
+write_settings() {
+  local path="$1" region="${2:-us-west-2}"
+  local block
+  block="$(J_AUTH_MODE=iam J_REGION="$region" J_EFFORT=xhigh J_STORAGE=profile \
+    J_USE_MANTLE=false J_OPUSPLAN=false J_SCOPE=user J_VERSION=2.0.0 \
+    J_SHELL_FALLBACK_MODE=settings-only schema_new_juggernaut_block)"
+  config_write_atomic "$path" "$(config_merge_juggernaut_block '{}' "$block" "$(schema_derive_native_keys "$block")")"
+}
+
+run_uninstall() { bash "$REPO_ROOT/commands/uninstall.sh" "$@"; }
+
+# ── Nothing to uninstall ──────────────────────────────────────────────────────
+section "nothing installed: clean exit"
+output="$(run_uninstall --dry-run 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$output" == *"Nothing to uninstall"* ]]; then pass
+else fail "expected 'Nothing to uninstall' (rc=$rc): $output"; fi
+
+# ── Dry-run: user scope ───────────────────────────────────────────────────────
+section "dry-run shows what would change and leaves files untouched"
+write_settings "$TMP_HOME/.claude/settings.json"
+output="$(run_uninstall --dry-run 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$output" == *"[dry-run]"* && "$output" == *"settings.json"* && "$output" == *"No files were changed"* ]]; then pass
+else fail "unexpected dry-run output (rc=$rc): $output"; fi
+if config_has_juggernaut_block "$(cat "$TMP_HOME/.claude/settings.json")"; then pass
+else fail "dry-run must not modify settings.json"; fi
+
+# ── Real uninstall: removes block, preserves unrelated keys ──────────────────
+section "removes juggernaut block, preserves unrelated keys"
+write_settings "$TMP_HOME/.claude/settings.json"
+jq '. + {"permissions": {"allow": ["Bash"]}}' "$TMP_HOME/.claude/settings.json" \
+  > "$TMP_HOME/.claude/settings.json.tmp" && mv "$TMP_HOME/.claude/settings.json.tmp" "$TMP_HOME/.claude/settings.json"
+run_uninstall --force >/dev/null 2>&1
+remaining="$(cat "$TMP_HOME/.claude/settings.json")"
+if ! config_has_juggernaut_block "$remaining"; then pass
+else fail "juggernaut block still present"; fi
+if echo "$remaining" | jq -e '.permissions' >/dev/null 2>&1; then pass
+else fail "unrelated key 'permissions' was removed"; fi
+if echo "$remaining" | jq -e '.env // empty' | grep -qv null 2>/dev/null; then
+  fail "native key .env was not cleaned up"
+else pass; fi
+
+# ── Default scope: both scopes ────────────────────────────────────────────────
+section "default scope removes all scopes with a block"
+write_settings "$TMP_HOME/.claude/settings.json"
+write_settings "$TMP_WORK/.claude/settings.json" eu-west-1
+output="$(cd "$TMP_WORK" && run_uninstall --force 2>&1)"; rc=$?
+if [[ $rc -eq 0 \
+      && "$output" == *"$TMP_HOME/.claude/settings.json"* \
+      && "$output" == *"$TMP_WORK/.claude/settings.json"* ]]; then pass
+else fail "expected both scopes removed (rc=$rc): $output"; fi
+if config_has_juggernaut_block "$(cat "$TMP_HOME/.claude/settings.json")"; then
+  fail "user block still present after default-scope uninstall"
+else pass; fi
+if config_has_juggernaut_block "$(cat "$TMP_WORK/.claude/settings.json")"; then
+  fail "project block still present after default-scope uninstall"
+else pass; fi
+
+# ── Explicit scope: only requested scope removed ──────────────────────────────
+section "--scope=user removes only user scope"
+write_settings "$TMP_HOME/.claude/settings.json"
+write_settings "$TMP_WORK/.claude/settings.json" eu-west-1
+(cd "$TMP_WORK" && run_uninstall --scope=user --force >/dev/null 2>&1)
+if config_has_juggernaut_block "$(cat "$TMP_HOME/.claude/settings.json")"; then
+  fail "user block should have been removed"
+else pass; fi
+if config_has_juggernaut_block "$(cat "$TMP_WORK/.claude/settings.json")"; then pass
+else fail "project block was incorrectly removed"; fi
+
+# ── Profile block removal ─────────────────────────────────────────────────────
+section "removes profile block, leaves non-block content"
+write_settings "$TMP_HOME/.claude/settings.json"
+printf '# existing content\n\n%s\nexport AWS_REGION="us-west-2"\n%s\n' \
+  "# BEGIN: Claude Code Bedrock Configuration" \
+  "# END: Claude Code Bedrock Configuration" > "$TMP_HOME/.bashrc"
+output="$(run_uninstall --force 2>&1)"; rc=$?
+if [[ $rc -eq 0 ]] && ! grep -q "BEGIN: Claude Code Bedrock Configuration" "$TMP_HOME/.bashrc"; then pass
+else fail "profile block still present (rc=$rc): $output"; fi
+if grep -q "existing content" "$TMP_HOME/.bashrc"; then pass
+else fail "non-block content was removed from profile"; fi
+
+# ── Idempotent ────────────────────────────────────────────────────────────────
+section "idempotent: second call is a no-op"
+output="$(run_uninstall --force 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$output" == *"Nothing to uninstall"* ]]; then pass
+else fail "second uninstall not idempotent (rc=$rc): $output"; fi
+
+# ── Invalid scope rejected ────────────────────────────────────────────────────
+section "rejects invalid scope"
+output="$(run_uninstall --scope=invalid 2>&1)"; rc=$?
+if [[ $rc -ne 0 && "$output" == *"scope"* ]]; then pass
+else fail "expected error for invalid scope (rc=$rc): $output"; fi
+
+echo
+echo "uninstall.sh tests: $PASS passed, $FAIL failed"
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- Implements `juggernaut uninstall` (bash side) as part of Phase 5
- `commands/uninstall.sh`: removes the Juggernaut block from `settings.json` (user and/or project scope), marker blocks from shell profiles, and OS keychain entries — without touching unrelated keys
- Default scope (no `--scope` flag) removes all scopes that contain a Juggernaut block
- `--dry-run`, `--force`, `--scope=user|project` flags fully supported
- Idempotent: clean `Nothing to uninstall.` message when nothing is found
- `tests/v2/test_uninstall.sh`: 16 integration tests (all passing)
- `juggernaut` dispatcher: stub replaced with live dispatch, help text updated

**Not yet included:** PowerShell implementation (`commands/uninstall.ps1`, `tests/v2/Uninstall.Tests.ps1`, `juggernaut.ps1` wiring) — pending review of this bash side first.

## Test plan

- [x] `bash tests/v2/test_uninstall.sh` — 16 passed, 0 failed
- [x] `JUGGERNAUT_USE_V2=1 bash juggernaut uninstall --help` — prints help, exits 0
- [x] Lint — pass
- [x] Test on ubuntu-latest — pass
- [x] Test on macos-latest — pass
- [x] Test on Windows (Git Bash) — pass
- [x] Test on Windows (PowerShell) — pass
- [x] Codacy Static Code Analysis — pass
- [x] CodeQL — pass