### PR TITLE
Fix PowerShell profile token storage

### DIFF
--- a/commands/apply.ps1
+++ b/commands/apply.ps1
@@ -228,13 +228,13 @@ if ($Auth -eq 'bedrock-api-key') {
             if ($probe -and $probe.Value) {
                 $BedrockKey = $probe.Value
                 $preservedStorage = $probe.Storage
-                if ($preservedStorage -in 'keychain','dpapi') { $Storage = $preservedStorage }
+                if ($preservedStorage -in 'keychain','dpapi','profile') { $Storage = $preservedStorage }
             } elseif ($probe -and $probe.Error) {
                 Write-Warning "apply: secure-storage read failed: $($probe.Error)"
             }
         }
         if (-not $BedrockKey) {
-            Write-Error 'apply: -PreserveKey specified but no existing key found in env, keychain, or DPAPI'; exit 1
+            Write-Error 'apply: -PreserveKey specified but no existing key found in env, keychain, DPAPI, or profile storage'; exit 1
         }
     }
     if (-not $BedrockKey) {
@@ -296,13 +296,27 @@ if ($Auth -eq 'bedrock-api-key') {
                 }
                 Write-Host ''
                 Write-Host '[apply] WARNING: secure storage failed - Claude Code will hang without'  -ForegroundColor Yellow
-                Write-Host '[apply] a token source. Falling back to profile (env-var-only, no persistence).' -ForegroundColor Yellow
+                Write-Host '[apply] a token source. Falling back to profile token storage.'          -ForegroundColor Yellow
                 Write-Host ("[apply] Details: {0}" -f $result.Error)                                   -ForegroundColor Yellow
                 Write-Host '[apply] Workaround: export AWS_BEARER_TOKEN_BEDROCK yourself, or use'     -ForegroundColor Yellow
                 Write-Host '[apply] -Auth iam with AWS SSO/IAM credentials.'                          -ForegroundColor Yellow
                 Write-Host ''
                 $Storage = 'profile'
             }
+        }
+    }
+    if ($Storage -eq 'profile') {
+        if ($PreserveKey -and $preservedStorage -eq 'profile') {
+            # Key already in profile file from a previous run.
+        } elseif ($DryRun) {
+            Write-Host '[dry-run] would store API key in profile token file'
+        } else {
+            $result = Save-BearerToken -Key $BedrockKey -Mode 'profile'
+            if (-not $result.Ok) {
+                Write-Error ("apply: profile token write failed: {0}" -f $result.Error)
+                exit 1
+            }
+            $Storage = 'profile'
         }
     }
 }

--- a/commands/uninstall.ps1
+++ b/commands/uninstall.ps1
@@ -93,6 +93,10 @@ if ((Get-KeychainOS) -eq 'windows') {
     if (Test-Path $dpapiPath) { $hasDpapi = $true }
 }
 
