### PR TITLE
feat(v2): add uninstall command (PowerShell)

### DIFF
--- a/commands/uninstall.ps1
+++ b/commands/uninstall.ps1
@@ -1,0 +1,153 @@
+# commands/uninstall.ps1 — Juggernaut v2 uninstall subcommand.
+
+[CmdletBinding(PositionalBinding=$false)]
+param(
+    [string]$Scope = '',
+    [switch]$DryRun,
+    [Alias('f')][switch]$Force,
+    [Alias('v2')][switch]$UseV2,
+    [switch]$Help,
+    [switch]$Version,
+    [Parameter(ValueFromRemainingArguments=$true)][string[]]$RemainingArgs
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+$env:BEDROCK_CONFIG_PATH = if ($env:BEDROCK_CONFIG_PATH) { $env:BEDROCK_CONFIG_PATH } else { Join-Path $RepoRoot 'bedrock-config.json' }
+
+$v2Active = ($env:JUGGERNAUT_USE_V2 -eq '1') -or $UseV2
+foreach ($arg in $RemainingArgs) {
+    switch -Regex ($arg) {
+        '^--v2$'                   { $v2Active = $true }
+        '^--dry-run$'              { $DryRun = $true }
+        '^--force$|^-f$'           { $Force = $true }
+        '^--scope=(user|project)$' { $Scope = $Matches[1] }
+        '^--scope='                { Write-Error "uninstall: --scope must be 'user' or 'project' (got: '$($arg.Substring(8))')"; exit 1 }
+        '^--help$|^-h$'            { $Help = $true }
+        '^--version$|^-v$'         { $Version = $true }
+        default                    { Write-Error "uninstall: unknown option '$arg'"; exit 1 }
+    }
+}
+
+if ($Help) {
+    @'
+juggernaut uninstall - remove Juggernaut v2 configuration
+
+Usage: juggernaut.ps1 uninstall [-Scope user|project] [-DryRun] [-Force]
+
+Options:
+  -Scope user|project  Limit removal to one scope (default: all scopes with a block)
+  -DryRun              Preview changes without writing files
+  -Force               Skip confirmation prompt
+'@
+    exit 0
+}
+
+if ($Version) {
+    $vf = Join-Path $RepoRoot 'VERSION'
+    if (Test-Path $vf) { Get-Content $vf -Raw } else { 'unknown' }
+    exit 0
+}
+
+if (-not $v2Active) {
+    Write-Output 'Juggernaut v2 is not active. Use --v2 to enable v2 commands.'
+    exit 0
+}
+
+if ($Scope -and $Scope -notin @('user', 'project')) {
+    Write-Error "uninstall: --scope must be 'user' or 'project' (got: '$Scope')"
+    exit 1
+}
+
+. (Join-Path $RepoRoot 'lib\config_manager.ps1')
+. (Join-Path $RepoRoot 'lib\profile_writer.ps1')
+. (Join-Path $RepoRoot 'lib\keychain.ps1')
+
+# ---------------------------------------------------------------------------
+# Detect what's installed
+# ---------------------------------------------------------------------------
+$userPath    = Get-UserSettingsPath
+$projectPath = Join-Path (Get-Location).Path '.claude\settings.json'
+
+$hasUser = $false; $hasProject = $false
+
+if (Test-Path $userPath) {
+    $j = try { Read-Settings -Path $userPath } catch { $null }
+    if ($j -and (Test-HasJuggernautBlock -Settings $j)) { $hasUser = $true }
+}
+if (Test-Path $projectPath) {
+    $j = try { Read-Settings -Path $projectPath } catch { $null }
+    if ($j -and (Test-HasJuggernautBlock -Settings $j)) { $hasProject = $true }
+}
+
+if ($Scope -eq 'user')    { $hasProject = $false }
+if ($Scope -eq 'project') { $hasUser    = $false }
+
+# Scan known shell profiles for the marker block
+$homePath = if ($env:HOME) { $env:HOME } elseif ($env:USERPROFILE) { $env:USERPROFILE } else { '' }
+$profileTargets = @()
+foreach ($shell in @('bash', 'zsh', 'fish')) {
+    $p = Get-ProfileWriterShellConfigPath -Shell $shell
+    if ($p -and (Test-ProfileWriterHasBlock -ProfileFile $p)) {
+        $profileTargets += $p
+    }
+}
+
+$hasKeychain = $false
+if (Test-KeychainAvailable) {
+    $kv = try { Get-KeychainEntry } catch { $null }
+    if ($kv) { $hasKeychain = $true }
+}
+
+if (-not ($hasUser -or $hasProject -or $profileTargets.Count -gt 0 -or $hasKeychain)) {
+    Write-Output 'Nothing to uninstall.'
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Confirmation
+# ---------------------------------------------------------------------------
+if (-not $Force -and -not $DryRun) {
+    Write-Output 'The following will be removed:'
+    if ($hasUser)    { Write-Output "  - Juggernaut block from $userPath" }
+    if ($hasProject) { Write-Output "  - Juggernaut block from $projectPath" }
+    foreach ($p in $profileTargets) { Write-Output "  - Juggernaut block from $p" }
+    if ($hasKeychain) { Write-Output "  - Keychain entry: $($script:KeychainService)/$($script:KeychainAccount)" }
+    Write-Output ''
+    $answer = Read-Host 'Proceed? [y/N]'
+    if ($answer -notmatch '^[Yy]') { Write-Output 'Aborted.'; exit 0 }
+}
+
+# ---------------------------------------------------------------------------
+# Execute
+# ---------------------------------------------------------------------------
+function Remove-SettingsBlock([string]$Path) {
+    $json    = Read-Settings -Path $Path
+    $cleaned = Remove-JuggernautBlockFromSettings -Existing $json
+    Write-SettingsAtomic -Path $Path -Content $cleaned
+    Write-Output "Removed Juggernaut block from $($Path.Replace('\', '/'))"
+}
+
+if ($hasUser) {
+    if ($DryRun) { Write-Output "[dry-run] Would remove Juggernaut block from $($userPath.Replace('\', '/'))" }
+    else         { Remove-SettingsBlock $userPath }
+}
+if ($hasProject) {
+    if ($DryRun) { Write-Output "[dry-run] Would remove Juggernaut block from $($projectPath.Replace('\', '/'))" }
+    else         { Remove-SettingsBlock $projectPath }
+}
+foreach ($p in $profileTargets) {
+    if ($DryRun) { Write-Output "[dry-run] Would remove Juggernaut block from $p" }
+    else         { Remove-ProfileWriterBlock -ProfileFile $p; Write-Output "Removed Juggernaut block from $p" }
+}
+if ($hasKeychain) {
+    if ($DryRun) { Write-Output "[dry-run] Would remove keychain entry: $($script:KeychainService)/$($script:KeychainAccount)" }
+    else         { Remove-KeychainEntry; Write-Output "Removed keychain entry: $($script:KeychainService)/$($script:KeychainAccount)" }
+}
+
+if ($DryRun) {
+    Write-Output 'No files were changed.'
+} else {
+    Write-Output ''
+    Write-Output 'Uninstall complete.'
+}

--- a/juggernaut.ps1
+++ b/juggernaut.ps1
@@ -32,7 +32,7 @@ Subcommands:
   migrate     Migrate a v1 profile block to settings.json
   show        Print current Juggernaut configuration
   doctor      Verify configuration and connectivity (not yet implemented)
-  uninstall   Remove Juggernaut configuration (not yet implemented)
+  uninstall   Remove Juggernaut configuration
 
 Run 'juggernaut.ps1 apply --help' for apply-specific options.
 '@
@@ -80,8 +80,9 @@ switch ($Subcommand) {
         exit $LASTEXITCODE
     }
     'uninstall' {
-        Write-Error "juggernaut ${Subcommand}: not yet implemented in Phase 4"
-        exit 1
+        $uninstallScript = Join-Path $PSScriptRoot_ 'commands\uninstall.ps1'
+        & $uninstallScript @subcommandArgs
+        exit $LASTEXITCODE
     }
     { $_ -in '--version','-v' } {
         $vf = Join-Path $PSScriptRoot_ 'VERSION'

--- a/tests/v2/Uninstall.Tests.ps1
+++ b/tests/v2/Uninstall.Tests.ps1
@@ -1,0 +1,190 @@
+# tests/v2/Uninstall.Tests.ps1 - Pester 5 tests for commands/uninstall.ps1
+
+BeforeAll {
+    function Get-RepoRoot {
+        if ($env:GITHUB_WORKSPACE) { return $env:GITHUB_WORKSPACE }
+        return (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    }
+    $script:RepoRoot = Get-RepoRoot
+    . (Join-Path $script:RepoRoot 'lib\schema.ps1')
+    . (Join-Path $script:RepoRoot 'lib\config_manager.ps1')
+    . (Join-Path $script:RepoRoot 'lib\keychain.ps1')
+    $script:BedrockConfigPath = Join-Path $script:RepoRoot 'bedrock-config.json'
+    $script:UninstallScript   = Join-Path $script:RepoRoot 'commands\uninstall.ps1'
+    $env:BEDROCK_CONFIG_PATH  = $script:BedrockConfigPath
+
+    function New-TestDirs {
+        $h = Join-Path ([IO.Path]::GetTempPath()) ("jug-ui-h-" + [Guid]::NewGuid().ToString('N'))
+        $w = Join-Path ([IO.Path]::GetTempPath()) ("jug-ui-w-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $h '.claude') -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $w '.claude') -Force | Out-Null
+        return @{ Home = $h; Work = $w }
+    }
+
+    function Write-TestSettings($path, $region = 'us-west-2') {
+        $block = New-JuggernautBlock -AuthMode 'iam' -Region $region -Storage 'profile' `
+            -UseMantle $false -ShellFallbackMode 'settings-only' -Scope 'user' `
+            -BedrockConfigPath $script:BedrockConfigPath
+        $merged = Merge-JuggernautBlock -Existing ([ordered]@{}) -NewBlock $block `
+            -NativeKeys (Get-NativeKeysFromJuggernautBlock -Block $block)
+        Write-SettingsAtomic -Path $path -Content $merged
+    }
+
+    function Invoke-Uninstall($d, $params = @{}) {
+        $oldHome    = $env:HOME
+        $oldProfile = $env:USERPROFILE
+        $oldV2      = $env:JUGGERNAUT_USE_V2
+        $oldBedrock = $env:BEDROCK_CONFIG_PATH
+        $oldLoc     = (Get-Location).Path
+        try {
+            $env:HOME = $d.Home; $env:USERPROFILE = $d.Home
+            $env:JUGGERNAUT_USE_V2 = '1'
+            $env:BEDROCK_CONFIG_PATH = $script:BedrockConfigPath
+            Set-Variable -Name HOME -Value $d.Home -Scope Global -Force
+            Set-Location $d.Work
+            $output = & $script:UninstallScript @params 2>&1 | Out-String
+            return @{ Output = $output; ExitCode = $LASTEXITCODE }
+        } finally {
+            Set-Location $oldLoc
+            Set-Variable -Name HOME -Value $oldHome -Scope Global -Force
+            $env:HOME = $oldHome; $env:USERPROFILE = $oldProfile
+            $env:JUGGERNAUT_USE_V2 = $oldV2
+            $env:BEDROCK_CONFIG_PATH = $oldBedrock
+        }
+    }
+
+    function Remove-TestDirs($d) {
+        Remove-Item -Path $d.Home, $d.Work -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'uninstall.ps1' {
+
+    # ---------------------------------------------------------------------------
+    # v2 gate
+    # ---------------------------------------------------------------------------
+    It 'exits 0 with inactive message when v2 flag absent' {
+        $oldV2 = $env:JUGGERNAUT_USE_V2
+        try {
+            $env:JUGGERNAUT_USE_V2 = '0'
+            $output = & $script:UninstallScript 2>&1 | Out-String
+            $output | Should -Match 'Juggernaut v2 is not active'
+            $LASTEXITCODE | Should -Be 0
+        } finally {
+            $env:JUGGERNAUT_USE_V2 = $oldV2
+        }
+    }
+
+    # ---------------------------------------------------------------------------
+    # nothing installed
+    # ---------------------------------------------------------------------------
+    It 'reports nothing to uninstall when no block present' {
+        $d = New-TestDirs
+        try {
+            $r = Invoke-Uninstall $d @{ DryRun = $true }
+            $r.Output | Should -Match 'Nothing to uninstall'
+        } finally { Remove-TestDirs $d }
+    }
+
+    # ---------------------------------------------------------------------------
+    # dry-run
+    # ---------------------------------------------------------------------------
+    It 'dry-run shows what would change and leaves files untouched' {
+        $d = New-TestDirs
+        try {
+            Write-TestSettings (Join-Path $d.Home '.claude\settings.json')
+            $r = Invoke-Uninstall $d @{ DryRun = $true }
+            $r.Output | Should -Match '\[dry-run\]'
+            $r.Output | Should -Match 'settings\.json'
+            $r.Output | Should -Match 'No files were changed'
+            $remaining = Read-Settings -Path (Join-Path $d.Home '.claude\settings.json')
+            (Test-HasJuggernautBlock -Settings $remaining) | Should -Be $true
+        } finally { Remove-TestDirs $d }
+    }
+
+    # ---------------------------------------------------------------------------
+    # real uninstall: removes block, preserves unrelated keys
+    # ---------------------------------------------------------------------------
+    It 'removes juggernaut block and preserves unrelated keys' {
+        $d = New-TestDirs
+        try {
+            $p = Join-Path $d.Home '.claude\settings.json'
+            Write-TestSettings $p
+            $json = Get-Content $p -Raw | ConvertFrom-Json
+            $json | Add-Member -NotePropertyName 'permissions' -NotePropertyValue ([pscustomobject]@{ allow = @('Bash') }) -Force
+            $json | ConvertTo-Json -Depth 10 | Set-Content $p -Encoding utf8
+            Invoke-Uninstall $d @{ Force = $true } | Out-Null
+            $remaining = Get-Content $p -Raw | ConvertFrom-Json
+            ($remaining.PSObject.Properties.Name) | Should -Not -Contain 'juggernaut'
+            ($remaining.PSObject.Properties.Name) | Should -Not -Contain 'env'
+            ($remaining.PSObject.Properties.Name) | Should -Not -Contain 'model'
+            $remaining.permissions | Should -Not -BeNullOrEmpty
+        } finally { Remove-TestDirs $d }
+    }
+
+    # ---------------------------------------------------------------------------
+    # default scope: both user and project
+    # ---------------------------------------------------------------------------
+    It 'default scope removes both user and project blocks' {
+        $d = New-TestDirs
+        try {
+            Write-TestSettings (Join-Path $d.Home '.claude\settings.json')
+            Write-TestSettings (Join-Path $d.Work '.claude\settings.json') 'eu-west-1'
+            $r = Invoke-Uninstall $d @{ Force = $true }
+            $r.Output | Should -Match 'settings\.json'
+            $uRemain = Read-Settings -Path (Join-Path $d.Home '.claude\settings.json')
+            (Test-HasJuggernautBlock -Settings $uRemain) | Should -Be $false
+            $pRemain = Read-Settings -Path (Join-Path $d.Work '.claude\settings.json')
+            (Test-HasJuggernautBlock -Settings $pRemain) | Should -Be $false
+        } finally { Remove-TestDirs $d }
+    }
+
+    # ---------------------------------------------------------------------------
+    # explicit scope
+    # ---------------------------------------------------------------------------
+    It '-Scope user removes only user block' {
+        $d = New-TestDirs
+        try {
+            Write-TestSettings (Join-Path $d.Home '.claude\settings.json')
+            Write-TestSettings (Join-Path $d.Work '.claude\settings.json') 'eu-west-1'
+            Invoke-Uninstall $d @{ Scope = 'user'; Force = $true } | Out-Null
+            $uRemain = Read-Settings -Path (Join-Path $d.Home '.claude\settings.json')
+            (Test-HasJuggernautBlock -Settings $uRemain) | Should -Be $false
+            $pRemain = Read-Settings -Path (Join-Path $d.Work '.claude\settings.json')
+            (Test-HasJuggernautBlock -Settings $pRemain) | Should -Be $true
+        } finally { Remove-TestDirs $d }
+    }
+
+    # ---------------------------------------------------------------------------
+    # idempotent
+    # ---------------------------------------------------------------------------
+    It 'is idempotent: second call reports nothing to uninstall' {
+        $d = New-TestDirs
+        try {
+            Write-TestSettings (Join-Path $d.Home '.claude\settings.json')
+            Invoke-Uninstall $d @{ Force = $true } | Out-Null
+            $r = Invoke-Uninstall $d @{ Force = $true }
+            $r.Output | Should -Match 'Nothing to uninstall'
+        } finally { Remove-TestDirs $d }
+    }
+
+    # ---------------------------------------------------------------------------
+    # invalid scope
+    # ---------------------------------------------------------------------------
+    It 'rejects an invalid scope value' {
+        $oldV2 = $env:JUGGERNAUT_USE_V2
+        try {
+            $env:JUGGERNAUT_USE_V2 = '1'
+            $caught = $false
+            try {
+                & $script:UninstallScript -Scope 'invalid' 2>&1 | Out-Null
+            } catch {
+                $caught = $true
+                $_.ToString() | Should -Match 'scope'
+            }
+            $caught | Should -Be $true
+        } finally {
+            $env:JUGGERNAUT_USE_V2 = $oldV2
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `commands/uninstall.ps1`: PowerShell mirror of the bash uninstall command — removes `.juggernaut` block + derived native keys from `settings.json`, marker blocks from shell profiles, and OS keychain entries without touching unrelated keys
- Default scope (no `-Scope`) removes all scopes that contain a Juggernaut block
- `-DryRun`, `-Force`, `-Scope user|project` flags match bash behavior exactly
- Idempotent: `Nothing to uninstall.` when nothing is found
- `tests/v2/Uninstall.Tests.ps1`: 8 Pester 5 tests
- `juggernaut.ps1`: stub replaced with live dispatch, help text updated

## Test plan

- [ ] `pwsh -Command "Invoke-Pester ./tests/v2/Uninstall.Tests.ps1"` — 8 passed, 0 failed
- [ ] `$env:JUGGERNAUT_USE_V2='1'; & './juggernaut.ps1' uninstall --help` — prints help, exits 0
- [ ] Full Pester suite — 133 passed, 0 failed
- [ ] CI Lint — pass
- [ ] CI Test on ubuntu-latest — pass
- [ ] CI Test on macos-latest — pass
- [ ] CI Test on Windows (Git Bash) — pass
- [ ] CI Test on Windows (PowerShell) — pass
- [ ] CI Codacy Static Code Analysis — pass
- [ ] CI CodeQL — pass