### PR TITLE
fix: suppress os.Setenv return value (errcheck)

### DIFF
--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -73,9 +73,9 @@ func RunAsLauncher(args []string) error {
 		token = ""
 	}
 	if token != "" {
-		os.Setenv("AWS_BEARER_TOKEN_BEDROCK", token)
+		_ = os.Setenv("AWS_BEARER_TOKEN_BEDROCK", token)
 	}
-	os.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+	_ = os.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
 
 	claudePath, err := findRealClaude()
 	if err != nil {


### PR DESCRIPTION
golangci-lint v9 (stricter errcheck) flags os.Setenv return values not being checked. os.Setenv only errors on invalid env var names — these are hardcoded string literals so it cannot fail in practice. Suppress with `_ =` to satisfy the linter.