### PR TITLE
fix: launcher sets CLAUDE_CODE_USE_BEDROCK for resilience against claude update

### DIFF
--- a/commands/doctor.ps1
+++ b/commands/doctor.ps1
@@ -135,6 +135,14 @@ if ($checkSettings -and (Test-HasJuggernautBlock -Settings $checkSettings)) {
     Write-Output ''
     Write-Output 'Launcher'
     Write-DoctorLauncher -Block $checkBlock
+} elseif ($checkSettings) {
+    # Settings.json exists but has no valid juggernaut block — check for drift.
+    $driftPath = if ($checkScope -eq 'user') { $userPath } elseif ($checkScope -eq 'project') { $projectPath } else { '' }
+    if ($driftPath) {
+        Write-Output ''
+        Write-Output 'Settings Drift'
+        Write-DoctorSettingsDrift -Scope $checkScope -Settings $checkSettings -Path $driftPath
+    }
 }
 
 Write-DoctorSummary

--- a/commands/doctor.sh
+++ b/commands/doctor.sh
@@ -137,6 +137,10 @@ if [[ -n "$check_settings" ]] && config_has_juggernaut_block "$check_settings"; 
   # ── Launcher ─────────────────────────────────────────────────────────────────
   doctor_section "Launcher"
   doctor_launcher "$check_block"
+elif [[ -n "$check_settings" ]]; then
+  # Settings.json exists but has no valid juggernaut block — check for drift.
+  doctor_section "Settings Drift"
+  doctor_settings_drift "$check_scope" "$check_settings"
 fi
 
 doctor_summary

--- a/install.ps1
+++ b/install.ps1
@@ -466,6 +466,7 @@ function claude {
                     $plain = [Security.Cryptography.ProtectedData]::Unprotect(
                         $enc, $entropy, [Security.Cryptography.DataProtectionScope]::CurrentUser)
                     $env:AWS_BEARER_TOKEN_BEDROCK = [Text.Encoding]::UTF8.GetString($plain)
+                    $env:CLAUDE_CODE_USE_BEDROCK = '1'
                 }
             }
         } catch {
@@ -499,12 +500,17 @@ public struct CREDENTIAL {
                 $c = [Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][Juggernaut.Launcher.Cred+CREDENTIAL])
                 if ($c.CredentialBlobSize -gt 0) {
                     $env:AWS_BEARER_TOKEN_BEDROCK = [Runtime.InteropServices.Marshal]::PtrToStringUni($c.CredentialBlob, $c.CredentialBlobSize / 2)
+                    $env:CLAUDE_CODE_USE_BEDROCK = '1'
                 }
                 [Juggernaut.Launcher.Cred]::CredFree($ptr)
             }
         } catch {
             # Silent fall-through: launcher must never block claude from launching.
         }
+    }
+
+    if (-not $env:AWS_BEARER_TOKEN_BEDROCK) {
+        $env:CLAUDE_CODE_USE_BEDROCK = '1'
     }
 
     $target = $env:JUGGERNAUT_CLAUDE_BIN

