### PR TITLE
[codex] Fix opusplan mode repair and key paste

### DIFF
--- a/commands/apply.ps1
+++ b/commands/apply.ps1
@@ -4,6 +4,7 @@
 param(
     [string]$Auth          = '',
     [string]$BedrockKey    = '',
+    [switch]$BedrockKeyFromClipboard,
     [switch]$PreserveKey,
     [string]$Storage       = '',
     [string]$Region        = '',
@@ -47,6 +48,8 @@ Usage: juggernaut.ps1 apply [options]
 
   -Auth             iam|bedrock-api-key  (required on first run)
   -BedrockKey       Bedrock API key (prompts if omitted)
+  -BedrockKeyFromClipboard
+                   Read Bedrock API key from the system clipboard
                    Pipe it in: $env:KEY | juggernaut apply ...
   -PreserveKey      Reuse existing key from env/keychain
   -Storage          profile|keychain|dpapi (auto switches to dpapi on Windows when key > 1280 chars)
@@ -67,6 +70,7 @@ Usage: juggernaut.ps1 apply [options]
 
 $authExplicit = $PSBoundParameters.ContainsKey('Auth')
 $storageExplicit = $PSBoundParameters.ContainsKey('Storage')
+$noOpusPlanExplicit = $PSBoundParameters.ContainsKey('NoOpusPlan')
 if ($Auth -eq 'api-key') { $Auth = 'bedrock-api-key' }
 $HomeDir = if ($env:HOME) { $env:HOME } elseif ($env:USERPROFILE) { $env:USERPROFILE } else { [Environment]::GetFolderPath('UserProfile') }
 
@@ -117,6 +121,26 @@ if ($existingBlock) {
         if ($existingBlock.context.use1MContext) { $Use1MContext = $true } else { $No1MContext = $true }
     }
     if (-not $MantleUrl -and $existingBlock.mantle.baseUrl) { $MantleUrl = $existingBlock.mantle.baseUrl }
+}
+
+$existingTopModel = if ($existingSettings.Contains('model')) { $existingSettings['model'] } else { '' }
+$existingEnvModel = if ($existingSettings.Contains('env') -and $existingSettings['env'] -and $existingSettings['env'].Contains('ANTHROPIC_MODEL')) {
+    $existingSettings['env']['ANTHROPIC_MODEL']
+} else {
+    ''
+}
+$poisonedOpusPlanMode = ($Model -eq 'opusplan' -or $existingTopModel -eq 'opusplan' -or $existingEnvModel -eq 'opusplan')
+if ($poisonedOpusPlanMode -and -not $OpusPlan -and -not $noOpusPlanExplicit) {
+    $OpusPlan = $true
+    $NoOpusPlan = $false
+}
+
+if ($Model -eq 'opusplan') {
+    if ($PSBoundParameters.ContainsKey('Model')) {
+        Write-Error "apply: -Model cannot be 'opusplan'; use -OpusPlan for that routing mode"
+        exit 1
+    }
+    $Model = ''
 }
 
 # ---------------------------------------------------------------------------
