### PR TITLE
fix: align CI go-version with go.mod (1.22 -> 1.24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Verify version sync
         run: |
           FILE_VERSION=$(cat VERSION)
@@ -38,6 +38,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
       - name: Run tests
         run: go test ./... -v


### PR DESCRIPTION
ci.yml was pinned to Go 1.22 but go.mod requires go 1.24.0. Aligns them so setup-go@v6 (PR #121) works correctly.