### PR TITLE
test: isolate PowerShell launcher tests

### DIFF
--- a/tests/v2/Launcher.Tests.ps1
+++ b/tests/v2/Launcher.Tests.ps1
@@ -71,10 +71,22 @@ exit /b 42
     function Invoke-LauncherWith([string]$ProfilePath, [string]$Command, [hashtable]$EnvOverrides = @{}) {
         $pwsh = Get-Command pwsh.exe -ErrorAction SilentlyContinue
         if (-not $pwsh) { $pwsh = Get-Command powershell.exe -ErrorAction Stop }
+        $effectiveEnv = @{
+            AWS_BEARER_TOKEN_BEDROCK      = $null
+            HOME                          = $script:IsolatedHome
+            USERPROFILE                   = $script:IsolatedHome
+            XDG_CONFIG_HOME               = (Join-Path $script:IsolatedHome '.config')
+            JUGGERNAUT_HOME               = $script:IsolatedHome
+            JUGGERNAUT_PROFILE_TOKEN_PATH = (Join-Path (Join-Path $script:IsolatedHome '.config\juggernaut') 'bearer-token')
+            JUGGERNAUT_KEYCHAIN_SERVICE   = $script:IsolatedService
+        }
+        foreach ($k in $EnvOverrides.Keys) {
+            $effectiveEnv[$k] = $EnvOverrides[$k]
+        }
         # Build env assignments as a prelude.
         $envPrelude = ''
-        foreach ($k in $EnvOverrides.Keys) {
-            $v = $EnvOverrides[$k]
+        foreach ($k in $effectiveEnv.Keys) {
+            $v = $effectiveEnv[$k]
             if ($null -eq $v) {
                 $envPrelude += "Remove-Item Env:\$k -ErrorAction SilentlyContinue; "
             } else {
@@ -187,12 +199,15 @@ Describe 'function claude runtime behavior' {
         Install-BlockToPath $script:TestProfile
         $script:StubDir = Join-Path ([IO.Path]::GetTempPath()) ("jug-stub-" + [Guid]::NewGuid().ToString('N'))
         $script:StubBin = New-StubClaudeCmd $script:StubDir
+        $script:IsolatedHome = Join-Path ([IO.Path]::GetTempPath()) ("jug-launcher-home-" + [Guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:IsolatedHome -Force | Out-Null
         # Isolate the keychain service name so the stub never hits a real entry.
         $script:IsolatedService = "juggernaut-absent-pester-$([Guid]::NewGuid().ToString('N'))"
     }
     AfterAll {
         Remove-Item -Path (Split-Path -Parent $script:TestProfile) -Recurse -Force -ErrorAction SilentlyContinue
         Remove-Item -Path $script:StubDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $script:IsolatedHome -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     It 'function precedence: Get-Command claude resolves to a function after dot-sourcing the profile' {

--- a/tests/v2/Uninstall.Tests.ps1
+++ b/tests/v2/Uninstall.Tests.ps1
@@ -36,19 +36,34 @@ BeforeAll {
         $oldHome    = $env:HOME
         $oldProfile = $env:USERPROFILE
         $oldBedrock = $env:BEDROCK_CONFIG_PATH
+        $oldXdg     = $env:XDG_CONFIG_HOME
+        $oldJugHome = $env:JUGGERNAUT_HOME
+        $oldProfTok = $env:JUGGERNAUT_PROFILE_TOKEN_PATH
+        $oldPsProfile = $PROFILE
         $oldLoc     = (Get-Location).Path
         try {
             $env:HOME = $d.Home; $env:USERPROFILE = $d.Home
             $env:BEDROCK_CONFIG_PATH = $script:BedrockConfigPath
+            $env:XDG_CONFIG_HOME = Join-Path $d.Home '.config'
+            $env:JUGGERNAUT_HOME = $d.Home
+            $env:JUGGERNAUT_PROFILE_TOKEN_PATH = Join-Path (Join-Path $d.Home '.config\juggernaut') 'bearer-token'
             Set-Variable -Name HOME -Value $d.Home -Scope Global -Force
+            $profilePath = Join-Path $d.Home 'Documents\PowerShell\Microsoft.PowerShell_profile.ps1'
+            Set-Variable -Name PROFILE -Value ([pscustomobject]@{
+                CurrentUserCurrentHost = $profilePath
+            }) -Scope Global -Force
             Set-Location $d.Work
             $output = & $script:UninstallScript @params 2>&1 | Out-String
             return @{ Output = $output; ExitCode = $LASTEXITCODE }
         } finally {
             Set-Location $oldLoc
             Set-Variable -Name HOME -Value $oldHome -Scope Global -Force
+            Set-Variable -Name PROFILE -Value $oldPsProfile -Scope Global -Force
             $env:HOME = $oldHome; $env:USERPROFILE = $oldProfile
             $env:BEDROCK_CONFIG_PATH = $oldBedrock
+            if ($null -eq $oldXdg) { Remove-Item Env:\XDG_CONFIG_HOME -ErrorAction SilentlyContinue } else { $env:XDG_CONFIG_HOME = $oldXdg }
+            if ($null -eq $oldJugHome) { Remove-Item Env:\JUGGERNAUT_HOME -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_HOME = $oldJugHome }
+            if ($null -eq $oldProfTok) { Remove-Item Env:\JUGGERNAUT_PROFILE_TOKEN_PATH -ErrorAction SilentlyContinue } else { $env:JUGGERNAUT_PROFILE_TOKEN_PATH = $oldProfTok }
         }
     }
 


### PR DESCRIPTION
## Summary

- Isolates `Uninstall.Tests.ps1` from the developer machine's real PowerShell profile, HOME/USERPROFILE, JUGGERNAUT_HOME, XDG_CONFIG_HOME, and profile-token path.
- Isolates `Launcher.Tests.ps1` runtime invocations from real DPAPI/profile-token state by defaulting launcher child processes to a temp Juggernaut home and empty bearer-token env.
- Keeps per-test overrides available for cases that intentionally set a token, keychain service, or PATH.

## Why

Fixes #90. Local PowerShell tests could observe a real installed Juggernaut launcher block or DPAPI bearer-token file, which made tests fail or pass based on workstation state rather than fixture state.

## Validation

- `git diff --check` passed.
- Targeted PowerShell Pester run passed outside the sandbox: 34 passed, 0 failed. Pester 5 needs temporary HKCU registry access, which the sandbox blocks.
