### PR TITLE
feat: add version pinning to installers + final v2.0 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,6 @@ See [Model Switching on Bedrock](#model-switching-on-bedrock-v16) for details.
 - Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
 - AWS CLI configured (`aws configure` or SSO)
 
-**Install v2.0.0 (recommended — pinned, stable):**
-```bash
-# Unix/macOS/Linux
-curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --version 2.0.0
-
-# Windows PowerShell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Version 2.0.0
-```
-
 **Install latest (always tracks main):**
 ```bash
 # Unix/macOS/Linux
@@ -167,10 +158,19 @@ curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.s
 irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1 | iex
 ```
 
+**Install a pinned version (recommended for stability):**
+```bash
+# Unix/macOS/Linux
+curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --version 2.0.0
+
+# Windows PowerShell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Version 2.0.0
+```
+
 **One-Command Setup (manual clone):**
 ```bash
 # Clone and run setup
-git clone --branch 2.0.0 --depth 1 https://github.com/jpvelasco/juggernaut.git && cd juggernaut
+git clone --branch v2.0.0 --depth 1 https://github.com/jpvelasco/juggernaut.git && cd juggernaut
 ./setup  # Auto-detects your OS and shell
 
 # Apply configuration
@@ -179,6 +179,24 @@ source ~/.zshrc  # or ~/.bashrc
 # Launch Claude Code
 claude
 ```
+
+### Version Pinning
+
+By default, the installer clones the `main` branch (always latest). Pass `--version` to install a specific release tag instead:
+
+```bash
+# Bash — accepts "2.0.0" or "v2.0.0"
+curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --version 2.0.0
+
+# PowerShell — accepts "2.0.0" or "v2.0.0"
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Version 2.0.0
+
+# After downloading
+bash install.sh --version 2.0.0
+.\install.ps1 -Version 2.0.0
+```
+
+Both scripts normalize the version automatically — `2.0.0` and `v2.0.0` both work. Extra arguments after `--version <tag>` are forwarded to the setup script.
 
 **Verification:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -149,20 +149,28 @@ See [Model Switching on Bedrock](#model-switching-on-bedrock-v16) for details.
 - Claude Code installed (`npm install -g @anthropic-ai/claude-code`)
 - AWS CLI configured (`aws configure` or SSO)
 
-**One-Line Install (fastest):**
+**Install v2.0.0 (recommended — pinned, stable):**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash
+# Unix/macOS/Linux
+curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --version 2.0.0
+
+# Windows PowerShell
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Version 2.0.0
 ```
 
-**Windows PowerShell:**
-```powershell
+**Install latest (always tracks main):**
+```bash
+# Unix/macOS/Linux
+curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash
+
+# Windows PowerShell
 irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1 | iex
 ```
 
-**One-Command Setup:**
+**One-Command Setup (manual clone):**
 ```bash
 # Clone and run setup
-git clone https://github.com/jpvelasco/juggernaut.git && cd juggernaut
+git clone --branch 2.0.0 --depth 1 https://github.com/jpvelasco/juggernaut.git && cd juggernaut
 ./setup  # Auto-detects your OS and shell
 
 # Apply configuration

--- a/install.ps1
+++ b/install.ps1
@@ -1,24 +1,59 @@
 #Requires -Version 5.1
-$ErrorActionPreference = "Stop"
+# install.ps1 — Juggernaut installer
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1 | iex
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Version 2.0.0
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Latest
+#
+# Or after downloading:
+#   .\install.ps1 -Version 2.0.0
+#   .\install.ps1 -Latest
+
+param(
+    [string]$Version = '',
+    [switch]$Latest,
+    [Parameter(ValueFromRemainingArguments=$true)][string[]]$SetupArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Latest) { $Version = '' }
+
+$RepoUrl    = 'https://github.com/jpvelasco/juggernaut.git'
+$InstallDir = if ($env:JUGGERNAUT_DIR) { $env:JUGGERNAUT_DIR } else { Join-Path $HOME '.juggernaut' }
+
+if ($Version) {
+    Write-Host "Installing Juggernaut $Version..."
+} else {
+    Write-Host 'Installing Juggernaut (latest)...'
+}
 
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Error "git is required but not installed"
+    Write-Error 'git is required but not installed'
     exit 1
 }
 
-$RepoUrl = "https://github.com/jpvelasco/juggernaut.git"
-$InstallDir = if ($env:JUGGERNAUT_DIR) { $env:JUGGERNAUT_DIR } else { Join-Path $HOME ".juggernaut" }
-
-Write-Host "Installing Juggernaut..."
-
 if (Test-Path $InstallDir) {
     Write-Host "Updating existing installation in $InstallDir"
-    git -C $InstallDir pull --ff-only
-    if ($LASTEXITCODE -ne 0) { throw "git pull failed" }
+    git -C $InstallDir fetch --tags --quiet
+    if ($LASTEXITCODE -ne 0) { throw 'git fetch failed' }
+    if ($Version) {
+        git -C $InstallDir checkout --quiet $Version
+    } else {
+        git -C $InstallDir checkout --quiet main
+        git -C $InstallDir pull --ff-only --quiet
+    }
+    if ($LASTEXITCODE -ne 0) { throw 'git checkout/pull failed' }
 } else {
-    git clone $RepoUrl $InstallDir
-    if ($LASTEXITCODE -ne 0) { throw "git clone failed" }
+    if ($Version) {
+        git clone --branch $Version --depth 1 --quiet $RepoUrl $InstallDir
+    } else {
+        git clone --quiet $RepoUrl $InstallDir
+    }
+    if ($LASTEXITCODE -ne 0) { throw 'git clone failed' }
 }
 
+Write-Host "Installed to $InstallDir"
 Set-Location $InstallDir
-& .\setup-claude-bedrock.ps1 @args
+& .\setup-claude-bedrock.ps1 @SetupArgs

--- a/install.ps1
+++ b/install.ps1
@@ -20,6 +20,9 @@ $ErrorActionPreference = 'Stop'
 
 if ($Latest) { $Version = '' }
 
+# Normalize version: accept "2.0.0" or "v2.0.0" — tags are always v-prefixed.
+if ($Version -and -not $Version.StartsWith('v')) { $Version = "v$Version" }
+
 $RepoUrl    = 'https://github.com/jpvelasco/juggernaut.git'
 $InstallDir = if ($env:JUGGERNAUT_DIR) { $env:JUGGERNAUT_DIR } else { Join-Path $HOME '.juggernaut' }
 

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Normalize version: accept "2.0.0" or "v2.0.0" — tags are always v-prefixed.
+if [[ -n "$VERSION" && "$VERSION" != v* ]]; then
+  VERSION="v${VERSION}"
+fi
+
 if ! command -v git >/dev/null 2>&1; then
   echo "Error: git is required but not installed" >&2
   exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,75 @@
 #!/usr/bin/env bash
-set -e
+# install.sh — Juggernaut installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --version 2.0.0
+#   curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --latest
+#
+# Or after downloading:
+#   bash install.sh --version 2.0.0
+#   bash install.sh --latest
 
-if ! command -v git >/dev/null 2>&1; then
-    echo "Error: git is required but not installed" >&2
-    exit 1
-fi
+set -e
 
 REPO_URL="https://github.com/jpvelasco/juggernaut.git"
 INSTALL_DIR="${JUGGERNAUT_DIR:-$HOME/.juggernaut}"
+VERSION=""
+SETUP_ARGS=()
 
-echo "Installing Juggernaut..."
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --version requires a value" >&2
+        exit 1
+      fi
+      VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      VERSION="${1#--version=}"
+      shift
+      ;;
+    --latest)
+      VERSION=""
+      shift
+      ;;
+    *)
+      SETUP_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
 
-if [[ -d "$INSTALL_DIR" ]]; then
-    echo "Updating existing installation in $INSTALL_DIR"
-    git -C "$INSTALL_DIR" pull --ff-only
-else
-    git clone "$REPO_URL" "$INSTALL_DIR"
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is required but not installed" >&2
+  exit 1
 fi
 
+if [[ -n "$VERSION" ]]; then
+  echo "Installing Juggernaut $VERSION..."
+else
+  echo "Installing Juggernaut (latest)..."
+fi
+
+if [[ -d "$INSTALL_DIR" ]]; then
+  echo "Updating existing installation in $INSTALL_DIR"
+  git -C "$INSTALL_DIR" fetch --tags --quiet
+  if [[ -n "$VERSION" ]]; then
+    git -C "$INSTALL_DIR" checkout --quiet "$VERSION"
+  else
+    git -C "$INSTALL_DIR" checkout --quiet main
+    git -C "$INSTALL_DIR" pull --ff-only --quiet
+  fi
+else
+  if [[ -n "$VERSION" ]]; then
+    git clone --branch "$VERSION" --depth 1 --quiet "$REPO_URL" "$INSTALL_DIR"
+  else
+    git clone --quiet "$REPO_URL" "$INSTALL_DIR"
+  fi
+fi
+
+echo "Installed to $INSTALL_DIR"
 cd "$INSTALL_DIR"
-exec bash ./setup "$@"
+exec bash ./setup "${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}"


### PR DESCRIPTION
## Summary

Final cleanup PR before the v2.0.0 GitHub Release.

### Version pinning in installers

\`install.sh\` and \`install.ps1\` now support installing a specific tagged version. Both scripts normalize the version automatically — \`2.0.0\` and \`v2.0.0\` both work.

**Latest (default):**
\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash
irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1 | iex
\`\`\`

**Pinned to v2.0.0:**
\`\`\`bash
# Bash
curl -fsSL https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.sh | bash -s -- --version 2.0.0

# PowerShell
& ([scriptblock]::Create((irm https://raw.githubusercontent.com/jpvelasco/juggernaut/main/install.ps1))) -Version 2.0.0
\`\`\`

**Bug fixed:** previous version passed the raw user input to \`git clone --branch\`, but tags are \`v\`-prefixed. Scripts now normalize \`2.0.0\` → \`v2.0.0\` before any git operation.

### README
- Reordered Quick Setup: latest first, pinned second
- Fixed manual clone to use \`v2.0.0\`
- Added "Version Pinning" section with full examples

## Test plan

- [x] \`bash tests/v2/test_*.sh\` — 192 passed, 0 failed
- [x] Pester 5: \`Invoke-Pester ./tests/v2\` — 133 passed, 0 failed
- [x] CI Lint (shellcheck on install.sh) — pass
- [x] CI Test on ubuntu-latest — pass
- [x] CI Test on macos-latest — pass
- [x] CI Test on Windows (Git Bash) — pass
- [x] CI Test on Windows (PowerShell) — pass
- [x] CI Codacy Static Code Analysis — pass
- [x] CI CodeQL — pass