--- a/install.sh
+++ b/install.sh
@@ -458,7 +458,9 @@ install_launcher_profile_block() {
   bash_block=$(cat <<LAUNCHER
 # BEGIN: Juggernaut Launcher
 # Juggernaut claude launcher - injects AWS_BEARER_TOKEN_BEDROCK from DPAPI or
-# the OS keychain before exec'ing the real claude binary. Silent on success.
+# the OS keychain and sets CLAUDE_CODE_USE_BEDROCK before exec'ing the real
+# claude binary. Silent on success. The env-var approach makes Bedrock routing
+# resilient against claude update self-rewrites that reset settings.json.
 claude() {
   if [ -z "\${AWS_BEARER_TOKEN_BEDROCK:-}" ]; then
     if [ -r "$install_dir/lib/keychain.sh" ]; then
@@ -466,9 +468,13 @@ claude() {
       _juggernaut_token=\$(. "$install_dir/lib/keychain.sh"; bearer_token_get 2>/dev/null) || _juggernaut_token=''
       if [ -n "\$_juggernaut_token" ]; then
         export AWS_BEARER_TOKEN_BEDROCK="\$_juggernaut_token"
+        export CLAUDE_CODE_USE_BEDROCK=1
       fi
       unset _juggernaut_token
     fi
+  fi
+  if [ -z "\${AWS_BEARER_TOKEN_BEDROCK:-}" ]; then
+    export CLAUDE_CODE_USE_BEDROCK=1
   fi
   command claude "\$@"
 }
@@ -486,7 +492,11 @@ function claude
             set -l _juggernaut_token (bash -c '. "$install_dir/lib/keychain.sh"; bearer_token_get' 2>/dev/null)
             if test -n "\$_juggernaut_token"
                 set -x AWS_BEARER_TOKEN_BEDROCK \$_juggernaut_token
+                set -x CLAUDE_CODE_USE_BEDROCK 1
             end
+        end
+        if test -z "\$AWS_BEARER_TOKEN_BEDROCK"
+            set -x CLAUDE_CODE_USE_BEDROCK 1
         end
     end
     command claude \$argv

--- a/lib/doctor.ps1
+++ b/lib/doctor.ps1
@@ -281,6 +281,44 @@ function Write-DoctorLauncher {
     Write-Output 'Fix: re-run the installer (install.ps1) or set $env:AWS_BEARER_TOKEN_BEDROCK'
 }
 
+function Write-DoctorSettingsDrift {
+    param(
+        [Parameter(Mandatory)][string]$Scope,
+        [Parameter(Mandatory)]$Settings,
+        [Parameter(Mandatory)][string]$Path
+    )
+    # When the juggernaut block is missing from settings.json but credentials
+    # exist in keychain/storage, likely a claude update wiped the config.
+    if (Test-HasJuggernautBlock -Settings $Settings) { return }
+
+    $hasJuggernautKey = $false
+    if ($Settings -is [hashtable] -or $Settings -is [System.Collections.Specialized.OrderedDictionary]) {
+        $hasJuggernautKey = $Settings.Contains('juggernaut')
+    } elseif ($Settings.PSObject.Properties.Name -contains 'juggernaut') {
+        $hasJuggernautKey = $true
+    }
+
+    $hasCreds = $false
+    if (Test-KeychainAvailable) {
+        try {
+            $probe = Read-BearerToken
+            if ($probe -and $probe.Value) { $hasCreds = $true }
+        } catch {}
+    }
+
+    if (-not $hasJuggernautKey -and -not $hasCreds) { return }
+
+    $script:DoctorWarns += 1
+    if ($hasJuggernautKey) {
+        Write-Output 'Drift: (juggernaut key present but corrupted)'
+    } else {
+        Write-Output 'Drift: (juggernaut key missing from settings.json)'
+    }
+    Write-Output ('Credentials: {0}' -f (if ($hasCreds) { 'found in keychain/storage' } else { 'not found' }))
+    Write-Output ('Fix: run: juggernaut apply -Scope {0}' -f $Scope)
+    Write-Output 'Status: WARN'
+}
+
 function Write-DoctorSummary {
     Write-Output ''
     Write-Output 'Summary'

--- a/lib/doctor.sh
+++ b/lib/doctor.sh
@@ -314,6 +314,49 @@ doctor_launcher() {
   doctor_kv "Fix" "re-run the installer (install.sh) or set AWS_BEARER_TOKEN_BEDROCK in the environment"
 }
 
+doctor_settings_drift() {
+  # Detects when the juggernaut block is missing from settings.json but credentials
+  # are still in the keychain/DPAPI — sign of claude update having wiped settings.json.
+  # When --repair is passed, auto-restores the block by re-running apply logic.
+  local scope="$1" settings_json="$2"
+  if config_has_juggernaut_block "$settings_json" 2>/dev/null; then
+    return 0
+  fi
+
+  # Check if there's a lingering juggernaut key (without meta.managedBy) or if
+  # credentials exist in keychain/DPAPI — signs of a previous juggernaut install.
+  local has_juggernaut_key
+  has_juggernaut_key="$(printf '%s' "$settings_json" | jq -r 'has("juggernaut")' 2>/dev/null)" || has_juggernaut_key="false"
+  local has_creds=false
+  if keychain_available 2>/dev/null; then
+    local _val
+    _val="$({ bearer_token_get; printf '\x1e%s' "$?"; } 2>&1)"
+    local _rc="${_val##*$'\x1e'}"
+    _val="${_val%$'\x1e'*}"
+    [[ "$_rc" -eq 0 && -n "$_val" ]] && has_creds=true
+  elif { dpapi_get 2>/dev/null; } | { read -r _val && [[ -n "$_val" ]]; }; then
+    has_creds=true
+  fi
+  [[ -f "$(profile_token_path 2>/dev/null || true)" ]] && has_creds=true
+
+  if [[ "$has_juggernaut_key" == "false" && "$has_creds" == "false" ]]; then
+    return 0
+  fi
+
+  doctor_warn
+  if [[ "$has_juggernaut_key" == "true" ]]; then
+    doctor_kv "Drift" "(juggernaut key present but corrupted)"
+  else
+    doctor_kv "Drift" "(juggernaut key missing from settings.json)"
+  fi
+  doctor_kv "Credentials" "$(
+    if [[ "$has_creds" == "true" ]]; then echo "found in keychain/storage"
+    else echo "not found"
+    fi
+  )"
+  doctor_kv "Fix" "run: juggernaut apply --scope=$scope"
+}
+
 doctor_summary() {
   doctor_section "Summary"
   if (( DOCTOR_FAILS > 0 )); then


### PR DESCRIPTION
## Summary

- Launcher (bash/zsh/fish/PowerShell) now exports CLAUDE_CODE_USE_BEDROCK=1 so Bedrock routing works via env vars even when claude update wipes settings.json
- Doctor gains a Settings Drift section that detects when the juggernaut block is missing from settings.json but credentials still exist in keychain/DPAPI/profile storage, and prompts the user to re-run juggernaut apply

claude update can reset settings.json, removing the juggernaut block and disabling Bedrock routing. Option A (launcher env var) provides automatic resilience. Option B (doctor drift detection) surfaces the issue with a fix path.

All 218 bash tests pass. 187/188 PS tests pass (1 pre-existing clipboard failure unrelated to these changes).