### PR TITLE
fix: bump tar to 7.5.11 (6 high CVEs)

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -9,7 +9,7 @@
     "postinstall": "node install.js"
   },
   "dependencies": {
-    "tar": "^6.0.0",
+    "tar": "^7.5.11",
     "adm-zip": "^0.5.0"
   },
   "os": ["darwin", "linux", "win32"],


### PR DESCRIPTION
Resolves all 6 open Dependabot alerts — path traversal and symlink vulnerabilities in node-tar, all fixed in v7.5.11.

- #1 Arbitrary file overwrite via symlink poisoning (fixed 7.5.3)
- #2 Race condition via Unicode ligature collisions on macOS APFS (fixed 7.5.4)
- #3 Arbitrary file creation via hardlink path traversal (fixed 7.5.7)
- #4 Arbitrary file read/write via hardlink/symlink chain (fixed 7.5.8)
- #5 Hardlink path traversal via drive-relative linkpath (fixed 7.5.10)
- #6 Symlink path traversal via drive-relative linkpath (fixed 7.5.11)

API is unchanged between tar v6 and v7 for the `tar.x()` call used in install.js.