### PR TITLE
chore: apply modern Go idioms to reduce Codacy issues

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -40,20 +40,22 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	mgr := config.NewManager(settingsPath(home, "user"))
 	has, err := mgr.HasJuggernautBlock()
-	if err != nil {
+	switch {
+	case err != nil:
 		r.Check("settings.json", doctor.Fail, err.Error())
-	} else if !has {
+	case !has:
 		r.Check("settings.json", doctor.Fail, "juggernaut block not found — run `juggernaut apply`")
-	} else {
+	default:
 		r.Check("settings.json", doctor.OK, "juggernaut block present")
 	}
 
 	token, err := keychain.Default().Get()
-	if err != nil {
+	switch {
+	case err != nil:
 		r.Check("keychain", doctor.Warn, "error reading: "+err.Error())
-	} else if token == "" {
+	case token == "":
 		r.Check("keychain", doctor.OK, "no bearer token (IAM auth)")
-	} else {
+	default:
 		r.Check("keychain", doctor.OK, "bearer token found")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/jpvelasco/juggernaut/internal/launcher"
@@ -55,12 +56,7 @@ func isLauncherMode() bool {
 	if base == "claude" {
 		return true
 	}
-	for _, arg := range os.Args[1:] {
-		if arg == "--launcher" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(os.Args[1:], "--launcher")
 }
 
 func runLauncher() {

--- a/internal/bedrock/config.go
+++ b/internal/bedrock/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 )
 
 // LoadBytes parses a Config from raw JSON bytes (e.g. from an embedded file).
@@ -51,10 +52,5 @@ func Load(path string) (*Config, error) {
 }
 
 func (c *Config) IsSupportedRegion(region string) bool {
-	for _, r := range c.Regions {
-		if r == region {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.Regions, region)
 }

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -94,7 +94,7 @@ func meetsMinVersion(version, min string) bool {
 func compareSemver(a, b string) int {
 	pa := parseVersionParts(a)
 	pb := parseVersionParts(b)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if pa[i] != pb[i] {
 			if pa[i] > pb[i] {
 				return 1
@@ -108,7 +108,7 @@ func compareSemver(a, b string) int {
 func parseVersionParts(version string) [3]int {
 	parts := strings.SplitN(version, ".", 3)
 	var result [3]int
-	for i := 0; i < 3 && i < len(parts); i++ {
+	for i := range min(3, len(parts)) {
 		_, _ = fmt.Sscanf(parts[i], "%d", &result[i])
 	}
 	return result

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/jpvelasco/juggernaut/internal/bedrock"
@@ -91,14 +92,10 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	}
 
 	env := make(map[string]string, len(cfg.Environment))
-	for k, v := range cfg.Environment {
-		env[k] = v
-	}
+	maps.Copy(env, cfg.Environment)
 
 	if opts.AuthValidated {
-		for k, v := range cfg.EnvironmentBedrockAuth {
-			env[k] = v
-		}
+		maps.Copy(env, cfg.EnvironmentBedrockAuth)
 	}
 
 	env["AWS_REGION"] = opts.Region


### PR DESCRIPTION
- slices.Contains for linear search loops (bedrock, root)
- maps.Copy for map copy loops (schema)
- range N for integer range loops (migrate)
- switch for if-else chains (doctor)