### PR TITLE
docs + feat: improve uninstall + add --full removal flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,11 +367,14 @@ If you manually set `AWS_BEARER_TOKEN_BEDROCK` in your own shell profile and it 
 
 ## Uninstall
 
+### Remove Juggernaut configuration
+
 ```bash
 # Preview what will be removed
 juggernaut uninstall --dry-run
 
-# Remove the Juggernaut block from settings.json (all scopes) and the bearer token storage
+# Remove the Juggernaut block from settings.json, bearer token storage,
+# and the Claude launcher shell/profile block
 juggernaut uninstall
 
 # Limit to one scope
@@ -379,7 +382,71 @@ juggernaut uninstall --scope=user
 juggernaut uninstall --scope=project
 ```
 
-`juggernaut uninstall` removes the `juggernaut` key from settings.json and deletes the bearer token storage entry (OS keychain on macOS/Windows for short keys, per-user DPAPI file on Windows for long keys >1280 chars, profile file on Linux). It does not touch shell profiles (v3 never writes to them). For a full filesystem-level wipe — including any legacy profile blocks left over from older versions — re-run `install.sh` / `install.ps1`; the installer runs its destructive wipe before every install.
+"juggernaut uninstall" removes the "juggernaut" key from settings.json, deletes the bearer token storage entry (OS keychain on macOS/Windows for short keys, per-user DPAPI file on Windows for long keys >1280 chars, profile file on Linux), removes the Juggernaut "claude" launcher block from shell profiles, and removes the legacy "~/.local/bin/claude" symlink if present. It intentionally leaves the "juggernaut" command launcher and install directory in place so you can reconfigure later.
+
+### Fully remove Juggernaut
+
+> Warning: This will permanently delete your Juggernaut installation, all stored tokens, and configuration. This action cannot be undone.
+
+For most users, re-running the installer is still the easiest full-wipe path: the installer performs a destructive wipe before reinstalling. Use "juggernaut uninstall --full" only when you want Juggernaut removed from the machine instead of reinstalled.
+
+macOS:
+
+```bash
+juggernaut uninstall --full --dry-run
+juggernaut uninstall --full --yes
+
+# Clear the current shell's command cache. Start a new terminal if "claude"
+# or "juggernaut" was already loaded in this shell.
+hash -r 2>/dev/null || true
+unset -f claude 2>/dev/null || true
+unfunction claude 2>/dev/null || true
+functions -e claude 2>/dev/null || true
+
+# Optional sanity checks: these should print nothing for Juggernaut.
+command -v juggernaut || true
+type claude
+```
+
+Linux, WSL, and Git Bash:
+
+```bash
+juggernaut uninstall --full --dry-run
+juggernaut uninstall --full --yes
+
+# Clear the current shell's command cache. Start a new terminal if "claude"
+# or "juggernaut" was already loaded in this shell.
+hash -r 2>/dev/null || true
+unset -f claude 2>/dev/null || true
+unfunction claude 2>/dev/null || true
+functions -e claude 2>/dev/null || true
+
+# Optional sanity checks: these should print nothing for Juggernaut.
+command -v juggernaut || true
+type claude
+```
+
+Windows PowerShell:
+
+```powershell
+juggernaut uninstall --full --dry-run
+juggernaut uninstall --full --yes
+
+# Start a new PowerShell session if "claude" or "juggernaut" was already loaded.
+
+# Optional sanity checks: these should not point at Juggernaut.
+Get-Command juggernaut -ErrorAction SilentlyContinue
+Get-Command claude -All
+```
+
+If "Get-Command claude -All" still shows a PowerShell "Function" named "claude",
+open a new PowerShell session. If it still appears after that, remove the
+"# BEGIN: Juggernaut Launcher" block from your PowerShell profile and restart
+PowerShell.
+
+If you installed with "JUGGERNAUT_DIR", full uninstall removes that custom install directory instead of "$HOME/.juggernaut" / "$HOME\.juggernaut".
+
+The installer does not modify your PATH. If you manually added "~/.local/bin" (or equivalent) only for Juggernaut, remove that entry from your shell profile after deletion.
 
 After uninstalling, Claude Code will prompt you to log in with your Anthropic account.
 

