### PR TITLE
fix: skip npm version bump if already at tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,8 @@ jobs:
         working-directory: npm
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+          fi
           npm publish --access public


### PR DESCRIPTION
npm version fails with 'Version not changed' if package.json already matches the tag. Skip the version bump in that case.