### PR TITLE
fix: show explicit auth commands in doctor

### DIFF
--- a/lib/doctor.ps1
+++ b/lib/doctor.ps1
@@ -281,7 +281,9 @@ function Write-DoctorSummary {
     if ($script:DoctorFails -gt 0) {
         Write-Output 'Status: FAIL'
         Write-Output ('{0} failure(s), {1} warning(s)' -f $script:DoctorFails, $script:DoctorWarns)
-        Write-Output "Run 'juggernaut apply' to fix configuration issues."
+        Write-Output 'Run one of these to configure Juggernaut:'
+        Write-Output '  juggernaut apply -Auth iam'
+        Write-Output '  juggernaut apply -Auth bedrock-api-key'
         return
     }
     if ($script:DoctorWarns -gt 0) {

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -294,7 +294,9 @@ doctor_summary() {
   if (( DOCTOR_FAILS > 0 )); then
     printf 'Status: FAIL\n'
     printf '%d failure(s), %d warning(s)\n' "$DOCTOR_FAILS" "$DOCTOR_WARNS"
-    echo "Run 'juggernaut apply' to fix configuration issues."
+    echo "Run one of these to configure Juggernaut:"
+    echo "  juggernaut apply --auth=iam"
+    echo "  juggernaut apply --auth=bedrock-api-key"
     return 1
   fi
   if (( DOCTOR_WARNS > 0 )); then

--- a/tests/v2/Doctor.Tests.ps1
+++ b/tests/v2/Doctor.Tests.ps1
@@ -182,6 +182,29 @@ Describe 'doctor.ps1' {
         It 'points at juggernaut apply as fix'   { $script:output | Should -Match 'juggernaut apply' }
     }
 
+    Context 'fresh install with no Juggernaut config' {
+        BeforeAll {
+            $script:tmpNoConfigHome = Join-Path ([IO.Path]::GetTempPath()) ("jug-doc-empty-" + [Guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path (Join-Path $script:tmpNoConfigHome '.claude') -Force | Out-Null
+            $script:oldNoConfigHome = $env:HOME
+            $script:oldNoConfigProfile = $env:USERPROFILE
+            $env:HOME = $script:tmpNoConfigHome
+            $env:USERPROFILE = $script:tmpNoConfigHome
+
+            '{}' | Set-Content -Path (Join-Path $script:tmpNoConfigHome '.claude\settings.json') -Encoding utf8
+            $script:noConfigOutput = & (Join-Path $script:repoRoot 'commands\doctor.ps1') 2>&1 | Out-String
+        }
+        AfterAll {
+            $env:HOME = $script:oldNoConfigHome
+            $env:USERPROFILE = $script:oldNoConfigProfile
+            Remove-Item -Recurse -Force $script:tmpNoConfigHome -ErrorAction SilentlyContinue
+        }
+
+        It 'does not recommend bare apply' { $script:noConfigOutput | Should -Not -Match "Run 'juggernaut apply'" }
+        It 'recommends explicit IAM auth' { $script:noConfigOutput | Should -Match 'juggernaut apply -Auth iam' }
+        It 'recommends explicit Bedrock API key auth' { $script:noConfigOutput | Should -Match 'juggernaut apply -Auth bedrock-api-key' }
+    }
+
     Context 'help and unknown flags' {
         It '--help exits cleanly and mentions v3' {
             $out = & (Join-Path $script:repoRoot 'commands\doctor.ps1') --help 2>&1 | Out-String

--- a/tests/v2/test_doctor.sh
+++ b/tests/v2/test_doctor.sh
@@ -140,6 +140,24 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Fresh install guidance must use explicit auth mode.
+# ---------------------------------------------------------------------------
+section "fresh install without config recommends explicit auth mode"
+NO_CONFIG_HOME="$(mktemp -d)"
+mkdir -p "$NO_CONFIG_HOME/.claude"
+printf '{}\n' > "$NO_CONFIG_HOME/.claude/settings.json"
+OUTPUT="$(HOME="$NO_CONFIG_HOME" bash "$REPO_ROOT/commands/doctor.sh" 2>&1)"
+if [[ "$OUTPUT" != *"Run 'juggernaut apply'"* &&
+      "$OUTPUT" == *"juggernaut apply --auth=iam"* &&
+      "$OUTPUT" == *"juggernaut apply --auth=bedrock-api-key"* ]]; then
+  pass
+else
+  fail "expected doctor to recommend explicit apply auth modes"
+  printf '%s\n' "$OUTPUT" >&2
+fi
+rm -rf "$NO_CONFIG_HOME"
+
+# ---------------------------------------------------------------------------
 # Bedrock API-key auth: bearer-token source detected
 # ---------------------------------------------------------------------------
 section "bedrock API-key auth reports bearer-token source"


### PR DESCRIPTION
## Summary
- Update doctor failure guidance to stop recommending bare `juggernaut apply`
- Show platform-appropriate explicit auth commands for PowerShell and Unix shells
- Add regression coverage for fresh installs with no Juggernaut config

## Root cause
After the v3 auth gate, a fresh wipe-and-reinstall intentionally rejects bare `juggernaut apply` when no credentials can be detected. `doctor` still printed the old bare apply remediation, sending users into the exact failure shown after install.

## Validation
- `pwsh -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -ErrorAction Stop; Invoke-Pester -Path .\tests\v2\Doctor.Tests.ps1 -CI"`
- `bash tests/v2/test_doctor.sh`
- `git diff --check`