### PR TITLE
docs: clarify bearer token storage

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -31,7 +31,7 @@ aws sts get-caller-identity
 
 ### 3. Install Juggernaut
 
-The installer is a **destructive wipe-and-reinstall**: it strips any legacy Juggernaut shell-profile blocks, removes the `juggernaut` key from `~/.claude/settings.json`, and deletes the `juggernaut-bedrock` OS-keychain entry before placing fresh files. The installer does **not** auto-apply.
+The installer is a **destructive wipe-and-reinstall**: it strips any legacy Juggernaut shell-profile blocks, removes the `juggernaut` key from `~/.claude/settings.json`, and deletes Juggernaut bearer token storage before placing fresh files. The installer does **not** auto-apply.
 
 ```bash
 # Unix / macOS / Linux / Git Bash / WSL
@@ -59,7 +59,7 @@ $u='https://raw.githubusercontent.com/jpvelasco/juggernaut/v3.1.0/install.ps1'; 
 # IAM / SSO (recommended)
 juggernaut apply --auth=iam
 
-# Bedrock API key (interactive — key stored in OS keychain)
+# Bedrock API key (interactive — key stored in keychain/Credential Manager/DPAPI/profile storage)
 juggernaut apply --auth=bedrock-api-key
 ```
 
@@ -69,14 +69,14 @@ juggernaut apply --auth=bedrock-api-key
 .\juggernaut.ps1 apply -Auth bedrock-api-key
 ```
 
-`juggernaut apply` refuses to write `CLAUDE_CODE_USE_BEDROCK=1` to `settings.json` unless a valid auth source is present (`aws sts get-caller-identity` succeeds, `AWS_BEARER_TOKEN_BEDROCK` is set, or the `juggernaut-bedrock` keychain entry exists).
+`juggernaut apply` refuses to write `CLAUDE_CODE_USE_BEDROCK=1` to `settings.json` unless a valid auth source is present (`aws sts get-caller-identity` succeeds, `AWS_BEARER_TOKEN_BEDROCK` is set, or Juggernaut bearer token storage exists).
 
 ### 5. Launch
 ```bash
 claude
 ```
 
-Fresh shells automatically pick up the **launcher** installed in step 3 — a `claude()` shell function appended to `~/.bashrc`/`~/.zshrc`/`~/.profile` on Unix, or a `function claude` block in your PowerShell profile on Windows. Both read your bearer token from the OS keychain and inject it into the child process's environment before running the real `claude`. No manual env setup required, and the function approach survives Anthropic's `claude update` self-rewrites.
+Fresh shells automatically pick up the **launcher** installed in step 3 — a `claude()` shell function appended to `~/.bashrc`/`~/.zshrc`/`~/.profile` on Unix, or a `function claude` block in your PowerShell profile on Windows. The launcher reads your bearer token from Juggernaut bearer token storage (macOS keychain, Windows Credential Manager/DPAPI, or Linux profile token file) and injects it into the child process's environment before running the real `claude`. No manual env setup required, and the function approach survives Anthropic's `claude update` self-rewrites.
 
 ## Verify Setup
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ Both scripts normalize the version automatically — `3.0.2` and `v3.0.2` both w
 
 The installer also places a **claude launcher** so fresh shells pick up your bearer token automatically. On both platforms the launcher is a **shell function** that intercepts the `claude` command — it resolves before binaries on PATH, so it survives Anthropic's `claude update` self-rewrites that would clobber a symlink:
 
-- **Unix / macOS / Linux / Git Bash**: a bracketed `claude() { ... }` function block is appended to your `~/.bashrc`, `~/.zshrc`, and/or `~/.profile` (only files that already exist; if none do, the matching rc for `$SHELL` is seeded). The function reads `AWS_BEARER_TOKEN_BEDROCK` from the OS keychain or DPAPI file (when not already in env) via `lib/keychain.sh`, exports it, and runs the real binary via `command claude "$@"`.
+- **Unix / macOS / Linux / Git Bash**: a bracketed `claude() { ... }` function block is appended to your `~/.bashrc`, `~/.zshrc`, and/or `~/.profile` (only files that already exist; if none do, the matching rc for `$SHELL` is seeded). The function reads `AWS_BEARER_TOKEN_BEDROCK` from Juggernaut bearer token storage (macOS keychain, Linux profile token file, or Windows DPAPI/keychain when running under Git Bash) via `bearer_token_get` in `lib/keychain.sh`, exports it, and runs the real binary via `command claude "$@"`.
 - **Windows PowerShell**: a `function claude { ... }` block is written to `$PROFILE.CurrentUserCurrentHost` (and the sibling host's profile when present). PowerShell resolves functions before applications on the command name `claude`, so the function intercepts the call, reads Windows Credential Manager or the DPAPI file, and invokes the real `claude.exe`.
 
-This closes a v3.0.0 gap: `settings.json` flips `CLAUDE_CODE_USE_BEDROCK=1`, but Claude Code reads the bearer token only from its own process env. Without the launcher, a fresh shell with the token only in the keychain would hang. With the launcher, the hand-off happens automatically — and because it's a shell function, not a file on disk, Anthropic's own installer (which writes `~/.local/bin/claude` directly) is never fighting us.
+This closes a v3.0.0 gap: `settings.json` flips `CLAUDE_CODE_USE_BEDROCK=1`, but Claude Code reads the bearer token only from its own process env. Without the launcher, a fresh shell with the token only in Juggernaut storage would hang. With the launcher, the hand-off happens automatically — and because it's a shell function, not a file on disk, Anthropic's own installer (which writes `~/.local/bin/claude` directly) is never fighting us.
 
-**To skip the launcher** (set the token yourself): export `AWS_BEARER_TOKEN_BEDROCK` before running `claude`. The launcher preserves any pre-set value and only injects from the keychain or DPAPI file when the env var is unset.
+**To skip the launcher** (set the token yourself): export `AWS_BEARER_TOKEN_BEDROCK` before running `claude`. The launcher preserves any pre-set value and only injects from Juggernaut bearer token storage when the env var is unset.
 
 **Editor / IDE note:** tools that invoke `claude.exe` directly (bypassing both interactive shells and the PowerShell profile function) won't get the injection and must set the env var themselves.
 
@@ -116,7 +116,7 @@ Juggernaut v3 supports Windows PowerShell 5.1 and PowerShell 7 side-by-side:
 
 ## Configure
 
-After install, pick an auth mode and run `juggernaut apply` explicitly. v3 refuses to write `CLAUDE_CODE_USE_BEDROCK=1` to `~/.claude/settings.json` unless a valid auth source is present (`aws sts get-caller-identity` succeeds, `$AWS_BEARER_TOKEN_BEDROCK` is set, or a `juggernaut-bedrock` keychain entry or DPAPI file exists). This prevents the "installer silently routed me through Bedrock with no credentials" class of hang.
+After install, pick an auth mode and run `juggernaut apply` explicitly. v3 refuses to write `CLAUDE_CODE_USE_BEDROCK=1` to `~/.claude/settings.json` unless a valid auth source is present (`aws sts get-caller-identity` succeeds, `$AWS_BEARER_TOKEN_BEDROCK` is set, or Juggernaut bearer token storage exists). This prevents the "installer silently routed me through Bedrock with no credentials" class of hang.
 
 **IAM / SSO (recommended):**
 


### PR DESCRIPTION
## Summary

- Replaces keychain-only wording in Quickstart with Juggernaut bearer token storage language.
- Clarifies that Bedrock API keys may be stored in macOS keychain, Windows Credential Manager/DPAPI, or Linux profile-token storage.
- Updates README launcher/auth validation wording to mention `bearer_token_get` and Linux profile token files.

## Why

Fixes #91. After Linux profile-token storage became a first-class backend, parts of the docs still implied Unix launcher behavior and interactive API-key storage were keychain-only.

## Validation

- `git diff --check` passed.
- Documentation-only change; no runtime tests run.
