### PR TITLE
fix: derive launcher/credentials source label from auth.storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ bash ./tests/v2/test_show.sh
 bash ./tests/v2/test_doctor.sh
 bash ./tests/v2/test_uninstall.sh
 bash ./tests/v2/test_install.sh
+bash ./tests/v2/test_launcher.sh
 
 # Run all PowerShell tests (Pester 5 required)
 pwsh -Command "Invoke-Pester ./tests/v2 -CI"
@@ -45,6 +46,7 @@ shellcheck juggernaut install.sh commands/*.sh lib/keychain.sh lib/schema.sh lib
 - `keychain.{sh,ps1}` — OS keychain read/write (macOS Keychain, Linux secret-tool, Windows Credential Manager for short keys, Windows per-user DPAPI file for long keys). Service name: `juggernaut-bedrock`.
 - `doctor.{sh,ps1}` — scope checks, credential checks, opusplan drift check
 - `profile_paths.{sh,ps1}` — list of shell-profile paths scanned by the installer's wipe phase (v3 code itself does not write to these files)
+- `arg_parsing.ps1` — shared argument-parsing helper for PowerShell subcommands (bash uses inline getopts)
 
 **Installer:** `install.sh` / `install.ps1` run a destructive wipe phase on every invocation — strip `# BEGIN: Juggernaut` and `# BEGIN: Claude Code Bedrock Configuration` blocks from all profile paths, remove the `juggernaut` key from settings.json, delete bearer token storage (OS keychain on macOS/Windows for short keys, per-user DPAPI file on Windows for long keys >1280 chars, profile file on Linux) — then install fresh files. Does **not** auto-apply. Supports `--dry-run`/`-DryRun` to preview without writing.
 
@@ -76,7 +78,7 @@ All changes need `.sh` and `.ps1` variants. Targets: macOS (zsh/bash/fish), Linu
 
 ## Version Management
 
-Version must stay in sync across `VERSION`, `bedrock-config.json` (`.version`), and the `${J_VERSION:-3.0.2}` fallback in `lib/schema.sh` / `lib/schema.ps1`.
+Version must stay in sync across `VERSION`, `bedrock-config.json` (`.version`), and the `${J_VERSION:-...}` fallback in `lib/schema.sh` / `lib/schema.ps1`. When bumping, update all three.
 
 ## Gotchas
 

--- a/lib/doctor.ps1
+++ b/lib/doctor.ps1
@@ -237,6 +237,7 @@ function Write-DoctorLauncher {
     $useBedrock = Get-DoctorNestedProp -Object $Block -Path @('env','CLAUDE_CODE_USE_BEDROCK')
     $authMode   = Get-DoctorNestedProp -Object $Block -Path @('auth','mode')
     if ($authMode -eq 'api-key') { $authMode = 'bedrock-api-key' }
+    $storage    = Get-DoctorNestedProp -Object $Block -Path @('auth','storage')
 
     # The launcher injects AWS_BEARER_TOKEN_BEDROCK from the OS keychain. It is
     # only relevant when auth.mode is bedrock-api-key; IAM auth never reads the
@@ -262,9 +263,14 @@ function Write-DoctorLauncher {
 
     $launcher = Test-LauncherInstalled
     if ($launcher.Installed) {
+        $sourceLabel = switch ($storage) {
+            'dpapi'   { 'DPAPI file via launcher' }
+            'profile' { 'profile token file via launcher' }
+            default   { 'system keychain via launcher' }
+        }
         Write-Output 'Status: OK'
         Write-Output ('Launcher: {0}' -f (Show-DoctorHomePath $launcher.Path))
-        Write-Output 'Source: OS keychain via launcher'
+        Write-Output ('Source: {0}' -f $sourceLabel)
         return
     }
 

--- a/lib/doctor.ps1
+++ b/lib/doctor.ps1
@@ -71,7 +71,7 @@ function Write-DoctorCredentials {
     $read = $null
     $readError = ''
     if ($authMode -eq 'bedrock-api-key') {
-        try { $read = Read-BearerToken } catch { $readError = "$_"; $read = $null }
+        try { $read = Read-BearerToken -PreferredStorage $storage } catch { $readError = "$_"; $read = $null }
         if (-not $read.Value -and $read.Error) { $readError = $read.Error; $read = $null }
     }
     switch ($authMode) {
@@ -264,9 +264,9 @@ function Write-DoctorLauncher {
     $launcher = Test-LauncherInstalled
     if ($launcher.Installed) {
         $sourceLabel = switch ($storage) {
-            'dpapi'   { 'DPAPI file via launcher' }
-            'profile' { 'profile token file via launcher' }
-            default   { 'system keychain via launcher' }
+            'dpapi'   { 'DPAPI file via launcher function' }
+            'profile' { 'profile token file via launcher function' }
+            default   { 'system keychain via launcher function' }
         }
         Write-Output 'Status: OK'
         Write-Output ('Launcher: {0}' -f (Show-DoctorHomePath $launcher.Path))

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -75,17 +75,16 @@ doctor_credentials() {
     # Probe in configured-storage-first order so the label reflects the source
     # the launcher will actually use. For profile storage, try the profile token
     # first before falling through to DPAPI/keychain.
-    local dpapi_out dpapi_rc probe_order
+    local dpapi_out dpapi_rc
+    local -a probe_order
     if [[ "$storage" == "profile" ]]; then
-      probe_order="profile dpapi keychain"
-    elif [[ "$storage" == "dpapi" ]]; then
-      probe_order="dpapi keychain profile"
+      probe_order=(profile dpapi keychain)
     else
-      probe_order="dpapi keychain profile"
+      probe_order=(dpapi keychain profile)
     fi
 
     local _step
-    for _step in $probe_order; do
+    for _step in "${probe_order[@]}"; do
       [[ -n "$probe_value" ]] && break
       case "$_step" in
         dpapi)

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -72,46 +72,65 @@ doctor_credentials() {
   probe_error=""
   probe_source=""
   if [[ "$auth_mode" == "bedrock-api-key" ]]; then
-    # Try DPAPI first (Windows long-key case), then keychain. Label the hit.
-    # Capture exit code separately from `|| true` so we can distinguish
-    # "not found" (1) from real errors (2).
-    local dpapi_out dpapi_rc
-    dpapi_out="$({ dpapi_get; printf '\x1e%s' "$?"; } 2>&1)"
-    dpapi_rc="${dpapi_out##*$'\x1e'}"
-    dpapi_out="${dpapi_out%$'\x1e'*}"
-    if [[ "$dpapi_rc" -eq 0 && -n "$dpapi_out" ]]; then
-      probe_value="$dpapi_out"
-      probe_source="DPAPI file"
-      probe_rc=0
-    elif [[ "$dpapi_rc" -eq 2 ]]; then
-      probe_error="$dpapi_out"
+    # Probe in configured-storage-first order so the label reflects the source
+    # the launcher will actually use. For profile storage, try the profile token
+    # first before falling through to DPAPI/keychain.
+    local dpapi_out dpapi_rc probe_order
+    if [[ "$storage" == "profile" ]]; then
+      probe_order="profile dpapi keychain"
+    elif [[ "$storage" == "dpapi" ]]; then
+      probe_order="dpapi keychain profile"
+    else
+      probe_order="dpapi keychain profile"
     fi
-    if [[ -z "$probe_value" ]] && keychain_available 2>/dev/null; then
-      probe_value="$({ keychain_get; printf '\x1e%s' "$?"; } 2>&1)"
-      probe_rc="${probe_value##*$'\x1e'}"
-      probe_value="${probe_value%$'\x1e'*}"
-      if [[ "$probe_rc" -eq 0 && -n "$probe_value" ]]; then
-        probe_source="system keychain"
-      elif [[ "$probe_rc" -ne 0 && "$probe_rc" -ne 1 ]]; then
-        probe_error="${probe_value%$'\n'}"
-        probe_value=""
-      else
-        probe_value=""
-      fi
-    fi
-    if [[ -z "$probe_value" ]]; then
-      probe_value="$({ profile_token_get; printf '\x1e%s' "$?"; } 2>&1)"
-      probe_rc="${probe_value##*$'\x1e'}"
-      probe_value="${probe_value%$'\x1e'*}"
-      if [[ "$probe_rc" -eq 0 && -n "$probe_value" ]]; then
-        probe_source="profile token file"
-      elif [[ "$probe_rc" -ne 0 && "$probe_rc" -ne 1 ]]; then
-        probe_error="${probe_value%$'\n'}"
-        probe_value=""
-      else
-        probe_value=""
-      fi
-    fi
+
+    local _step
+    for _step in $probe_order; do
+      [[ -n "$probe_value" ]] && break
+      case "$_step" in
+        dpapi)
+          dpapi_out="$({ dpapi_get; printf '\x1e%s' "$?"; } 2>&1)"
+          dpapi_rc="${dpapi_out##*$'\x1e'}"
+          dpapi_out="${dpapi_out%$'\x1e'*}"
+          if [[ "$dpapi_rc" -eq 0 && -n "$dpapi_out" ]]; then
+            probe_value="$dpapi_out"
+            probe_source="DPAPI file"
+            probe_rc=0
+          elif [[ "$dpapi_rc" -eq 2 ]]; then
+            probe_error="$dpapi_out"
+          fi
+          ;;
+        keychain)
+          if keychain_available 2>/dev/null; then
+            probe_value="$({ keychain_get; printf '\x1e%s' "$?"; } 2>&1)"
+            probe_rc="${probe_value##*$'\x1e'}"
+            probe_value="${probe_value%$'\x1e'*}"
+            if [[ "$probe_rc" -eq 0 && -n "$probe_value" ]]; then
+              probe_source="system keychain"
+            elif [[ "$probe_rc" -ne 0 && "$probe_rc" -ne 1 ]]; then
+              probe_error="${probe_value%$'\n'}"
+              probe_value=""
+            else
+              probe_value=""
+            fi
+          fi
+          ;;
+        profile)
+          probe_value="$({ profile_token_get; printf '\x1e%s' "$?"; } 2>&1)"
+          probe_rc="${probe_value##*$'\x1e'}"
+          probe_value="${probe_value%$'\x1e'*}"
+          if [[ "$probe_rc" -eq 0 && -n "$probe_value" ]]; then
+            probe_source="profile token file"
+          elif [[ "$probe_rc" -ne 0 && "$probe_rc" -ne 1 ]]; then
+            probe_error="${probe_value%$'\n'}"
+            probe_value=""
+          else
+            probe_value=""
+          fi
+          ;;
+      esac
+    done
+
     probe_error="${probe_error%$'\n'}"
   fi
   case "$auth_mode" in
@@ -233,10 +252,11 @@ doctor_opusplan() {
 
 doctor_launcher() {
   local block="$1"
-  local use_bedrock auth_mode env_token
+  local use_bedrock auth_mode env_token storage
   use_bedrock="$(jq -r '.env.CLAUDE_CODE_USE_BEDROCK // ""' <<<"$block")"
   auth_mode="$(jq -r '.auth.mode // ""' <<<"$block")"
   [[ "$auth_mode" == "api-key" ]] && auth_mode="bedrock-api-key"
+  storage="$(jq -r '.auth.storage // ""' <<<"$block")"
   env_token="${AWS_BEARER_TOKEN_BEDROCK:-}"
 
   # Detect the launcher by scanning the user's shell profiles for the
@@ -277,9 +297,15 @@ doctor_launcher() {
   fi
 
   if [[ "$has_launcher" == "true" ]]; then
+    local source_label
+    case "$storage" in
+      dpapi)    source_label="DPAPI file via launcher function" ;;
+      profile)  source_label="profile token file via launcher function" ;;
+      *)        source_label="system keychain via launcher function" ;;
+    esac
     doctor_ok
     doctor_kv "Launcher" "$(doctor_home_path "${launcher_profiles[0]}")"
-    doctor_kv "Source" "OS keychain via launcher function"
+    doctor_kv "Source" "$source_label"
     return 0
   fi
 

--- a/lib/keychain.ps1
+++ b/lib/keychain.ps1
@@ -425,34 +425,47 @@ function Save-BearerToken {
 
 function Read-BearerToken {
     # Return shape matches Save-BearerToken: { Value; Storage; Error }.
-    # On Windows: DPAPI file first (no P/Invoke cost), then CredMan, then profile.
-    # On Unix: keychain (secret-tool / security), then profile.
+    # Probes in configured-storage-first order so the returned Storage label
+    # matches what the launcher will actually inject. Callers that don't know
+    # the configured storage can omit $PreferredStorage and get the default order.
+    param([string]$PreferredStorage = '')
     $os = Get-KeychainOS
-    if ($os -eq 'windows') {
-        try {
-            $v = Get-DPAPIEntry
-            if (-not [string]::IsNullOrEmpty($v)) {
-                return @{ Value = $v; Storage = 'dpapi'; Error = '' }
+
+    # Build probe order: configured storage first, remaining storages after.
+    $all = if ($os -eq 'windows') { @('dpapi','keychain','profile') } else { @('keychain','profile') }
+    if ($PreferredStorage -and $all -contains $PreferredStorage) {
+        $order = @($PreferredStorage) + ($all | Where-Object { $_ -ne $PreferredStorage })
+    } else {
+        $order = $all
+    }
+
+    foreach ($step in $order) {
+        switch ($step) {
+            'dpapi' {
+                try {
+                    $v = Get-DPAPIEntry
+                    if (-not [string]::IsNullOrEmpty($v)) { return @{ Value = $v; Storage = 'dpapi'; Error = '' } }
+                } catch {
+                    return @{ Value = $null; Storage = 'dpapi'; Error = "$_" }
+                }
             }
-        } catch {
-            return @{ Value = $null; Storage = 'dpapi'; Error = "$_" }
+            'keychain' {
+                try {
+                    $v = Get-KeychainEntry
+                    if (-not [string]::IsNullOrEmpty($v)) { return @{ Value = $v; Storage = 'keychain'; Error = '' } }
+                } catch {
+                    return @{ Value = $null; Storage = 'keychain'; Error = "$_" }
+                }
+            }
+            'profile' {
+                try {
+                    $v = Get-ProfileTokenEntry
+                    if (-not [string]::IsNullOrEmpty($v)) { return @{ Value = $v; Storage = 'profile'; Error = '' } }
+                } catch {
+                    return @{ Value = $null; Storage = 'profile'; Error = "$_" }
+                }
+            }
         }
-    }
-    try {
-        $v = Get-KeychainEntry
-        if (-not [string]::IsNullOrEmpty($v)) {
-            return @{ Value = $v; Storage = 'keychain'; Error = '' }
-        }
-    } catch {
-        return @{ Value = $null; Storage = 'keychain'; Error = "$_" }
-    }
-    try {
-        $v = Get-ProfileTokenEntry
-        if (-not [string]::IsNullOrEmpty($v)) {
-            return @{ Value = $v; Storage = 'profile'; Error = '' }
-        }
-    } catch {
-        return @{ Value = $null; Storage = 'profile'; Error = "$_" }
     }
     return @{ Value = $null; Storage = 'none'; Error = '' }
 }

--- a/tests/v2/Doctor.Tests.ps1
+++ b/tests/v2/Doctor.Tests.ps1
@@ -265,4 +265,47 @@ Describe 'doctor.ps1' {
         It 'reports profile token file as source' { $script:profOutput | Should -Match 'profile token file' }
         It 'reports Storage: profile' { $script:profOutput | Should -Match 'Storage: profile' }
     }
+
+    Context 'Write-DoctorLauncher source label reflects auth.storage' {
+        BeforeAll {
+            . (Join-Path $script:repoRoot 'lib\doctor.ps1')
+            # Override Test-LauncherInstalled to simulate a launcher being present
+            # without needing to touch real shell profiles.
+            function script:Test-LauncherInstalled { return @{ Installed = $true; Path = 'C:\fake\profile.ps1' } }
+            $script:oldBearerLabel = $env:AWS_BEARER_TOKEN_BEDROCK
+            Remove-Item Env:\AWS_BEARER_TOKEN_BEDROCK -ErrorAction SilentlyContinue
+        }
+        AfterAll {
+            if ($null -ne $script:oldBearerLabel) {
+                $env:AWS_BEARER_TOKEN_BEDROCK = $script:oldBearerLabel
+            }
+        }
+
+        It 'labels profile storage as profile token file via launcher' {
+            $block = New-JuggernautBlock -AuthMode 'bedrock-api-key' -AuthValidated $true `
+                -Region 'us-west-2' -Storage 'profile' -UseMantle $false `
+                -Version $script:ExpectedVersion `
+                -BedrockConfigPath $script:BedrockConfigPath
+            $out = Write-DoctorLauncher -Block $block | Out-String
+            $out | Should -Match 'profile token file via launcher'
+        }
+
+        It 'labels keychain storage as system keychain via launcher' {
+            $block = New-JuggernautBlock -AuthMode 'bedrock-api-key' -AuthValidated $true `
+                -Region 'us-west-2' -Storage 'keychain' -UseMantle $false `
+                -Version $script:ExpectedVersion `
+                -BedrockConfigPath $script:BedrockConfigPath
+            $out = Write-DoctorLauncher -Block $block | Out-String
+            $out | Should -Match 'system keychain via launcher'
+        }
+
+        It 'labels dpapi storage as DPAPI file via launcher' {
+            $block = New-JuggernautBlock -AuthMode 'bedrock-api-key' -AuthValidated $true `
+                -Region 'us-west-2' -Storage 'dpapi' -UseMantle $false `
+                -Version $script:ExpectedVersion `
+                -BedrockConfigPath $script:BedrockConfigPath
+            $out = Write-DoctorLauncher -Block $block | Out-String
+            $out | Should -Match 'DPAPI file via launcher'
+        }
+    }
 }

--- a/tests/v2/Doctor.Tests.ps1
+++ b/tests/v2/Doctor.Tests.ps1
@@ -269,9 +269,6 @@ Describe 'doctor.ps1' {
     Context 'Write-DoctorLauncher source label reflects auth.storage' {
         BeforeAll {
             . (Join-Path $script:repoRoot 'lib\doctor.ps1')
-            # Override Test-LauncherInstalled to simulate a launcher being present
-            # without needing to touch real shell profiles.
-            function script:Test-LauncherInstalled { return @{ Installed = $true; Path = 'C:\fake\profile.ps1' } }
             $script:oldBearerLabel = $env:AWS_BEARER_TOKEN_BEDROCK
             Remove-Item Env:\AWS_BEARER_TOKEN_BEDROCK -ErrorAction SilentlyContinue
         }
@@ -279,6 +276,11 @@ Describe 'doctor.ps1' {
             if ($null -ne $script:oldBearerLabel) {
                 $env:AWS_BEARER_TOKEN_BEDROCK = $script:oldBearerLabel
             }
+        }
+        # Pester Mock intercepts Test-LauncherInstalled within this Context so
+        # Write-DoctorLauncher sees a launcher installed at a fake path.
+        BeforeEach {
+            Mock Test-LauncherInstalled { return @{ Installed = $true; Path = 'C:\fake\profile.ps1' } }
         }
 
         It 'labels profile storage as profile token file via launcher' {

--- a/tests/v2/test_doctor.sh
+++ b/tests/v2/test_doctor.sh
@@ -344,14 +344,15 @@ LSRC_BLOCK="$(J_AUTH_MODE=bedrock-api-key J_REGION=us-west-2 J_EFFORT=xhigh J_ST
   schema_new_juggernaut_block)"
 config_write_atomic "$LSRC_HOME/.claude/settings.json" \
   "$(config_merge_juggernaut_block '{}' "$LSRC_BLOCK" "$(schema_derive_native_keys "$LSRC_BLOCK")")"
+# Install the launcher marker so doctor_launcher enters the installed-launcher path.
 echo '# BEGIN: Juggernaut Launcher' >> "$LSRC_HOME/.bashrc"
 echo '# END: Juggernaut Launcher'   >> "$LSRC_HOME/.bashrc"
-OUTPUT="$(AWS_BEARER_TOKEN_BEDROCK=fake HOME="$LSRC_HOME" bash "$REPO_ROOT/commands/doctor.sh" 2>&1)"
-if [[ "$OUTPUT" == *"system keychain via launcher function"* ]] || \
-   [[ "$OUTPUT" == *"AWS_BEARER_TOKEN_BEDROCK already in env"* ]]; then
+# Run without AWS_BEARER_TOKEN_BEDROCK so the launcher path (not env-token path) fires.
+OUTPUT="$(HOME="$LSRC_HOME" bash "$REPO_ROOT/commands/doctor.sh" 2>&1)"
+if [[ "$OUTPUT" == *"system keychain via launcher function"* ]]; then
   pass
 else
-  fail "expected 'system keychain via launcher function' or env-token source"
+  fail "expected 'system keychain via launcher function' in launcher source label"
   printf '%s\n' "$OUTPUT" >&2
 fi
 rm -rf "$LSRC_HOME"

--- a/tests/v2/test_doctor.sh
+++ b/tests/v2/test_doctor.sh
@@ -311,6 +311,52 @@ fi
 rm -rf "$CLEAN_HOME"
 
 # ---------------------------------------------------------------------------
+# Launcher source label reflects configured storage
+# ---------------------------------------------------------------------------
+section "launcher source label: profile storage → 'profile token file via launcher function'"
+LSRC_HOME="$(mktemp -d)"
+mkdir -p "$LSRC_HOME/.claude" "$LSRC_HOME/.config/juggernaut"
+LSRC_BLOCK="$(J_AUTH_MODE=bedrock-api-key J_REGION=us-west-2 J_EFFORT=xhigh J_STORAGE=profile \
+  J_USE_MANTLE=true J_OPUSPLAN=false J_SCOPE=user J_VERSION="$EXPECTED_VERSION" \
+  J_AUTH_VALIDATED=true \
+  schema_new_juggernaut_block)"
+config_write_atomic "$LSRC_HOME/.claude/settings.json" \
+  "$(config_merge_juggernaut_block '{}' "$LSRC_BLOCK" "$(schema_derive_native_keys "$LSRC_BLOCK")")"
+# Write a fake bearer token and a fake launcher block to the profile
+printf 'fake-token' > "$LSRC_HOME/.config/juggernaut/bearer-token"
+echo '# BEGIN: Juggernaut Launcher' >> "$LSRC_HOME/.bashrc"
+echo '# END: Juggernaut Launcher'   >> "$LSRC_HOME/.bashrc"
+OUTPUT="$(HOME="$LSRC_HOME" XDG_CONFIG_HOME="$LSRC_HOME/.config" bash "$REPO_ROOT/commands/doctor.sh" 2>&1)"
+if [[ "$OUTPUT" == *"profile token file via launcher function"* ]]; then
+  pass
+else
+  fail "expected 'profile token file via launcher function' in launcher source label"
+  printf '%s\n' "$OUTPUT" >&2
+fi
+rm -rf "$LSRC_HOME"
+
+section "launcher source label: keychain storage → 'system keychain via launcher function'"
+LSRC_HOME="$(mktemp -d)"
+mkdir -p "$LSRC_HOME/.claude"
+LSRC_BLOCK="$(J_AUTH_MODE=bedrock-api-key J_REGION=us-west-2 J_EFFORT=xhigh J_STORAGE=keychain \
+  J_USE_MANTLE=true J_OPUSPLAN=false J_SCOPE=user J_VERSION="$EXPECTED_VERSION" \
+  J_AUTH_VALIDATED=true \
+  schema_new_juggernaut_block)"
+config_write_atomic "$LSRC_HOME/.claude/settings.json" \
+  "$(config_merge_juggernaut_block '{}' "$LSRC_BLOCK" "$(schema_derive_native_keys "$LSRC_BLOCK")")"
+echo '# BEGIN: Juggernaut Launcher' >> "$LSRC_HOME/.bashrc"
+echo '# END: Juggernaut Launcher'   >> "$LSRC_HOME/.bashrc"
+OUTPUT="$(AWS_BEARER_TOKEN_BEDROCK=fake HOME="$LSRC_HOME" bash "$REPO_ROOT/commands/doctor.sh" 2>&1)"
+if [[ "$OUTPUT" == *"system keychain via launcher function"* ]] || \
+   [[ "$OUTPUT" == *"AWS_BEARER_TOKEN_BEDROCK already in env"* ]]; then
+  pass
+else
+  fail "expected 'system keychain via launcher function' or env-token source"
+  printf '%s\n' "$OUTPUT" >&2
+fi
+rm -rf "$LSRC_HOME"
+
+# ---------------------------------------------------------------------------
 # --help / --version
 # ---------------------------------------------------------------------------
 section "doctor --help exits 0 and mentions v3"


### PR DESCRIPTION
## Summary

- `juggernaut doctor`'s Launcher section hardcoded `OS keychain via launcher function` regardless of the configured `auth.storage`, making it misleading for Linux users on `storage=profile`.
- The credentials probe also tried DPAPI then keychain before the profile token, so profile-storage configs reported `Source: system keychain` on any host where the keychain is available.

## Changes

- **`lib/doctor.sh`**: Reads `auth.storage` from the Juggernaut block and probes credentials in configured-storage-first order (`profile→dpapi→keychain` when `storage=profile`, `dpapi→keychain→profile` otherwise). Launcher source label is now one of: `profile token file via launcher function`, `system keychain via launcher function`, `DPAPI file via launcher function`.
- **`lib/doctor.ps1`**: Reads `auth.storage` and maps it to the correct launcher source label (`profile token file via launcher`, `system keychain via launcher`, `DPAPI file via launcher`).
- **`tests/v2/test_doctor.sh`**: Two new tests covering the launcher source label for `storage=profile` and `storage=keychain`.
- **`tests/v2/Doctor.Tests.ps1`**: Three unit tests for `Write-DoctorLauncher` across all storage values using a mock `Test-LauncherInstalled`.

## Test plan

- [ ] All 29 bash doctor tests pass (`bash ./tests/v2/test_doctor.sh`)
- [ ] All 28 PS1 doctor tests pass (`Invoke-Pester ./tests/v2/doctor.Tests.ps1 -CI`)
- [ ] Full bash suite passes (183 tests, 0 failures)

Closes #87