--- a/commands/uninstall.ps1
+++ b/commands/uninstall.ps1
@@ -5,6 +5,8 @@ param(
     [string]$Scope = '',
     [switch]$DryRun,
     [Alias('f')][switch]$Force,
+    [switch]$Full,
+    [Alias('y')][switch]$Yes,
     [switch]$Help,
     [switch]$Version,
     [Parameter(ValueFromRemainingArguments=$true)][string[]]$RemainingArgs
@@ -18,6 +20,8 @@ foreach ($arg in $RemainingArgs) {
     switch -Regex ($arg) {
         '^--dry-run$'              { $DryRun = $true }
         '^--force$|^-f$'           { $Force = $true }
+        '^--full$'                 { $Full = $true }
+        '^--yes$|^-y$'             { $Yes = $true; $Force = $true }
         '^--scope=(user|project)$' { $Scope = $Matches[1] }
         '^--scope='                { Write-Error "uninstall: --scope must be 'user' or 'project' (got: '$($arg.Substring(8))')"; exit 1 }
         '^--help$|^-h$'            { $Help = $true }
@@ -30,18 +34,28 @@ if ($Help) {
     @'
 juggernaut uninstall - remove Juggernaut configuration
 
-Usage: juggernaut.ps1 uninstall [-Scope user|project] [-DryRun] [-Force]
+Usage:
+  juggernaut.ps1 uninstall [-Scope user|project] [-DryRun] [-Force]
+  juggernaut.ps1 uninstall -Full [-DryRun] [-Yes]
 
 Options:
   -Scope user|project  Limit removal to one scope (default: all scopes with a block)
   -DryRun              Preview changes without writing files
   -Force               Skip confirmation prompt
+  -Full                Also remove the Juggernaut command shims and install tree
+  -Yes                 Confirm full removal without prompting
 
 Removes the Juggernaut block from settings.json, the keychain entry, and
 the launcher profile block from `$PROFILE.CurrentUserCurrentHost` (plus
 the sibling host's profile when present). The installer-wipe regex is
 the only place Juggernaut strips legacy profile blocks from earlier
-versions — run `install.ps1` for that.
+versions - run `install.ps1` for that.
+
+Examples:
+  juggernaut uninstall --dry-run
+  juggernaut uninstall --force
+  juggernaut uninstall --full --dry-run
+  juggernaut uninstall --full --yes
 '@
     exit 0
 }
@@ -124,7 +138,21 @@ function Test-ProfileHasLauncherBlock([string]$Path) {
 $launcherProfiles = @(Get-LauncherProfileTargets | Where-Object { Test-ProfileHasLauncherBlock $_ })
 $hasLauncher = $launcherProfiles.Count -gt 0
 
-if (-not ($hasUser -or $hasProject -or $hasKeychain -or $hasDpapi -or $hasProfileToken -or $hasLauncher)) {
+$fullInstallDir = if ($env:JUGGERNAUT_DIR) { $env:JUGGERNAUT_DIR } else { Join-Path $HOME '.juggernaut' }
+$fullShimDir = Join-Path $HOME '.local\bin'
+$fullShimPaths = @(
+    (Join-Path $fullShimDir 'juggernaut.cmd'),
+    (Join-Path $fullShimDir 'juggernaut.ps1'),
+    (Join-Path $fullShimDir 'juggernaut-install-dir.txt')
+)
+$fullExistingShimPaths = @()
+$hasFullInstallDir = $false
+if ($Full) {
+    $fullExistingShimPaths = @($fullShimPaths | Where-Object { Test-Path $_ })
+    $hasFullInstallDir = Test-Path $fullInstallDir
+}
+
+if (-not ($hasUser -or $hasProject -or $hasKeychain -or $hasDpapi -or $hasProfileToken -or $hasLauncher -or $fullExistingShimPaths.Count -gt 0 -or $hasFullInstallDir)) {
     Write-Output 'Nothing to uninstall.'
     exit 0
 }
@@ -132,7 +160,12 @@ if (-not ($hasUser -or $hasProject -or $hasKeychain -or $hasDpapi -or $hasProfil
 # ---------------------------------------------------------------------------
 # Confirmation
 # ---------------------------------------------------------------------------
-if (-not $Force -and -not $DryRun) {
+if (-not $DryRun -and ((-not $Force) -or ($Full -and -not $Yes))) {
+    if ($Full) {
+        Write-Output 'Warning: full uninstall permanently deletes your Juggernaut installation, stored tokens, and configuration.'
+        Write-Output 'This action cannot be undone.'
+        Write-Output ''
+    }
     Write-Output 'The following will be removed:'
     if ($hasUser)        { Write-Output "  - Juggernaut block from $userPath" }
     if ($hasProject)     { Write-Output "  - Juggernaut block from $projectPath" }
@@ -140,6 +173,8 @@ if (-not $Force -and -not $DryRun) {
     if ($hasDpapi)       { Write-Output "  - DPAPI file: $dpapiPath" }
     if ($hasProfileToken) { Write-Output "  - Profile token file: $profileTokenPath" }
     foreach ($lp in $launcherProfiles) { Write-Output "  - Launcher block from $lp" }
+    foreach ($shim in $fullExistingShimPaths) { Write-Output "  - Juggernaut command shim: $shim" }
+    if ($hasFullInstallDir) { Write-Output "  - Juggernaut install directory: $fullInstallDir" }
     Write-Output ''
     $answer = Read-Host 'Proceed? [y/N]'
     if ($answer -notmatch '^[Yy]') { Write-Output 'Aborted.'; exit 0 }
@@ -208,9 +243,33 @@ foreach ($lp in $launcherProfiles) {
     else         { Remove-LauncherProfileBlock $lp }
 }
 
+if ($Full) {
+    foreach ($shim in $fullExistingShimPaths) {
+        if ($DryRun) {
+            Write-Output "[dry-run] Would remove Juggernaut command shim: $shim"
+        } else {
+            Remove-Item -LiteralPath $shim -Force -ErrorAction SilentlyContinue
+            Write-Output "Removed Juggernaut command shim: $shim"
+        }
+    }
+
+    if ($hasFullInstallDir) {
+        if ($DryRun) {
+            Write-Output "[dry-run] Would remove Juggernaut install directory: $fullInstallDir"
+        } else {
+            Remove-Item -LiteralPath $fullInstallDir -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Output "Removed Juggernaut install directory: $fullInstallDir"
+        }
+    }
+}
+
 if ($DryRun) {
     Write-Output 'No files were changed.'
 } else {
     Write-Output ''
-    Write-Output 'Uninstall complete.'
+    if ($Full) {
+        Write-Output 'Full uninstall complete.'
+    } else {
+        Write-Output 'Uninstall complete.'
+    }
 }

--- a/commands/uninstall.sh
+++ b/commands/uninstall.sh
@@ -9,31 +9,45 @@ export BEDROCK_CONFIG_PATH
 
 DRY_RUN=false
 FORCE=false
+FULL=false
+YES=false
 REQUESTED_SCOPE=""
 
 for arg in "$@"; do
   case "$arg" in
     --dry-run)    DRY_RUN=true ;;
     --force|-f)   FORCE=true ;;
+    --full)       FULL=true ;;
+    --yes|-y)     YES=true; FORCE=true ;;
     --scope=*)    REQUESTED_SCOPE="${arg#--scope=}" ;;
     --version|-v) cat "$SCRIPT_DIR/VERSION" 2>/dev/null || echo "unknown"; exit 0 ;;
     --help|-h)
       cat <<'EOF'
 juggernaut uninstall - remove Juggernaut configuration
 
-Usage: juggernaut uninstall [--scope=user|project] [--dry-run] [--force]
+Usage:
+  juggernaut uninstall [--scope=user|project] [--dry-run] [--force]
+  juggernaut uninstall --full [--dry-run] [--yes]
 
 Options:
   --scope=user|project  Limit removal to one scope (default: all scopes with a block)
   --dry-run             Preview changes without writing files
   --force, -f           Skip confirmation prompt
+  --full                Also remove the Juggernaut command launcher and install tree
+  --yes, -y             Confirm full removal without prompting
 
 Removes the Juggernaut block from settings.json, the keychain entry, and
 the Claude launcher function block from shell profiles (~/.bashrc,
 ~/.zshrc, ~/.profile). Also removes a legacy ~/.local/bin/claude symlink
 from earlier launcher iterations if present. Does not strip legacy
-v1/v2 profile blocks from earlier versions — run the installer
+v1/v2 profile blocks from earlier versions - run the installer
 (install.sh) for that full-wipe pass.
+
+Examples:
+  juggernaut uninstall --dry-run
+  juggernaut uninstall --force
+  juggernaut uninstall --full --dry-run
+  juggernaut uninstall --full --yes
 EOF
       exit 0 ;;
     *) echo "uninstall: unknown option '$arg'" >&2; exit 1 ;;
@@ -116,18 +130,33 @@ legacy_symlink="$HOME/.local/bin/claude"
 has_legacy_symlink=false
 [[ -L "$legacy_symlink" ]] && has_legacy_symlink=true
 
+full_launcher="$HOME/.local/bin/juggernaut"
+full_install_dir="${JUGGERNAUT_DIR:-$HOME/.juggernaut}"
+has_full_launcher=false
+has_full_install_dir=false
+if [[ "$FULL" == "true" ]]; then
+  [[ -e "$full_launcher" || -L "$full_launcher" ]] && has_full_launcher=true
+  [[ -e "$full_install_dir" ]] && has_full_install_dir=true
+fi
+
 if [[ "$has_user" == "false" && "$has_project" == "false" \
       && "$has_keychain" == "false" && "$has_dpapi" == "false" \
       && "$has_profile_token" == "false" \
-      && "$has_launcher" == "false" && "$has_legacy_symlink" == "false" ]]; then
+      && "$has_launcher" == "false" && "$has_legacy_symlink" == "false" \
+      && "$has_full_launcher" == "false" && "$has_full_install_dir" == "false" ]]; then
   echo "Nothing to uninstall."
   exit 0
 fi
 
 # ---------------------------------------------------------------------------
-# Confirmation (skipped for --force and --dry-run)
+# Confirmation (skipped for --force/--yes and --dry-run; --full requires --yes)
 # ---------------------------------------------------------------------------
-if [[ "$FORCE" != "true" && "$DRY_RUN" != "true" ]]; then
+if [[ "$DRY_RUN" != "true" && ( "$FORCE" != "true" || ( "$FULL" == "true" && "$YES" != "true" ) ) ]]; then
+  if [[ "$FULL" == "true" ]]; then
+    echo "Warning: full uninstall permanently deletes your Juggernaut installation, stored tokens, and configuration."
+    echo "This action cannot be undone."
+    echo ""
+  fi
   echo "The following will be removed:"
   [[ "$has_user"    == "true" ]] && printf '  - Juggernaut block from %s\n' "$user_path"
   [[ "$has_project" == "true" ]] && printf '  - Juggernaut block from %s\n' "$project_path"
@@ -138,6 +167,8 @@ if [[ "$FORCE" != "true" && "$DRY_RUN" != "true" ]]; then
     printf '  - Launcher block from %s\n' "$_lp"
   done
   [[ "$has_legacy_symlink" == "true" ]] && printf '  - Legacy launcher symlink: %s\n' "$legacy_symlink"
+  [[ "$has_full_launcher" == "true" ]] && printf '  - Juggernaut command launcher: %s\n' "$full_launcher"
+  [[ "$has_full_install_dir" == "true" ]] && printf '  - Juggernaut install directory: %s\n' "$full_install_dir"
   echo ""
   read -r -p "Proceed? [y/N] " _answer
   case "$_answer" in
@@ -227,9 +258,33 @@ if [[ "$has_legacy_symlink" == "true" ]]; then
   fi
 fi
 
+if [[ "$FULL" == "true" ]]; then
+  if [[ "$has_full_launcher" == "true" ]]; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+      printf '[dry-run] Would remove Juggernaut command launcher: %s\n' "$full_launcher"
+    else
+      rm -f -- "$full_launcher"
+      printf 'Removed Juggernaut command launcher: %s\n' "$full_launcher"
+    fi
+  fi
+
+  if [[ "$has_full_install_dir" == "true" ]]; then
+    if [[ "$DRY_RUN" == "true" ]]; then
+      printf '[dry-run] Would remove Juggernaut install directory: %s\n' "$full_install_dir"
+    elif [[ -n "$full_install_dir" && "$full_install_dir" != "/" ]]; then
+      rm -rf -- "$full_install_dir"
+      printf 'Removed Juggernaut install directory: %s\n' "$full_install_dir"
+    fi
+  fi
+fi
+
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "No files were changed."
 else
   echo ""
-  echo "Uninstall complete."
+  if [[ "$FULL" == "true" ]]; then
+    echo "Full uninstall complete."
+  else
+    echo "Uninstall complete."
+  fi
 fi

--- a/tests/v2/Uninstall.Tests.ps1
+++ b/tests/v2/Uninstall.Tests.ps1
@@ -84,6 +84,44 @@ Describe 'uninstall.ps1 (v3)' {
         } finally { Remove-TestDirs $d }
     }
 
