### PR TITLE
chore: fix all Codacy issues

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,4 @@
 ---
-exclude_paths: []
+exclude_paths:
+  - ".remember/**"
+  - ".codacy/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "stable"
       - name: Verify version sync
@@ -25,7 +25,7 @@ jobs:
           fi
           echo "Version sync OK: $FILE_VERSION"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@63c23d5020da8f97005b6de340504130bdbe42c7  # v9
         with:
           version: latest
 
@@ -35,8 +35,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "stable"
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,22 +13,22 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version: "stable"
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7
         with:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -1,3 +1,4 @@
+// Package cmd implements the juggernaut CLI commands.
 package cmd
 
 import (
@@ -67,7 +68,7 @@ func init() {
 	rootCmd.AddCommand(applyCmd)
 }
 
-func runApply(cmd *cobra.Command, args []string) error {
+func runApply(_ *cobra.Command, _ []string) error {
 	home := homeDir()
 
 	bCfg, err := loadBedrockConfig()

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -27,7 +27,7 @@ func init() {
 	rootCmd.AddCommand(doctorCmd)
 }
 
-func runDoctor(cmd *cobra.Command, args []string) error {
+func runDoctor(_ *cobra.Command, _ []string) error {
 	home := homeDir()
 	r := doctor.NewReport()
 

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -23,7 +23,7 @@ func init() {
 	rootCmd.AddCommand(migrateCmd)
 }
 
-func runMigrate(cmd *cobra.Command, args []string) error {
+func runMigrate(_ *cobra.Command, _ []string) error {
 	home := homeDir()
 
 	state, err := migrate.Detect(home)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var rootCmd = &cobra.Command{
 	Long:  `Juggernaut installs and configures Claude Code to route through Amazon Bedrock instead of Anthropic's direct API.`,
 }
 
+// Execute is the main entry point for the CLI.
 func Execute() {
 	if isLauncherMode() {
 		runLauncher()

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -25,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(showCmd)
 }
 
-func runShow(cmd *cobra.Command, args []string) error {
+func runShow(_ *cobra.Command, _ []string) error {
 	home := homeDir()
 	scopes := []string{"user", "project"}
 	if showFlags.scope != "" {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -35,7 +35,7 @@ func init() {
 	rootCmd.AddCommand(uninstallCmd)
 }
 
-func runUninstall(cmd *cobra.Command, args []string) error {
+func runUninstall(_ *cobra.Command, _ []string) error {
 	home := homeDir()
 
 	if !uninstallFlags.force && !uninstallFlags.dryRun {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,7 +12,7 @@ var versionJSONFlag bool
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print Juggernaut version",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		if versionJSONFlag {
 			out, _ := json.Marshal(map[string]string{"version": Version})
 			fmt.Println(string(out))

--- a/internal/bedrock/config.go
+++ b/internal/bedrock/config.go
@@ -1,3 +1,4 @@
+// Package bedrock loads and validates bedrock-config.json.
 package bedrock
 
 import (
@@ -6,6 +7,41 @@ import (
 	"os"
 	"slices"
 )
+
+// Config is the typed representation of bedrock-config.json.
+type Config struct {
+	Version                string            `json:"version"`
+	Models                 ModelSet          `json:"models"`
+	Environment            map[string]string `json:"environment"`
+	EnvironmentBedrockAuth map[string]string `json:"environment_bedrock_auth"`
+	Regions                []string          `json:"regions"`
+	Defaults               Defaults          `json:"defaults"`
+}
+
+// ModelSet holds the Bedrock inference profile IDs for each model tier.
+type ModelSet struct {
+	Default string `json:"default"`
+	Fast    string `json:"fast"`
+	Opus    string `json:"opus"`
+	Sonnet  string `json:"sonnet"`
+	Haiku   string `json:"haiku"`
+}
+
+// Defaults holds the default values for region, auth mode, and model.
+type Defaults struct {
+	Region   string `json:"region"`
+	AuthMode string `json:"auth_mode"`
+	Model    string `json:"model"`
+}
+
+// Load reads and parses bedrock-config.json from the given path.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading bedrock-config.json: %w", err)
+	}
+	return LoadBytes(data)
+}
 
 // LoadBytes parses a Config from raw JSON bytes (e.g. from an embedded file).
 func LoadBytes(data []byte) (*Config, error) {
@@ -16,41 +52,7 @@ func LoadBytes(data []byte) (*Config, error) {
 	return &cfg, nil
 }
 
-type Config struct {
-	Version                string            `json:"version"`
-	Models                 ModelSet          `json:"models"`
-	Environment            map[string]string `json:"environment"`
-	EnvironmentBedrockAuth map[string]string `json:"environment_bedrock_auth"`
-	Regions                []string          `json:"regions"`
-	Defaults               Defaults          `json:"defaults"`
-}
-
-type ModelSet struct {
-	Default string `json:"default"`
-	Fast    string `json:"fast"`
-	Opus    string `json:"opus"`
-	Sonnet  string `json:"sonnet"`
-	Haiku   string `json:"haiku"`
-}
-
-type Defaults struct {
-	Region   string `json:"region"`
-	AuthMode string `json:"auth_mode"`
-	Model    string `json:"model"`
-}
-
-func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading bedrock-config.json: %w", err)
-	}
-	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parsing bedrock-config.json: %w", err)
-	}
-	return &cfg, nil
-}
-
+// IsSupportedRegion returns true if region is in the supported list.
 func (c *Config) IsSupportedRegion(region string) bool {
 	return slices.Contains(c.Regions, region)
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -1,3 +1,4 @@
+// Package config handles atomic read/merge/write of settings.json with backup rotation.
 package config
 
 import (
@@ -13,10 +14,12 @@ import (
 
 const backupRetain = 5
 
+// Manager handles atomic read/merge/write of a settings.json file.
 type Manager struct {
 	path string
 }
 
+// NewManager creates a Manager for the settings.json at the given path.
 func NewManager(path string) *Manager {
 	return &Manager{path: path}
 }
@@ -79,6 +82,7 @@ func (m *Manager) Write(data map[string]any) error {
 	return nil
 }
 
+// MergeJuggernautBlock merges the juggernaut block and native keys into existing settings.
 func (m *Manager) MergeJuggernautBlock(block map[string]any, nativeEnv map[string]string, model string) error {
 	existing, err := m.Read()
 	if err != nil {
@@ -96,6 +100,7 @@ func (m *Manager) MergeJuggernautBlock(block map[string]any, nativeEnv map[strin
 	return m.Write(existing)
 }
 
+// RemoveJuggernautBlock strips Juggernaut-managed keys from settings.json.
 func (m *Manager) RemoveJuggernautBlock() error {
 	existing, err := m.Read()
 	if err != nil {
@@ -108,6 +113,7 @@ func (m *Manager) RemoveJuggernautBlock() error {
 	return m.Write(existing)
 }
 
+// HasJuggernautBlock returns true if settings.json contains a managed Juggernaut block.
 func (m *Manager) HasJuggernautBlock() (bool, error) {
 	data, err := m.Read()
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,3 +1,4 @@
+// Package doctor provides a Report type for structured diagnostic output.
 package doctor
 
 import (
@@ -6,32 +7,39 @@ import (
 	"strings"
 )
 
+// Status represents the result of a single diagnostic check.
 type Status string
 
+// OK, Warn, and Fail are the possible check statuses.
 const (
 	OK   Status = "OK"
 	Warn Status = "WARN"
 	Fail Status = "FAIL"
 )
 
+// Entry holds the result of a single diagnostic check.
 type Entry struct {
 	Label  string `json:"label"`
 	Status Status `json:"status"`
 	Detail string `json:"detail"`
 }
 
+// Report accumulates diagnostic check results.
 type Report struct {
 	entries []Entry
 }
 
+// NewReport creates an empty Report.
 func NewReport() *Report {
 	return &Report{}
 }
 
+// Check records a single diagnostic result.
 func (r *Report) Check(label string, status Status, detail string) {
 	r.entries = append(r.entries, Entry{Label: label, Status: status, Detail: detail})
 }
 
+// HasFailures returns true if any check recorded a Fail status.
 func (r *Report) HasFailures() bool {
 	for _, e := range r.entries {
 		if e.Status == Fail {
@@ -41,6 +49,7 @@ func (r *Report) HasFailures() bool {
 	return false
 }
 
+// HasWarnings returns true if any check recorded a Warn status.
 func (r *Report) HasWarnings() bool {
 	for _, e := range r.entries {
 		if e.Status == Warn {
@@ -50,6 +59,7 @@ func (r *Report) HasWarnings() bool {
 	return false
 }
 
+// String returns a human-readable summary of all checks.
 func (r *Report) String() string {
 	var sb strings.Builder
 	for _, e := range r.entries {
@@ -58,6 +68,7 @@ func (r *Report) String() string {
 	return sb.String()
 }
 
+// JSON returns the check results as indented JSON.
 func (r *Report) JSON() ([]byte, error) {
 	return json.MarshalIndent(r.entries, "", "  ")
 }

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -1,3 +1,4 @@
+// Package keychain provides cross-platform credential storage via go-keyring.
 package keychain
 
 import (
@@ -9,10 +10,13 @@ const (
 	account        = "api-key"
 )
 
+// Store wraps go-keyring with a fixed account name and configurable service name.
 type Store struct {
 	service string
 }
 
+// NewStore creates a Store using the given service name.
+// Pass an empty string to use the default production service name.
 func NewStore(service string) *Store {
 	if service == "" {
 		service = defaultService
@@ -20,14 +24,17 @@ func NewStore(service string) *Store {
 	return &Store{service: service}
 }
 
+// Default returns a Store using the production service name.
 func Default() *Store {
 	return NewStore(defaultService)
 }
 
+// Set stores the token in the OS keychain.
 func (s *Store) Set(token string) error {
 	return keyring.Set(s.service, account, token)
 }
 
+// Get retrieves the token. Returns "" (not an error) if not found.
 func (s *Store) Get() (string, error) {
 	token, err := keyring.Get(s.service, account)
 	if err == keyring.ErrNotFound {
@@ -36,6 +43,7 @@ func (s *Store) Get() (string, error) {
 	return token, err
 }
 
+// Delete removes the token. Silent if not found.
 func (s *Store) Delete() error {
 	err := keyring.Delete(s.service, account)
 	if err == keyring.ErrNotFound {

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -1,3 +1,4 @@
+// Package launcher installs and operates the claude credential-injecting shim.
 package launcher
 
 import (
@@ -13,6 +14,7 @@ import (
 
 const cmdShim = "@echo off\njuggernaut --launcher %*\n"
 
+// DefaultBinDir returns the platform-appropriate bin directory for the claude shim.
 func DefaultBinDir() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(os.Getenv("USERPROFILE"), ".local", "bin")
@@ -24,6 +26,7 @@ func DefaultBinDir() string {
 	return filepath.Join(home, ".local", "bin")
 }
 
+// Install creates the claude shim in binDir (symlink on Unix, .cmd on Windows).
 func Install(binDir string) error {
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return fmt.Errorf("creating bin dir: %w", err)
@@ -46,6 +49,7 @@ func Install(binDir string) error {
 	return os.Symlink(self, shimPath)
 }
 
+// Uninstall removes the claude shim from binDir.
 func Uninstall(binDir string) error {
 	if runtime.GOOS == "windows" {
 		return removeIfExists(filepath.Join(binDir, "claude.cmd"))
@@ -53,6 +57,7 @@ func Uninstall(binDir string) error {
 	return removeIfExists(filepath.Join(binDir, "claude"))
 }
 
+// IsInstalled returns true if the claude shim exists in binDir.
 func IsInstalled(binDir string) bool {
 	var path string
 	if runtime.GOOS == "windows" {
@@ -64,6 +69,7 @@ func IsInstalled(binDir string) bool {
 	return err == nil
 }
 
+// RunAsLauncher injects credentials and execs the real claude binary.
 func RunAsLauncher(args []string) error {
 	token, err := keychain.Default().Get()
 	if err != nil {

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,3 +1,4 @@
+// Package migrate handles detection and execution of v3-to-v4 migration.
 package migrate
 
 import (
@@ -8,14 +9,16 @@ import (
 	"strings"
 )
 
+// State describes what was found during migration detection.
 type State struct {
 	HasV3Block bool
 	V3Version  string
 	AuthMode   string
-	TooOld     bool
-	AlreadyV4  bool
+	TooOld     bool  // version < 3.2.3 — must upgrade v3 first
+	AlreadyV4  bool  // schemaVersion == 2 — migration already complete
 }
 
+// Detect inspects homeDir for a v3 Juggernaut block.
 func Detect(homeDir string) (*State, error) {
 	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
 	data, err := os.ReadFile(settingsPath)
@@ -69,6 +72,7 @@ func Detect(homeDir string) (*State, error) {
 	return state, nil
 }
 
+// StripLauncherBlocks removes legacy shell launcher blocks from shell profiles in homeDir.
 func StripLauncherBlocks(homeDir string) []string {
 	profiles := []string{
 		filepath.Join(homeDir, ".bashrc"),
@@ -108,7 +112,10 @@ func compareSemver(a, b string) int {
 func parseVersionParts(version string) [3]int {
 	parts := strings.SplitN(version, ".", 3)
 	var result [3]int
-	for i := range min(3, len(parts)) {
+	for i := range 3 {
+		if i >= len(parts) {
+			break
+		}
 		_, _ = fmt.Sscanf(parts[i], "%d", &result[i])
 	}
 	return result

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,3 +1,4 @@
+// Package schema builds and validates the Juggernaut block written to settings.json.
 package schema
 
 import (
@@ -8,8 +9,10 @@ import (
 	"github.com/jpvelasco/juggernaut/internal/bedrock"
 )
 
+// SchemaVersion is the current version of the Juggernaut settings.json block.
 const SchemaVersion = 2
 
+// Options holds all user-supplied apply parameters.
 type Options struct {
 	AuthMode      string
 	Region        string
@@ -27,6 +30,7 @@ type Options struct {
 	AuthValidated bool
 }
 
+// Block is the .juggernaut block written to settings.json.
 type Block struct {
 	Auth   Auth              `json:"auth"`
 	Models ModelOverrides    `json:"modelOverrides"`
@@ -34,12 +38,14 @@ type Block struct {
 	Meta   Meta              `json:"meta"`
 }
 
+// Auth holds the authentication configuration within the Juggernaut block.
 type Auth struct {
 	Mode    string `json:"mode"`
 	Region  string `json:"region"`
 	Storage string `json:"storage,omitempty"`
 }
 
+// ModelOverrides holds the Bedrock model IDs for each tier.
 type ModelOverrides struct {
 	Opus     string `json:"opus"`
 	Sonnet   string `json:"sonnet"`
@@ -47,6 +53,7 @@ type ModelOverrides struct {
 	Subagent string `json:"subagent"`
 }
 
+// Meta holds Juggernaut metadata stored in the block.
 type Meta struct {
 	SchemaVersion int    `json:"schemaVersion"`
 	Version       string `json:"version"`
@@ -60,6 +67,7 @@ type Meta struct {
 	Effort        string `json:"effort"`
 }
 
+// NativeKeys are the top-level settings.json keys Claude Code reads directly.
 type NativeKeys struct {
 	Model          string            `json:"model,omitempty"`
 	ModelOverrides map[string]string `json:"modelOverrides,omitempty"`
@@ -70,6 +78,7 @@ var validEfforts = map[string]bool{
 	"low": true, "medium": true, "high": true, "xhigh": true, "max": true,
 }
 
+// Build constructs and validates a Block from bedrock config and options.
 func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	if !cfg.IsSupportedRegion(opts.Region) {
 		return nil, fmt.Errorf("unsupported region %q — run `juggernaut doctor` for supported regions", opts.Region)
@@ -148,6 +157,7 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	}, nil
 }
 
+// NativeKeys derives the top-level settings.json keys from the block.
 func (b *Block) NativeKeys() NativeKeys {
 	model := ""
 	if b.Meta.Opusplan {

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Juggernaut configures Claude Code to use Amazon Bedrock.
 package main
 
 import (


### PR DESCRIPTION
Addresses every finding from local codacy-cli analysis:

**Revive (Go):**
- Add package comments to all packages
- Add doc comments to all exported types, functions, and methods
- Rename unused cobra `cmd`/`args` params to `_`
- Fix `min` builtin redefinition warning in migrate.go

**ESLint (npm/install.js):**
- Add Node.js globals (require, process, console, Buffer, __dirname) to ESLint config

**Opengrep (GitHub Actions):**
- Pin all third-party actions to full commit SHAs (supply chain security)

**Codacy config:**
- Exclude .remember/ and .codacy/ from analysis