### PR TITLE
chore: update GITHUB_SETTINGS.md to reflect modern ruleset

### DIFF
--- a/.github/GITHUB_SETTINGS.md
+++ b/.github/GITHUB_SETTINGS.md
@@ -4,10 +4,6 @@ These settings are configured outside the repo (GitHub UI or API) and cannot
 be enforced by files in the codebase. Re-apply these when setting up a fork
 or new instance.
 
-> **Public repos:** all settings below can be applied via `gh api`.
-> **Private repos on free tier:** rulesets, secret scanning, push protection,
-> and CodeQL must be set via the GitHub UI.
-
 ---
 
 ## Apply via `gh api` (replace `OWNER/REPO`)
@@ -19,7 +15,7 @@ gh api repos/OWNER/REPO \
   --field delete_branch_on_merge=true \
   --field default_branch=main
 
-# Dependabot
+# Dependabot alerts + security updates
 gh api repos/OWNER/REPO/vulnerability-alerts --method PUT
 gh api repos/OWNER/REPO/automated-security-fixes --method PUT
 
@@ -62,8 +58,8 @@ gh api repos/OWNER/REPO/rulesets \
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": true,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
         "require_last_push_approval": false,
         "required_review_thread_resolution": true
       }
@@ -73,7 +69,13 @@ gh api repos/OWNER/REPO/rulesets \
       "parameters": {
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
-        "required_status_checks": []
+        "required_status_checks": [
+          { "context": "Lint" },
+          { "context": "Test on ubuntu-latest" },
+          { "context": "Test on macos-latest" },
+          { "context": "Test on Windows (PowerShell)" },
+          { "context": "Test on Windows (Git Bash)" }
+        ]
       }
     }
   ]
@@ -100,10 +102,8 @@ gh api repos/OWNER/REPO/rulesets \
 EOF
 ```
 
-> **Note on required status checks:** the `required_status_checks` array above
-> is intentionally empty — GitHub only recognises job names after they've run
-> once. After the first CI run, update the ruleset via:
-> `PATCH /repos/OWNER/REPO/rulesets/{ruleset_id}`
+> **Note on required status checks:** update `required_status_checks` after
+> the first CI run so GitHub recognises the job names.
 
 ---
 
@@ -113,22 +113,25 @@ EOF
 - Default branch: `main`
 - Auto-delete head branches: enabled
 
-### Branch protection (`main`)
-- Require PR before merging: yes
+### Branch ruleset: `protect-main`
+- Blocks deletion and force pushes
+- Requires PR before merging: yes
 - Required approvals: 0
-- Dismiss stale reviews on push: yes
-- Require review from code owners: yes
+- Dismiss stale reviews on push: no
+- Require CODEOWNERS review: no
 - Require conversation resolution: yes
-- Required status checks: `Test on ubuntu-latest`, `Test on macos-latest`, `Test on Windows (PowerShell)`, `Test on Windows (Git Bash)`
+- Required status checks (all must pass):
+  - `Lint`
+  - `Test on ubuntu-latest`
+  - `Test on macos-latest`
+  - `Test on Windows (PowerShell)`
+  - `Test on Windows (Git Bash)`
 - Require branch up to date: yes
-- Block force pushes: yes
-- Allow deletions: no
-- Enforce on admins: yes
 
-### Tag protection (`v*`)
-- Ruleset name: `protect-version-tags`
+### Tag ruleset: `protect-version-tags`
+- Pattern: `v*`
 - Restrict deletions: yes
-- Restrict updates: yes
+- Restrict force pushes: yes
 
 ### Security & Analysis
 - Secret scanning: enabled


### PR DESCRIPTION
## Summary
- Updates `.github/GITHUB_SETTINGS.md` to reflect the modern ruleset (was showing classic branch protection settings)
- Correct required status check job names: Lint, Test on ubuntu-latest, Test on macos-latest, Test on Windows (PowerShell), Test on Windows (Git Bash)
- Solo settings: no CODEOWNERS review, no stale review dismissal

## Test Plan
- [ ] CI passes