+    It '-Full dry-run shows command shims and install tree without removing them' {
+        $d = New-TestDirs
+        try {
+            $shimDir = Join-Path $d.Home '.local\bin'
+            New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
+            $shim = Join-Path $shimDir 'juggernaut.cmd'
+            'echo juggernaut' | Set-Content -Path $shim -Encoding ascii
+            $installDir = Join-Path $d.Home '.juggernaut'
+            New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+
+            $r = Invoke-Uninstall $d @{ Full = $true; DryRun = $true }
+            $r.Output | Should -Match '\[dry-run\] Would remove Juggernaut command shim'
+            $r.Output | Should -Match '\[dry-run\] Would remove Juggernaut install directory'
+            $r.Output | Should -Match 'No files were changed'
+            Test-Path $shim | Should -BeTrue
+            Test-Path $installDir | Should -BeTrue
+        } finally { Remove-TestDirs $d }
+    }
+
+    It '-Full -Yes removes command shims and install tree' {
+        $d = New-TestDirs
+        try {
+            $shimDir = Join-Path $d.Home '.local\bin'
+            New-Item -ItemType Directory -Path $shimDir -Force | Out-Null
+            $shim = Join-Path $shimDir 'juggernaut.cmd'
+            'echo juggernaut' | Set-Content -Path $shim -Encoding ascii
+            $installDir = Join-Path $d.Home '.juggernaut'
+            New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+
+            $r = Invoke-Uninstall $d @{ Full = $true; Yes = $true }
+            $r.Output | Should -Match 'Removed Juggernaut command shim'
+            $r.Output | Should -Match 'Removed Juggernaut install directory'
+            $r.Output | Should -Match 'Full uninstall complete'
+            Test-Path $shim | Should -BeFalse
+            Test-Path $installDir | Should -BeFalse
+        } finally { Remove-TestDirs $d }
+    }
+
     It 'removes juggernaut block and preserves unrelated keys' {
         $d = New-TestDirs
         try {
@@ -168,6 +206,8 @@ Describe 'uninstall.ps1 (v3)' {
         $out = & $script:UninstallScript -Help 2>&1 | Out-String
         $out | Should -Match '-Scope'
         $out | Should -Match '-DryRun'
+        $out | Should -Match '-Full'
+        $out | Should -Match '-Yes'
         $out | Should -Not -Match 'LegacyV1'
     }
 

--- a/tests/v2/test_uninstall.sh
+++ b/tests/v2/test_uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tests/v2/test_uninstall.sh — v3 tests for commands/uninstall.sh.
-# Covers: scope removal (user, project, both), --dry-run, --force, keychain.
-# v3: uninstall does NOT touch shell profiles — those are cleaned by install.sh's wipe.
+# Covers: scope removal (user, project, both), --dry-run, --force, --full, keychain.
+# v3: uninstall removes the Juggernaut launcher block but leaves legacy v1/v2 profile blocks.
 
 set -uo pipefail
 
@@ -68,6 +68,34 @@ if [[ $rc -eq 0 && "$output" == *"[dry-run]"* && "$output" == *"settings.json"* 
 else fail "unexpected dry-run output (rc=$rc): $output"; fi
 if config_has_juggernaut_block "$(cat "$TMP_HOME/.claude/settings.json")"; then pass
 else fail "dry-run must not modify settings.json"; fi
+
+# ---------------------------------------------------------------------------
+# --full dry-run shows command launcher and install tree removal
+# ---------------------------------------------------------------------------
+section "--full dry-run shows command launcher and install tree removal"
+mkdir -p "$TMP_HOME/.local/bin" "$TMP_HOME/.juggernaut"
+printf '#!/usr/bin/env bash\n' > "$TMP_HOME/.local/bin/juggernaut"
+output="$(run_uninstall --full --dry-run 2>&1)"; rc=$?
+if [[ $rc -eq 0 \
+      && "$output" == *"[dry-run] Would remove Juggernaut command launcher"* \
+      && "$output" == *"[dry-run] Would remove Juggernaut install directory"* \
+      && "$output" == *"No files were changed"* ]]; then pass
+else fail "unexpected --full dry-run output (rc=$rc): $output"; fi
+if [[ -f "$TMP_HOME/.local/bin/juggernaut" && -d "$TMP_HOME/.juggernaut" ]]; then pass
+else fail "--full dry-run must not remove launcher or install tree"; fi
+
+# ---------------------------------------------------------------------------
+# --full --yes removes command launcher and install tree
+# ---------------------------------------------------------------------------
+section "--full --yes removes command launcher and install tree"
+output="$(run_uninstall --full --yes 2>&1)"; rc=$?
+if [[ $rc -eq 0 \
+      && "$output" == *"Removed Juggernaut command launcher"* \
+      && "$output" == *"Removed Juggernaut install directory"* \
+      && "$output" == *"Full uninstall complete"* ]]; then pass
+else fail "unexpected --full --yes output (rc=$rc): $output"; fi
+if [[ ! -e "$TMP_HOME/.local/bin/juggernaut" && ! -d "$TMP_HOME/.juggernaut" ]]; then pass
+else fail "--full --yes should remove launcher and install tree"; fi
 
 # ---------------------------------------------------------------------------
 # Real uninstall removes block, preserves unrelated keys
@@ -162,8 +190,8 @@ else fail "expected error for invalid scope (rc=$rc): $output"; fi
 section "uninstall --help exits 0 and omits legacy flags"
 help_out="$(run_uninstall --help 2>&1)"; rc=$?
 if [[ $rc -eq 0 ]]; then pass; else fail "uninstall --help should exit 0 (got $rc)"; fi
-if [[ "$help_out" == *"--scope"* && "$help_out" == *"--dry-run"* ]]; then pass
-else fail "uninstall --help should mention --scope and --dry-run"; fi
+if [[ "$help_out" == *"--scope"* && "$help_out" == *"--dry-run"* && "$help_out" == *"--full"* && "$help_out" == *"--yes"* ]]; then pass
+else fail "uninstall --help should mention --scope, --dry-run, --full, and --yes"; fi
 if [[ "$help_out" != *"--legacy-v1"* ]]; then pass
 else fail "uninstall --help should NOT mention --legacy-v1"; fi
 


### PR DESCRIPTION
## Summary

- Adds juggernaut uninstall --full / -Full for full removal of Juggernaut command launchers/shims and the install tree after normal configuration cleanup.
- Adds --yes / -Yes confirmation support for non-interactive full removal, plus --full --dry-run output for safe previews.
- Refreshes README uninstall docs with cleaner config-uninstall guidance, a full-removal warning, macOS/Linux/WSL/Git Bash/Windows instructions, fish shell cleanup, installer full-wipe guidance, sanity checks, and PATH cleanup notes.
- Adds focused Unix and PowerShell uninstall tests for help text and full-removal behavior.

## Why

The previous README documented configuration cleanup but did not provide a clean built-in way to remove the installed juggernaut command and install directory. Users could run juggernaut uninstall successfully and still see the command on PATH via installer-created launchers/shims.

## Validation

- git diff --check passed.
- ash ./tests/v2/test_uninstall.sh passed via Git Bash: 22 passed, 0 failed.
- Verified Unix --full --dry-run output against a temporary HOME.
- Verified Windows PowerShell help and -Full -DryRun output against a temporary HOME. Full Pester suite was not run on this workstation because the active PowerShell profile contains real Juggernaut launcher blocks, and non-dry-run uninstall tests could modify that profile.