+$hasProfileToken = $false
+$profileTokenPath = Get-ProfileTokenPath
+if (Test-Path $profileTokenPath) { $hasProfileToken = $true }
+
 function Get-LauncherProfileTargets {
     $targets = @()
     try {
@@ -120,7 +124,7 @@ function Test-ProfileHasLauncherBlock([string]$Path) {
 $launcherProfiles = @(Get-LauncherProfileTargets | Where-Object { Test-ProfileHasLauncherBlock $_ })
 $hasLauncher = $launcherProfiles.Count -gt 0
 
-if (-not ($hasUser -or $hasProject -or $hasKeychain -or $hasDpapi -or $hasLauncher)) {
+if (-not ($hasUser -or $hasProject -or $hasKeychain -or $hasDpapi -or $hasProfileToken -or $hasLauncher)) {
     Write-Output 'Nothing to uninstall.'
     exit 0
 }
@@ -130,10 +134,11 @@ if (-not ($hasUser -or $hasProject -or $hasKeychain -or $hasDpapi -or $hasLaunch
 # ---------------------------------------------------------------------------
 if (-not $Force -and -not $DryRun) {
     Write-Output 'The following will be removed:'
-    if ($hasUser)    { Write-Output "  - Juggernaut block from $userPath" }
-    if ($hasProject) { Write-Output "  - Juggernaut block from $projectPath" }
-    if ($hasKeychain) { Write-Output "  - Keychain entry: $($script:KeychainService)/$($script:KeychainAccount)" }
-    if ($hasDpapi)    { Write-Output "  - DPAPI file: $dpapiPath" }
+    if ($hasUser)        { Write-Output "  - Juggernaut block from $userPath" }
+    if ($hasProject)     { Write-Output "  - Juggernaut block from $projectPath" }
+    if ($hasKeychain)    { Write-Output "  - Keychain entry: $($script:KeychainService)/$($script:KeychainAccount)" }
+    if ($hasDpapi)       { Write-Output "  - DPAPI file: $dpapiPath" }
+    if ($hasProfileToken) { Write-Output "  - Profile token file: $profileTokenPath" }
     foreach ($lp in $launcherProfiles) { Write-Output "  - Launcher block from $lp" }
     Write-Output ''
     $answer = Read-Host 'Proceed? [y/N]'
@@ -165,6 +170,10 @@ if ($hasKeychain) {
 if ($hasDpapi) {
     if ($DryRun) { Write-Output "[dry-run] Would remove DPAPI file: $dpapiPath" }
     else         { Remove-DPAPIEntry; Write-Output "Removed DPAPI file: $dpapiPath" }
+}
+if ($hasProfileToken) {
+    if ($DryRun) { Write-Output "[dry-run] Would remove profile token file: $profileTokenPath" }
+    else         { Remove-ProfileTokenEntry; Write-Output "Removed profile token file: $profileTokenPath" }
 }
 
 function Remove-LauncherProfileBlock([string]$Path) {

--- a/lib/doctor.ps1
+++ b/lib/doctor.ps1
@@ -70,7 +70,7 @@ function Write-DoctorCredentials {
     if ($authMode -eq 'api-key') { $authMode = 'bedrock-api-key' }
     $read = $null
     $readError = ''
-    if ($authMode -eq 'bedrock-api-key' -and $storage -in 'keychain','dpapi') {
+    if ($authMode -eq 'bedrock-api-key') {
         try { $read = Read-BearerToken } catch { $readError = "$_"; $read = $null }
         if (-not $read.Value -and $read.Error) { $readError = $read.Error; $read = $null }
     }
@@ -100,8 +100,9 @@ function Write-DoctorCredentials {
                 Write-Output 'Source: AWS_BEARER_TOKEN_BEDROCK'
                 Write-Output 'Status: OK'
             } elseif ($read -and $read.Value) {
-                $label = if ($read.Storage -eq 'dpapi') { 'DPAPI file' }
+                $label = if ($read.Storage -eq 'dpapi')  { 'DPAPI file' }
                          elseif ($read.Storage -eq 'keychain') { 'system keychain' }
+                         elseif ($read.Storage -eq 'profile') { 'profile token file' }
                          else { $read.Storage }
                 Write-Output ("Source: {0}" -f $label)
                 Write-Output ("Storage: {0}" -f $read.Storage)
@@ -113,7 +114,7 @@ function Write-DoctorCredentials {
                 }
                 $script:DoctorFails += 1
                 Write-Output 'Status: FAIL'
-                Write-Output 'Details: no API key found in env, keychain, or DPAPI file'
+                Write-Output 'Details: no API key found in env, keychain, DPAPI file, or profile token file'
             }
         }
         default {

--- a/lib/keychain.ps1
+++ b/lib/keychain.ps1
@@ -206,6 +206,67 @@ public static extern bool CredDelete(string target, int type, int flags);
 }
 
 # ---------------------------------------------------------------------------
+# Profile token storage — cross-platform plaintext file at
+# XDG_CONFIG_HOME/juggernaut/bearer-token (or ~/.config/juggernaut/bearer-token).
+# Mirrors Bash's profile_token_path / profile_token_store / profile_token_get /
+# profile_token_delete. Test override via JUGGERNAUT_PROFILE_TOKEN_PATH.
+# ---------------------------------------------------------------------------
+
+function Get-ProfileTokenPath {
+    if ($env:JUGGERNAUT_PROFILE_TOKEN_PATH) { return $env:JUGGERNAUT_PROFILE_TOKEN_PATH }
+    $configRoot = if ($env:XDG_CONFIG_HOME) { $env:XDG_CONFIG_HOME }
+                 elseif ($env:HOME)         { Join-Path $env:HOME '.config' }
+                 elseif ($env:USERPROFILE)  { Join-Path $env:USERPROFILE '.config' }
+                 else                       { Join-Path ([Environment]::GetFolderPath('UserProfile')) '.config' }
+    return Join-Path (Join-Path $configRoot 'juggernaut') 'bearer-token'
+}
+
+function Set-ProfileTokenEntry {
+    param([Parameter(Mandatory)][string]$Key)
+    $path = Get-ProfileTokenPath
+    $dir  = Split-Path -Parent $path
+    try {
+        if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+        $tmp = Join-Path $dir (".bearer-token.tmp.{0}" -f [Guid]::NewGuid().ToString('N'))
+        try {
+            [IO.File]::WriteAllText($tmp, $Key, [Text.UTF8Encoding]::new($false))
+            $chmod = Get-Command chmod -ErrorAction SilentlyContinue
+            if ($chmod) { & $chmod.Source 600 -- $tmp 2>$null }
+            Move-Item -Path $tmp -Destination $path -Force
+        } catch {
+            if (Test-Path $tmp) { Remove-Item $tmp -Force -ErrorAction SilentlyContinue }
+            Write-Warning "Set-ProfileTokenEntry: write failed: $_"
+            return $false
+        }
+        return $true
+    } catch {
+        Write-Warning "Set-ProfileTokenEntry: mkdir failed: $_"
+        return $false
+    }
+}
+
+function Get-ProfileTokenEntry {
+    $path = Get-ProfileTokenPath
+    if (-not (Test-Path $path)) { return $null }
+    try {
+        $val = [IO.File]::ReadAllText($path).Trim()
+        if ([string]::IsNullOrEmpty($val)) { return $null }
+        return $val
+    } catch {
+        throw "Get-ProfileTokenEntry: failed to read $path : $_"
+    }
+}
+
+function Remove-ProfileTokenEntry {
+    $path = Get-ProfileTokenPath
+    if (Test-Path $path) {
+        try { Remove-Item -Path $path -Force -ErrorAction Stop } catch {
+            Write-Warning "Remove-ProfileTokenEntry: delete failed: $_"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
 # DPAPI-backed storage (Windows only). Used when a Bedrock API key exceeds
 # the Credential Manager CredWrite blob cap (~1280 unicode chars / 2560 bytes).
 # The DPAPI ciphertext only decrypts under the same Windows user account.
@@ -305,9 +366,16 @@ function Save-BearerToken {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Key,
-        [ValidateSet('auto','keychain','dpapi')][string]$Mode = 'auto'
+        [ValidateSet('auto','keychain','dpapi','profile')][string]$Mode = 'auto'
     )
     $os = Get-KeychainOS
+    # profile: always write to profile token file regardless of platform.
+    if ($Mode -eq 'profile') {
+        if (Set-ProfileTokenEntry -Key $Key) {
+            return @{ Ok = $true; Storage = 'profile'; Error = '' }
+        }
+        return @{ Ok = $false; Storage = 'none'; Error = 'profile token write failed' }
+    }
     # Non-Windows: CredMan is 'keychain' (macOS Keychain, secret-tool). No DPAPI.
     if ($os -ne 'windows') {
         if ($Mode -eq 'dpapi') {
@@ -357,8 +425,8 @@ function Save-BearerToken {
 
 function Read-BearerToken {
     # Return shape matches Save-BearerToken: { Value; Storage; Error }.
-    # On Windows: DPAPI file first (no P/Invoke cost), then CredMan.
-    # On Unix: keychain (secret-tool / security) only.
+    # On Windows: DPAPI file first (no P/Invoke cost), then CredMan, then profile.
+    # On Unix: keychain (secret-tool / security), then profile.
     $os = Get-KeychainOS
     if ($os -eq 'windows') {
         try {
@@ -378,6 +446,14 @@ function Read-BearerToken {
     } catch {
         return @{ Value = $null; Storage = 'keychain'; Error = "$_" }
     }
+    try {
+        $v = Get-ProfileTokenEntry
+        if (-not [string]::IsNullOrEmpty($v)) {
+            return @{ Value = $v; Storage = 'profile'; Error = '' }
+        }
+    } catch {
+        return @{ Value = $null; Storage = 'profile'; Error = "$_" }
+    }
     return @{ Value = $null; Storage = 'none'; Error = '' }
 }
 
@@ -386,4 +462,5 @@ function Remove-BearerToken {
     if ((Get-KeychainOS) -eq 'windows') {
         Remove-DPAPIEntry
     }
+    Remove-ProfileTokenEntry
 }

--- a/tests/v2/Apply.Tests.ps1
+++ b/tests/v2/Apply.Tests.ps1
@@ -340,3 +340,48 @@ Describe 'apply.ps1 — piped stdin key capture' -Skip:(-not (Get-Command pwsh -
         $out | Should -Match 'truncated'
     }
 }
+
+Describe 'apply.ps1 — profile token storage persistence' -Skip:(-not (Get-Command pwsh -ErrorAction SilentlyContinue)) {
+    BeforeEach {
+        $script:fakeHome = Join-Path ([IO.Path]::GetTempPath()) "juggernaut-apply-pf-$([guid]::NewGuid().Guid)"
+        New-Item -ItemType Directory -Force -Path $script:fakeHome | Out-Null
+    }
+    AfterEach {
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $script:fakeHome
+    }
+
+    It '-Storage profile persists the key to the profile token file' {
+        $fakeKey = 'C' * 110
+        $applyScript = Join-Path $script:repoRoot 'commands\apply.ps1'
+        $null = $fakeKey | pwsh -NoProfile -NonInteractive -Command "
+            `$env:HOME = '$($script:fakeHome -replace "'","''")';
+            `$env:USERPROFILE = `$env:HOME;
+            `$env:BEDROCK_CONFIG_PATH = '$($script:BedrockConfigPath -replace "'","''")';
+            `$env:JUGGERNAUT_KEYCHAIN_SERVICE = 'juggernaut-absent-profile-test';
+            Remove-Item Env:\AWS_BEARER_TOKEN_BEDROCK -ErrorAction SilentlyContinue;
+            Remove-Item Env:\AWS_PROFILE -ErrorAction SilentlyContinue;
+            & '$($applyScript -replace "'","''")' -Auth bedrock-api-key -Storage profile
+        " 2>&1
+        $LASTEXITCODE | Should -Be 0
+        $settingsPath = Join-Path $script:fakeHome '.claude\settings.json'
+        Test-Path $settingsPath | Should -BeTrue
+        $s = Get-Content $settingsPath -Raw | ConvertFrom-Json
+        $s.juggernaut.auth.mode | Should -Be 'bedrock-api-key'
+        $s.juggernaut.auth.storage | Should -Be 'profile'
+        # Verify the token was written to the profile token file
+        $profileDir = Join-Path $script:fakeHome '.config\juggernaut'
+        $profileFile = Join-Path $profileDir 'bearer-token'
+        if (Test-Path $profileFile) {
+            $stored = Get-Content $profileFile -Raw
+            $stored | Should -Be $fakeKey
+        } else {
+            # On Windows profile path is ~\.config\juggernaut\bearer-token
+            # which is under $env:HOME\.config
+            $altProfileDir = Join-Path $script:fakeHome '.config\juggernaut'
+            $altProfileFile = Join-Path $altProfileDir 'bearer-token'
+            Test-Path $altProfileFile | Should -BeTrue
+            $stored = Get-Content $altProfileFile -Raw
+            $stored | Should -Be $fakeKey
+        }
+    }
+}

--- a/tests/v2/Doctor.Tests.ps1
+++ b/tests/v2/Doctor.Tests.ps1
@@ -189,4 +189,57 @@ Describe 'doctor.ps1' {
             $out | Should -Not -Match 'JUGGERNAUT_USE_V2'
         }
     }
+
+    Context 'bedrock-api-key with profile token storage detected by doctor' {
+        BeforeAll {
+            $script:tmpHome2 = Join-Path ([IO.Path]::GetTempPath()) ("jug-doc-prof-" + [Guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path (Join-Path $script:tmpHome2 '.claude') -Force | Out-Null
+            $script:oldHome2 = $env:HOME; $script:oldProfile2 = $env:USERPROFILE
+            $script:oldBedrock2 = $env:BEDROCK_CONFIG_PATH
+            $script:oldBearer2 = $env:AWS_BEARER_TOKEN_BEDROCK
+            $script:oldKeychainService2 = $env:JUGGERNAUT_KEYCHAIN_SERVICE
+            $script:oldProfileTokenPath = $env:JUGGERNAUT_PROFILE_TOKEN_PATH
+
+            $env:HOME = $script:tmpHome2; $env:USERPROFILE = $script:tmpHome2
+            $env:BEDROCK_CONFIG_PATH = $script:BedrockConfigPath
+            $env:JUGGERNAUT_KEYCHAIN_SERVICE = "juggernaut-absent-docprof-$([Guid]::NewGuid().ToString('N'))"
+            Remove-Item Env:\AWS_BEARER_TOKEN_BEDROCK -ErrorAction SilentlyContinue
+
+            # Write profile token directly
+            $profFile = Join-Path $script:tmpHome2 '.config\juggernaut\bearer-token'
+            New-Item -ItemType Directory -Path (Split-Path -Parent $profFile) -Force | Out-Null
+            'sk-brk-doctor-profile-test' | Set-Content -Path $profFile -Encoding utf8 -NoNewline
+            $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $profFile
+
+            $block = New-JuggernautBlock -AuthMode 'bedrock-api-key' -AuthValidated $true `
+                -Region 'us-west-2' -Storage 'profile' -UseMantle $true `
+                -Version $script:ExpectedVersion `
+                -BedrockConfigPath $script:BedrockConfigPath
+            $native = Get-NativeKeysFromJuggernautBlock -Block $block
+            $merged = Merge-JuggernautBlock -Existing ([ordered]@{}) -NewBlock $block -NativeKeys $native
+            Write-SettingsAtomic -Path (Join-Path $script:tmpHome2 '.claude\settings.json') -Content $merged
+
+            $script:profOutput = & (Join-Path $script:repoRoot 'commands\doctor.ps1') 2>&1 | Out-String
+        }
+        AfterAll {
+            $env:HOME = $script:oldHome2; $env:USERPROFILE = $script:oldProfile2
+            $env:BEDROCK_CONFIG_PATH = $script:oldBedrock2
+            $env:AWS_BEARER_TOKEN_BEDROCK = $script:oldBearer2
+            if ($null -eq $script:oldKeychainService2) {
+                Remove-Item Env:\JUGGERNAUT_KEYCHAIN_SERVICE -ErrorAction SilentlyContinue
+            } else {
+                $env:JUGGERNAUT_KEYCHAIN_SERVICE = $script:oldKeychainService2
+            }
+            if ($null -eq $script:oldProfileTokenPath) {
+                Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+            } else {
+                $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $script:oldProfileTokenPath
+            }
+            Remove-Item -Recurse -Force $script:tmpHome2 -ErrorAction SilentlyContinue
+        }
+
+        It 'reports Bedrock API key auth' { $script:profOutput | Should -Match 'Auth: Bedrock API key' }
+        It 'reports profile token file as source' { $script:profOutput | Should -Match 'profile token file' }
+        It 'reports Storage: profile' { $script:profOutput | Should -Match 'Storage: profile' }
+    }
 }

--- a/tests/v2/Keychain.Tests.ps1
+++ b/tests/v2/Keychain.Tests.ps1
@@ -51,3 +51,156 @@ Describe 'Get-KeychainEntry — not found returns $null' {
     }
 }
 
+Describe 'Profile token storage' {
+    BeforeAll {
+        $script:testTokenDir = Join-Path ([IO.Path]::GetTempPath()) ("jug-pt-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:testTokenDir -Force | Out-Null
+        $script:profilePath = Join-Path $script:testTokenDir 'bearer-token'
+    }
+    AfterAll {
+        Remove-Item -Path $script:testTokenDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach {
+        $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $script:profilePath
+    }
+    AfterEach {
+        Remove-ProfileTokenEntry
+        Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+    }
+
+    It 'Get-ProfileTokenPath respects JUGGERNAUT_PROFILE_TOKEN_PATH' {
+        Get-ProfileTokenPath | Should -Be $script:profilePath
+    }
+
+    It 'Get-ProfileTokenPath builds path from XDG_CONFIG_HOME without embedded separators' {
+        $oldOverride = $env:JUGGERNAUT_PROFILE_TOKEN_PATH
+        $oldXdg = $env:XDG_CONFIG_HOME
+        try {
+            Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+            $env:XDG_CONFIG_HOME = $script:testTokenDir
+            Get-ProfileTokenPath | Should -Be (Join-Path (Join-Path $script:testTokenDir 'juggernaut') 'bearer-token')
+        } finally {
+            if ($null -eq $oldOverride) { Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $oldOverride }
+            if ($null -eq $oldXdg) { Remove-Item Env:\XDG_CONFIG_HOME -ErrorAction SilentlyContinue } else { $env:XDG_CONFIG_HOME = $oldXdg }
+        }
+    }
+
+    It 'Set-ProfileTokenEntry writes file, Get-ProfileTokenEntry reads it back' {
+        $token = 'sk-brk-test-' + [Guid]::NewGuid().ToString('N')
+        $ok = Set-ProfileTokenEntry -Key $token
+        $ok | Should -BeTrue
+        $val = Get-ProfileTokenEntry
+        $val | Should -Be $token
+    }
+
+    It 'Get-ProfileTokenEntry returns $null when file does not exist' {
+        Remove-ProfileTokenEntry
+        $val = Get-ProfileTokenEntry
+        $val | Should -BeNullOrEmpty
+    }
+
+    It 'Remove-ProfileTokenEntry deletes the file' {
+        $token = 'sk-brk-deltest'
+        Set-ProfileTokenEntry -Key $token | Out-Null
+        $file = Get-ProfileTokenPath
+        Test-Path $file | Should -BeTrue
+        Remove-ProfileTokenEntry
+        Test-Path $file | Should -BeFalse
+    }
+
+    It 'Set-ProfileTokenEntry is idempotent on re-write' {
+        $first  = 'tok-one'
+        $second = 'tok-two'
+        Set-ProfileTokenEntry -Key $first  | Out-Null
+        Set-ProfileTokenEntry -Key $second | Out-Null
+        Get-ProfileTokenEntry | Should -Be $second
+    }
+}
+
+Describe 'Save-BearerToken — profile mode' {
+    BeforeAll {
+        $script:testTokenDir2 = Join-Path ([IO.Path]::GetTempPath()) ("jug-pt2-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:testTokenDir2 -Force | Out-Null
+        $script:profilePath2 = Join-Path $script:testTokenDir2 'bearer-token'
+    }
+    AfterAll {
+        Remove-Item -Path $script:testTokenDir2 -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'Mode=profile writes to profile token file' {
+        $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $script:profilePath2
+        $env:JUGGERNAUT_KEYCHAIN_SERVICE = "juggernaut-absent-save-prof-$([Guid]::NewGuid().ToString('N'))"
+        try {
+            $token = 'sk-profile-save-test'
+            $result = Save-BearerToken -Key $token -Mode 'profile'
+            $result.Ok      | Should -BeTrue
+            $result.Storage | Should -Be 'profile'
+            Test-Path $script:profilePath2 | Should -BeTrue
+        } finally {
+            Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+            Remove-Item Env:\JUGGERNAUT_KEYCHAIN_SERVICE -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'Read-BearerToken — profile as fallback' {
+    BeforeAll {
+        $script:testTokenDir3 = Join-Path ([IO.Path]::GetTempPath()) ("jug-pt3-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:testTokenDir3 -Force | Out-Null
+        $script:profilePath3 = Join-Path $script:testTokenDir3 'bearer-token'
+    }
+    AfterAll {
+        Remove-Item -Path $script:testTokenDir3 -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'Read-BearerToken finds profile token when keychain and dpapi are empty' {
+        $script:oldHome3 = $env:JUGGERNAUT_HOME
+        $script:oldSvc3  = $env:JUGGERNAUT_KEYCHAIN_SERVICE
+        $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $script:profilePath3
+        $env:JUGGERNAUT_KEYCHAIN_SERVICE = "juggernaut-absent-read-prof-$([Guid]::NewGuid().ToString('N'))"
+        # Point DPAPI at a temp location so the default DPAPI file doesn't interfere
+        $env:JUGGERNAUT_HOME = $script:testTokenDir3
+        try {
+            $token = 'sk-profile-read-test'
+            Set-ProfileTokenEntry -Key $token | Out-Null
+            $result = Read-BearerToken
+            $result.Value   | Should -Be $token
+            $result.Storage | Should -Be 'profile'
+        } finally {
+            Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+            if ($null -eq $script:oldSvc3) { Remove-Item Env:\JUGGERNAUT_KEYCHAIN_SERVICE -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_KEYCHAIN_SERVICE = $script:oldSvc3 }
+            if ($null -eq $script:oldHome3) { Remove-Item Env:\JUGGERNAUT_HOME -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_HOME = $script:oldHome3 }
+        }
+    }
+}
+
+Describe 'Remove-BearerToken — cleans profile token' {
+    BeforeAll {
+        $script:testTokenDir4 = Join-Path ([IO.Path]::GetTempPath()) ("jug-pt4-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:testTokenDir4 -Force | Out-Null
+        $script:profilePath4 = Join-Path $script:testTokenDir4 'bearer-token'
+    }
+    AfterAll {
+        Remove-Item -Path $script:testTokenDir4 -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'Remove-BearerToken removes the profile token file' {
+        $script:oldHome4 = $env:JUGGERNAUT_HOME
+        $script:oldSvc4  = $env:JUGGERNAUT_KEYCHAIN_SERVICE
+        $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $script:profilePath4
+        $env:JUGGERNAUT_KEYCHAIN_SERVICE = "juggernaut-absent-rm-prof-$([Guid]::NewGuid().ToString('N'))"
+        $env:JUGGERNAUT_HOME = $script:testTokenDir4
+        try {
+            Set-ProfileTokenEntry -Key 'sk-test' | Out-Null
+            Test-Path $script:profilePath4 | Should -BeTrue
+            Remove-BearerToken
+            Test-Path $script:profilePath4 | Should -BeFalse
+        } finally {
+            Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+            if ($null -eq $script:oldSvc4) { Remove-Item Env:\JUGGERNAUT_KEYCHAIN_SERVICE -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_KEYCHAIN_SERVICE = $script:oldSvc4 }
+            if ($null -eq $script:oldHome4) { Remove-Item Env:\JUGGERNAUT_HOME -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_HOME = $script:oldHome4 }
+        }
+    }
+}
+

--- a/tests/v2/Uninstall.Tests.ps1
+++ b/tests/v2/Uninstall.Tests.ps1
@@ -170,4 +170,58 @@ Describe 'uninstall.ps1 (v3)' {
         $out | Should -Match '-DryRun'
         $out | Should -Not -Match 'LegacyV1'
     }
+
+    It 'removes profile token file when present' {
+        $d = New-TestDirs
+        try {
+            Write-TestSettings (Join-Path $d.Home '.claude\settings.json')
+            # Create a profile token file
+            $profDir = Join-Path $d.Home '.config\juggernaut'
+            $profFile = Join-Path $profDir 'bearer-token'
+            New-Item -ItemType Directory -Path $profDir -Force | Out-Null
+            'sk-brk-uninstall-prof' | Set-Content -Path $profFile -Encoding utf8 -NoNewline
+            Test-Path $profFile | Should -BeTrue
+
+            # Override the profile token path
+            $oldProfileTokenPath = $env:JUGGERNAUT_PROFILE_TOKEN_PATH
+            $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $profFile
+            try {
+                $r = Invoke-Uninstall $d @{ Force = $true }
+                $r.Output | Should -Match 'profile token file'
+                Test-Path $profFile | Should -BeFalse
+            } finally {
+                if ($null -eq $oldProfileTokenPath) {
+                    Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+                } else {
+                    $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $oldProfileTokenPath
+                }
+            }
+        } finally { Remove-TestDirs $d }
+    }
+
+    It 'dry-run with profile token shows it but leaves file intact' {
+        $d = New-TestDirs
+        try {
+            Write-TestSettings (Join-Path $d.Home '.claude\settings.json')
+            $profDir = Join-Path $d.Home '.config\juggernaut'
+            $profFile = Join-Path $profDir 'bearer-token'
+            New-Item -ItemType Directory -Path $profDir -Force | Out-Null
+            'sk-brk-dry-prof' | Set-Content -Path $profFile -Encoding utf8 -NoNewline
+
+            $oldProfileTokenPath = $env:JUGGERNAUT_PROFILE_TOKEN_PATH
+            $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $profFile
+            try {
+                $r = Invoke-Uninstall $d @{ DryRun = $true }
+                $r.Output | Should -Match '\[dry-run\]'
+                $r.Output | Should -Match 'profile token file'
+                Test-Path $profFile | Should -BeTrue
+            } finally {
+                if ($null -eq $oldProfileTokenPath) {
+                    Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue
+                } else {
+                    $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $oldProfileTokenPath
+                }
+            }
+        } finally { Remove-TestDirs $d }
+    }
 }


### PR DESCRIPTION
Fixes #89.

## Summary
- adds PowerShell profile token store/read/delete support under XDG_CONFIG_HOME or ~/.config/juggernaut/bearer-token
- makes apply.ps1 -Storage profile persist the token and fail if persistence fails
- teaches doctor.ps1 and uninstall.ps1 to recognize and clean profile token storage
- adds focused Pester coverage for profile storage, apply persistence, doctor detection, and uninstall cleanup

## Validation
- Invoke-Pester -Path tests\v2 -Output Detailed - 172 passed
- git diff --check