@@ -191,6 +215,7 @@ if (-not $SkipPreflight -and $Auth -eq 'iam') {
 # ---------------------------------------------------------------------------
 # Step 5: Resolve API key.
 # ---------------------------------------------------------------------------
+$preservedStorage = ''
 if ($Auth -eq 'bedrock-api-key') {
     if ($PreserveKey) {
         if ($env:AWS_BEARER_TOKEN_BEDROCK) {
@@ -200,12 +225,26 @@ if ($Auth -eq 'bedrock-api-key') {
             $probe = $null
             try { $probe = Read-BearerToken }
             catch { Write-Warning "apply: secure-storage read failed: $_"; $probe = $null }
-            if ($probe -and $probe.Value) { $BedrockKey = $probe.Value } elseif ($probe -and $probe.Error) {
+            if ($probe -and $probe.Value) {
+                $BedrockKey = $probe.Value
+                $preservedStorage = $probe.Storage
+                if ($preservedStorage -in 'keychain','dpapi') { $Storage = $preservedStorage }
+            } elseif ($probe -and $probe.Error) {
                 Write-Warning "apply: secure-storage read failed: $($probe.Error)"
             }
         }
         if (-not $BedrockKey) {
             Write-Error 'apply: -PreserveKey specified but no existing key found in env, keychain, or DPAPI'; exit 1
+        }
+    }
+    if (-not $BedrockKey) {
+        if ($BedrockKeyFromClipboard) {
+            try {
+                $BedrockKey = (Get-Clipboard -Raw -ErrorAction Stop).Trim()
+            } catch {
+                Write-Error "apply: failed to read Bedrock API key from clipboard: $_"
+                exit 1
+            }
         }
     }
     if (-not $BedrockKey) {
@@ -226,7 +265,7 @@ if ($Auth -eq 'bedrock-api-key') {
             Write-Host 'Paste your Bedrock API key, then press Enter.'
             Write-Host '(Tip: you can also pipe it in: $env:KEY | juggernaut apply ...)'
             Write-Host -NoNewline '> '
-            $BedrockKey = (Read-Host).Trim()
+            $BedrockKey = ([Console]::ReadLine()).Trim()
             if (-not $BedrockKey) {
                 Write-Error 'apply: API key cannot be empty. Pass -BedrockKey KEY, or pipe it: $env:KEY | juggernaut apply ...'
                 exit 1
@@ -240,6 +279,8 @@ if ($Auth -eq 'bedrock-api-key') {
     if ($Storage -in 'keychain','dpapi') {
         if ($DryRun) {
             Write-Host '[dry-run] would store API key in system keychain or DPAPI file'
+        } elseif ($PreserveKey -and $preservedStorage -in 'keychain','dpapi') {
+            $Storage = $preservedStorage
         } else {
             $mode = if ($Storage -eq 'dpapi') { 'dpapi' } else { 'auto' }
             if ($mode -eq 'auto' -and (Get-KeychainOS) -eq 'windows' -and $BedrockKey.Length -gt 1280) {

--- a/commands/apply.sh
+++ b/commands/apply.sh
@@ -24,16 +24,19 @@ DRY_RUN=false
 J_AUTH_MODE=""          # Populated from existing block or flag; default applied below.
 J_AUTH_EXPLICIT=false
 J_API_KEY=""
+J_API_KEY_FROM_CLIPBOARD=false
 J_PRESERVE_KEY=false
 J_STORAGE=""            # Populated from existing block or platform default.
 J_STORAGE_EXPLICIT=false
 J_REGION=""
 J_MODEL=""
+J_MODEL_EXPLICIT=false
 J_OPUS_MODEL=""
 J_SONNET_MODEL=""
 J_HAIKU_MODEL=""
 J_EFFORT=""
 J_OPUSPLAN=""           # Tri-state: ""=unset, "true", "false"
+J_OPUSPLAN_EXPLICIT=false
 J_1M_CONTEXT=""
 J_USE_MANTLE=true       # v3: Mantle on by default.
 J_MANTLE_URL=""
@@ -52,6 +55,8 @@ Usage: juggernaut apply [options]
 Options:
   --auth=iam|bedrock-api-key  Authentication mode (required on first run)
   --bedrock-key=KEY        Bedrock API key (prompts if omitted)
+  --bedrock-key-from-clipboard
+                           Read Bedrock API key from the system clipboard
                            Pipe it in: echo $KEY | juggernaut apply ...
   --preserve-key           Reuse existing key from env/keychain
   --storage=profile|keychain  API key storage (default: keychain on macOS/Win)
@@ -100,12 +105,52 @@ _apply_acquire_key() {
     printf '> '
   } > /dev/tty 2>/dev/null || return 1
 
-  IFS= read -r value < /dev/tty || return 1
+  if [[ -n "${BASH_VERSION:-}" && -t 0 ]]; then
+    IFS= read -e -r value || return 1
+  else
+    IFS= read -r value < /dev/tty || return 1
+  fi
   printf '\n' > /dev/tty 2>/dev/null
 
   value="${value//$'\e[200~'/}"
   value="${value//$'\e[201~'/}"
+  value="${value//$'\r'/}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
 
+  printf '%s' "$value"
+}
+
+_apply_clipboard_key() {
+  local value=""
+
+  if command -v pbpaste >/dev/null 2>&1; then
+    value="$(pbpaste 2>/dev/null)" || return 1
+  elif command -v wl-paste >/dev/null 2>&1; then
+    value="$(wl-paste --no-newline 2>/dev/null)" || return 1
+  elif command -v xclip >/dev/null 2>&1; then
+    value="$(xclip -selection clipboard -o 2>/dev/null)" || return 1
+  elif command -v xsel >/dev/null 2>&1; then
+    value="$(xsel --clipboard --output 2>/dev/null)" || return 1
+  elif command -v powershell.exe >/dev/null 2>&1; then
+    value="$(powershell.exe -NoProfile -Command 'Get-Clipboard -Raw' 2>/dev/null)" || return 1
+  elif command -v pwsh >/dev/null 2>&1; then
+    value="$(pwsh -NoProfile -Command 'Get-Clipboard -Raw' 2>/dev/null)" || return 1
+  elif command -v powershell >/dev/null 2>&1; then
+    value="$(powershell -NoProfile -Command 'Get-Clipboard -Raw' 2>/dev/null)" || return 1
+  else
+    echo "apply: no supported clipboard reader found (pbpaste, wl-paste, xclip, xsel, or PowerShell)" >&2
+    return 1
+  fi
+
+  value="${value//$'\e[200~'/}"
+  value="${value//$'\e[201~'/}"
+  value="${value//$'\r'/}"
+  while [[ "${value: -1}" == $'\n' || "${value: -1}" == $'\r' ]]; do
+    value="${value%?}"
+  done
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
   printf '%s' "$value"
 }
 
@@ -121,13 +166,14 @@ while [[ $# -gt 0 ]]; do
     --auth)                 shift; [[ $# -gt 0 ]] || { echo "apply: --auth requires a value" >&2; exit 1; }; J_AUTH_MODE="$1"; J_AUTH_EXPLICIT=true ;;
     --bedrock-key=*)        J_API_KEY="${arg#--bedrock-key=}" ;;
     --bedrock-key)          shift; [[ $# -gt 0 ]] || { echo "apply: --bedrock-key requires a value" >&2; exit 1; }; J_API_KEY="$1" ;;
+    --bedrock-key-from-clipboard) J_API_KEY_FROM_CLIPBOARD=true ;;
     --preserve-key)         J_PRESERVE_KEY=true ;;
     --storage=*)            J_STORAGE="${arg#--storage=}"; J_STORAGE_EXPLICIT=true ;;
     --storage)              shift; [[ $# -gt 0 ]] || { echo "apply: --storage requires a value" >&2; exit 1; }; J_STORAGE="$1"; J_STORAGE_EXPLICIT=true ;;
     --region=*)             J_REGION="${arg#--region=}" ;;
     --region)               shift; [[ $# -gt 0 ]] || { echo "apply: --region requires a value" >&2; exit 1; }; J_REGION="$1" ;;
-    --model=*)              J_MODEL="${arg#--model=}" ;;
-    --model)                shift; [[ $# -gt 0 ]] || { echo "apply: --model requires a value" >&2; exit 1; }; J_MODEL="$1" ;;
+    --model=*)              J_MODEL="${arg#--model=}"; J_MODEL_EXPLICIT=true ;;
+    --model)                shift; [[ $# -gt 0 ]] || { echo "apply: --model requires a value" >&2; exit 1; }; J_MODEL="$1"; J_MODEL_EXPLICIT=true ;;
     --opus-model=*)         J_OPUS_MODEL="${arg#--opus-model=}" ;;
     --opus-model)           shift; [[ $# -gt 0 ]] || { echo "apply: --opus-model requires a value" >&2; exit 1; }; J_OPUS_MODEL="$1" ;;
     --sonnet-model=*)       J_SONNET_MODEL="${arg#--sonnet-model=}" ;;
@@ -136,8 +182,8 @@ while [[ $# -gt 0 ]]; do
     --haiku-model)          shift; [[ $# -gt 0 ]] || { echo "apply: --haiku-model requires a value" >&2; exit 1; }; J_HAIKU_MODEL="$1" ;;
     --effort=*)             J_EFFORT="${arg#--effort=}" ;;
     --effort)               shift; [[ $# -gt 0 ]] || { echo "apply: --effort requires a value" >&2; exit 1; }; J_EFFORT="$1" ;;
-    --opusplan)             J_OPUSPLAN=true ;;
-    --no-opusplan)          J_OPUSPLAN=false ;;
+    --opusplan)             J_OPUSPLAN=true; J_OPUSPLAN_EXPLICIT=true ;;
+    --no-opusplan)          J_OPUSPLAN=false; J_OPUSPLAN_EXPLICIT=true ;;
     --1m-context)           J_1M_CONTEXT=true ;;
     --no-1m-context)        J_1M_CONTEXT=false ;;
     --no-mantle)            J_USE_MANTLE=false ;;
@@ -209,6 +255,22 @@ if [[ "$HAS_BLOCK" == "true" ]]; then
   [[ -z "$J_OPUSPLAN" ]]   && J_OPUSPLAN="$(printf '%s' "$EXISTING_BLOCK" | jq -r '.opusplan | tostring')"
   [[ -z "$J_1M_CONTEXT" ]] && J_1M_CONTEXT="$(printf '%s' "$EXISTING_BLOCK" | jq -r '.context.use1MContext | tostring')"
   [[ -z "$J_MANTLE_URL" ]] && J_MANTLE_URL="$(printf '%s' "$EXISTING_BLOCK" | jq -r '.mantle.baseUrl // ""')"
+fi
+
+if [[ "$J_OPUSPLAN_EXPLICIT" != "true" ]]; then
+  _settings_model="$(printf '%s' "$EXISTING_JSON" | jq -r '.model // ""')"
+  _settings_env_model="$(printf '%s' "$EXISTING_JSON" | jq -r '.env.ANTHROPIC_MODEL // ""')"
+  if [[ "$J_MODEL" == "opusplan" || "$_settings_model" == "opusplan" || "$_settings_env_model" == "opusplan" ]]; then
+    J_OPUSPLAN=true
+  fi
+fi
+
+if [[ "$J_MODEL" == "opusplan" ]]; then
+  if [[ "$J_MODEL_EXPLICIT" == "true" ]]; then
+    echo "apply: --model cannot be 'opusplan'; use --opusplan for that routing mode" >&2
+    exit 1
+  fi
+  J_MODEL=""
 fi
 
 # ---------------------------------------------------------------------------
@@ -301,6 +363,15 @@ if [[ "$J_AUTH_MODE" == "bedrock-api-key" ]]; then
     if [[ -z "$J_API_KEY" ]]; then
       echo "apply: --preserve-key specified but no existing key found in env or keychain" >&2
       exit 1
+    fi
+  fi
+
+  if [[ -z "$J_API_KEY" ]]; then
+    if [[ "$J_API_KEY_FROM_CLIPBOARD" == "true" ]]; then
+      if ! J_API_KEY="$(_apply_clipboard_key)"; then
+        echo "apply: failed to read Bedrock API key from clipboard" >&2
+        exit 1
+      fi
     fi
   fi
 

--- a/lib/config_manager.ps1
+++ b/lib/config_manager.ps1
@@ -132,9 +132,14 @@ function Backup-Settings {
     if (-not (Test-Path $Path)) { return $null }
     $stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
     $backup = "$Path.backup.$stamp"
-    Copy-Item -Path $Path -Destination $backup -Force
-    Invoke-SettingsBackupRotation -Path $Path
-    return $backup
+    try {
+        Copy-Item -Path $Path -Destination $backup -Force -ErrorAction Stop
+        Invoke-SettingsBackupRotation -Path $Path
+        return $backup
+    } catch {
+        Write-Warning "Backup-Settings: could not create backup ${backup}: $_"
+        return $null
+    }
 }
 
 function Invoke-SettingsBackupRotation {
@@ -182,8 +187,8 @@ function Write-SettingsAtomic {
         if (Test-Path $Path) { Backup-Settings -Path $Path | Out-Null }
         $tmp = "$Path.tmp.$PID"
         try {
-            Set-Content -Path $tmp -Value $json -NoNewline -Encoding utf8
-            Move-Item -Path $tmp -Destination $Path -Force
+            Set-Content -Path $tmp -Value $json -NoNewline -Encoding utf8 -ErrorAction Stop
+            Move-Item -Path $tmp -Destination $Path -Force -ErrorAction Stop
         } catch {
             Remove-Item -Path $tmp -Force -ErrorAction SilentlyContinue
             throw

--- a/lib/config_manager.sh
+++ b/lib/config_manager.sh
@@ -194,8 +194,7 @@ _config_write_atomic_locked() {
 
   if [[ -f "$path" ]]; then
     if ! config_backup "$path" >/dev/null; then
-      echo "_config_write_atomic_locked: backup failed for $path" >&2
-      return 1
+      echo "_config_write_atomic_locked: warning: backup failed for $path; continuing" >&2
     fi
   fi
 

--- a/lib/schema.ps1
+++ b/lib/schema.ps1
@@ -39,6 +39,8 @@ function ConvertTo-SchemaAuthMode {
     }
 }
 
+function Get-SchemaDefaultModel { 'global.anthropic.claude-sonnet-4-6' }
+
 function New-JuggernautBlock {
     [CmdletBinding()]
     param(
@@ -66,6 +68,7 @@ function New-JuggernautBlock {
     )
 
     if ([string]::IsNullOrEmpty($Region)) { $Region = Get-SchemaDefaultRegion }
+    if ([string]::IsNullOrEmpty($Model) -or $Model -eq 'opusplan') { $Model = Get-SchemaDefaultModel }
     $AuthMode = ConvertTo-SchemaAuthMode -AuthMode $AuthMode
     if ([string]::IsNullOrEmpty($SubagentModel)) { $SubagentModel = $HaikuModel }
 
@@ -166,6 +169,10 @@ function Test-JuggernautBlock {
 
     $storage = $Block.auth.storage
     if ($storage -notin @('profile','keychain','dpapi')) { $errors.Add("auth.storage must be 'profile', 'keychain', or 'dpapi' (got: '$storage')") }
+
+    if ($Block.model -eq 'opusplan') {
+        $errors.Add("model must be a Bedrock model ID; 'opusplan' is a routing mode for env.ANTHROPIC_MODEL only")
+    }
 
     $effort = $Block.effortLevel
     if ($effort -notin @('low','medium','high','xhigh','max')) { $errors.Add("effortLevel must be one of low|medium|high|xhigh|max (got: '$effort')") }

--- a/lib/schema.sh
+++ b/lib/schema.sh
@@ -19,6 +19,7 @@ schema_require_jq() {
 schema_require_jq || exit 1
 
 schema_default_region() { echo "us-east-1"; }
+schema_default_model() { echo "global.anthropic.claude-sonnet-4-6"; }
 
 schema_supported_regions() {
   jq -r '.regions[]' "${BEDROCK_CONFIG_PATH:-bedrock-config.json}"
@@ -61,6 +62,9 @@ schema_new_juggernaut_block() {
   local use_mantle="${J_USE_MANTLE:-true}"
   local mantle_base_url="${J_MANTLE_BASE_URL:-}"
   local model="${J_MODEL:-global.anthropic.claude-sonnet-4-6}"
+  if [[ -z "$model" || "$model" == "opusplan" ]]; then
+    model="$(schema_default_model)"
+  fi
   local opus_model="${J_OPUS_MODEL:-global.anthropic.claude-opus-4-7}"
   local sonnet_model="${J_SONNET_MODEL:-global.anthropic.claude-sonnet-4-6}"
   local haiku_model="${J_HAIKU_MODEL:-global.anthropic.claude-haiku-4-5-20251001-v1:0}"
@@ -196,6 +200,12 @@ schema_validate() {
     profile|keychain|dpapi) ;;
     *) errors+="  - auth.storage must be 'profile', 'keychain', or 'dpapi' (got: '$storage')"$'\n' ;;
   esac
+
+  local model
+  model="$(echo "$block" | jq -r '.model // ""')"
+  if [[ "$model" == "opusplan" ]]; then
+    errors+="  - model must be a Bedrock model ID; 'opusplan' is a routing mode for env.ANTHROPIC_MODEL only"$'\n'
+  fi
 
   # Enum: effortLevel
   local effort

--- a/tests/v2/Apply.Tests.ps1
+++ b/tests/v2/Apply.Tests.ps1
@@ -81,6 +81,12 @@ Describe 'New-JuggernautBlock — opusplan' {
         $b.env['ANTHROPIC_MODEL'] | Should -Be 'opusplan'
         $b.opusplan               | Should -BeTrue
     }
+
+    It 'does not allow opusplan as the primary model ID' {
+        $b = New-JuggernautBlock -AuthMode 'iam' -Region 'us-west-2' -Model 'opusplan' `
+            -BedrockConfigPath $script:BedrockConfigPath
+        $b.model | Should -Be 'global.anthropic.claude-sonnet-4-6'
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -215,6 +221,46 @@ Describe 'apply.ps1 — -OpusPlan wiring' {
 
     It 'juggernaut.opusplan = true' { $script:settings.juggernaut.opusplan | Should -BeTrue }
     It 'env.ANTHROPIC_MODEL = opusplan' { $script:settings.env.ANTHROPIC_MODEL | Should -Be 'opusplan' }
+    It 'top-level model remains a Bedrock model ID' {
+        $script:settings.model | Should -Be 'global.anthropic.claude-sonnet-4-6'
+    }
+}
+
+Describe 'apply.ps1 — repairs opusplan poisoned primary model' {
+    BeforeAll {
+        $script:fakeHome = Join-Path ([IO.Path]::GetTempPath()) "juggernaut-apply-poison-$([guid]::NewGuid().Guid)"
+        New-Item -ItemType Directory -Force -Path (Join-Path $script:fakeHome '.claude') | Out-Null
+        $script:oldHome = $env:HOME
+        $script:oldUserProfile = $env:USERPROFILE
+        $env:HOME = $script:fakeHome
+        $env:USERPROFILE = $script:fakeHome
+
+        & (Join-Path $script:repoRoot 'commands\apply.ps1') -Auth 'iam' -Region 'us-west-2' -SkipPreflight 2>&1 | Out-Null
+        $settingsPath = Join-Path $script:fakeHome '.claude\settings.json'
+        $json = Get-Content $settingsPath -Raw | ConvertFrom-Json
+        $json.model = 'opusplan'
+        $json.juggernaut.model = 'opusplan'
+        $json | ConvertTo-Json -Depth 30 | Set-Content -Path $settingsPath -Encoding utf8
+
+        & (Join-Path $script:repoRoot 'commands\apply.ps1') -Auth 'iam' -SkipPreflight 2>&1 | Out-Null
+        $script:settings = Get-Content $settingsPath -Raw | ConvertFrom-Json
+    }
+    AfterAll {
+        $env:HOME = $script:oldHome
+        $env:USERPROFILE = $script:oldUserProfile
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $script:fakeHome
+    }
+
+    It 'rewrites top-level model to a Bedrock model ID' {
+        $script:settings.model | Should -Be 'global.anthropic.claude-sonnet-4-6'
+    }
+    It 'rewrites juggernaut.model to a Bedrock model ID' {
+        $script:settings.juggernaut.model | Should -Be 'global.anthropic.claude-sonnet-4-6'
+    }
+    It 'preserves opusplan as a mode' {
+        $script:settings.juggernaut.opusplan | Should -BeTrue
+        $script:settings.env.ANTHROPIC_MODEL | Should -Be 'opusplan'
+    }
 }
 
 Describe 'apply.ps1 — help / unknown args' {
@@ -252,6 +298,26 @@ Describe 'apply.ps1 — piped stdin key capture' -Skip:(-not (Get-Command pwsh -
             Remove-Item Env:\AWS_PROFILE -ErrorAction SilentlyContinue;
             & '$($applyScript -replace "'","''")' -Auth bedrock-api-key -Storage profile
         " 2>&1
+        $LASTEXITCODE | Should -Be 0
+        $settingsPath = Join-Path $script:fakeHome '.claude\settings.json'
+        Test-Path $settingsPath | Should -BeTrue
+        $s = Get-Content $settingsPath -Raw | ConvertFrom-Json
+        $s.juggernaut.auth.mode | Should -Be 'bedrock-api-key'
+    }
+
+    It 'clipboard key is captured and written to settings.json' {
+        $fakeKey = 'B' * 110
+        Set-Clipboard -Value $fakeKey
+        $applyScript = Join-Path $script:repoRoot 'commands\apply.ps1'
+        $out = pwsh -NoProfile -NonInteractive -Command "
+            `$env:HOME = '$($script:fakeHome -replace "'","''")';
+            `$env:USERPROFILE = `$env:HOME;
+            `$env:BEDROCK_CONFIG_PATH = '$($script:BedrockConfigPath -replace "'","''")';
+            `$env:JUGGERNAUT_KEYCHAIN_SERVICE = 'juggernaut-absent-clipboard-test';
+            Remove-Item Env:\AWS_BEARER_TOKEN_BEDROCK -ErrorAction SilentlyContinue;
+            Remove-Item Env:\AWS_PROFILE -ErrorAction SilentlyContinue;
+            & '$($applyScript -replace "'","''")' -Auth bedrock-api-key -Storage profile -BedrockKeyFromClipboard
+        " 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
         $settingsPath = Join-Path $script:fakeHome '.claude\settings.json'
         Test-Path $settingsPath | Should -BeTrue

--- a/tests/v2/test_apply.sh
+++ b/tests/v2/test_apply.sh
@@ -138,6 +138,27 @@ BEDROCK_CONFIG_PATH="$BEDROCK_CONFIG_PATH" HOME="$FAKE_HOME" \
 SETTINGS="$FAKE_HOME/.claude/settings.json"
 if jq -e '.env.ANTHROPIC_MODEL == "opusplan"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "--opusplan should set env.ANTHROPIC_MODEL = 'opusplan'"; fi
 if jq -e '.juggernaut.opusplan == true' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "--opusplan should set juggernaut.opusplan = true"; fi
+if jq -e '.model == "global.anthropic.claude-sonnet-4-6"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "--opusplan should keep top-level .model as a Bedrock model ID"; fi
+rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Poisoned primary model: apply translates model=opusplan into opusplan mode
+# while restoring top-level .model to a Bedrock model ID.
+# ---------------------------------------------------------------------------
+section "poisoned model='opusplan' is preserved as mode, not model ID"
+_clean_env
+FAKE_HOME="$(mktemp -d)"
+BEDROCK_CONFIG_PATH="$BEDROCK_CONFIG_PATH" HOME="$FAKE_HOME" \
+  bash "$REPO_ROOT/commands/apply.sh" --auth=iam --region=us-west-2 --skip-preflight >/dev/null 2>&1
+SETTINGS="$FAKE_HOME/.claude/settings.json"
+tmp_json="$SETTINGS.tmp"
+jq '.model = "opusplan" | .juggernaut.model = "opusplan"' "$SETTINGS" > "$tmp_json"
+mv "$tmp_json" "$SETTINGS"
+BEDROCK_CONFIG_PATH="$BEDROCK_CONFIG_PATH" HOME="$FAKE_HOME" \
+  bash "$REPO_ROOT/commands/apply.sh" --auth=iam --skip-preflight >/dev/null 2>&1
+if jq -e '.model == "global.anthropic.claude-sonnet-4-6"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "apply should repair top-level .model to a Bedrock model ID"; fi
+if jq -e '.juggernaut.model == "global.anthropic.claude-sonnet-4-6"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "apply should repair juggernaut.model to a Bedrock model ID"; fi
+if jq -e '.juggernaut.opusplan == true and .env.ANTHROPIC_MODEL == "opusplan"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "apply should preserve opusplan as routing mode"; fi
 rm -rf "$FAKE_HOME"
 
 # ---------------------------------------------------------------------------
@@ -183,6 +204,27 @@ if [[ "$RC" -eq 0 ]]; then pass; else fail "piped stdin should exit 0 (got $RC);
 SETTINGS="$FAKE_HOME/.claude/settings.json"
 if jq -e '.juggernaut.auth.mode == "bedrock-api-key"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "settings.json missing bedrock-api-key block after piped key"; fi
 rm -rf "$FAKE_HOME"
+
+# ---------------------------------------------------------------------------
+# Clipboard key input: avoids interactive terminal paste handling.
+# ---------------------------------------------------------------------------
+section "clipboard key input: 110-char key captured and written to settings.json"
+_clean_env
+FAKE_HOME="$(mktemp -d)"
+STUB_DIR="$(mktemp -d)"
+FAKE_KEY="$(printf 'B%.0s' {1..110})"
+cat > "$STUB_DIR/pbpaste" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '$FAKE_KEY'
+EOF
+chmod +x "$STUB_DIR/pbpaste"
+OUTPUT="$(PATH="$STUB_DIR:$PATH" BEDROCK_CONFIG_PATH="$BEDROCK_CONFIG_PATH" HOME="$FAKE_HOME" \
+  bash "$REPO_ROOT/commands/apply.sh" --auth=bedrock-api-key --storage=profile --bedrock-key-from-clipboard 2>&1)"
+RC=$?
+if [[ "$RC" -eq 0 ]]; then pass; else fail "clipboard key input should exit 0 (got $RC); output: $OUTPUT"; fi
+SETTINGS="$FAKE_HOME/.claude/settings.json"
+if jq -e '.juggernaut.auth.mode == "bedrock-api-key"' "$SETTINGS" >/dev/null 2>&1; then pass; else fail "settings.json missing bedrock-api-key block after clipboard key"; fi
+rm -rf "$FAKE_HOME" "$STUB_DIR"
 
 # ---------------------------------------------------------------------------
 # Short key (<40 chars): rejected with truncation error


### PR DESCRIPTION
## Summary

- Treat `opusplan` as a routing mode, never as a persisted primary model ID
- Preserve user intent when Claude poisons `.model = "opusplan"` by enabling `juggernaut.opusplan` and restoring `.model` / `juggernaut.model` to Sonnet
- Reject explicit `--model=opusplan` / `-Model opusplan` with a clear error
- Improve long Bedrock API key entry by using Readline in Bash and `[Console]::ReadLine()` in PowerShell
- Add optional clipboard key input for cases where terminal paste is unreliable
- Make settings backup failures non-fatal, while making PowerShell atomic write errors truly fatal

## Root Cause

PR #82 added doctor detection for top-level `.model = "opusplan"`, but `apply` could still carry the sentinel forward as if it were a real Bedrock model ID. Long key paste also remained fragile in the normal interactive prompt path on Bash/PowerShell.

## Validation

- `bash tests/v2/test_apply.sh` - 31 passed, 0 failed
- `Invoke-Pester -Path tests/v2/Apply.Tests.ps1 -Output Detailed` - 36 passed, 0 failed
- Installed `juggernaut doctor` locally after applying the patch - Status OK, DPAPI key present
