### PR TITLE
chore: upgrade to Go 1.26 stable, pin CI to 'stable'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "stable"
       - name: Verify version sync
         run: |
           FILE_VERSION=$(cat VERSION)
@@ -38,6 +38,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "stable"
       - name: Run tests
         run: go test ./... -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "stable"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/juggernaut
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/charmbracelet/huh v1.0.0


### PR DESCRIPTION
- go.mod: go 1.24 → go 1.26 (latest stable)
- CI workflows: go-version '1.24' → 'stable' (auto-follows new Go releases)
- Unblocks PR #121 (setup-go@v6)