### PR TITLE
fix: address Codacy findings from repo analysis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/juggernaut
 
-go 1.26
+go 1.26.4
 
 require (
 	github.com/charmbracelet/huh v1.0.0

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -43,7 +43,7 @@ func (m *Manager) Read() (map[string]any, error) {
 }
 
 func (m *Manager) Write(data map[string]any) error {
-	if err := os.MkdirAll(filepath.Dir(m.path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(m.path), 0o700); err != nil {
 		return fmt.Errorf("creating settings directory: %w", err)
 	}
 
@@ -70,7 +70,7 @@ func (m *Manager) Write(data map[string]any) error {
 	}
 
 	tmp := m.path + ".tmp"
-	if err := os.WriteFile(tmp, encoded, 0o644); err != nil {
+	if err := os.WriteFile(tmp, encoded, 0o600); err != nil {
 		return fmt.Errorf("writing temp settings file: %w", err)
 	}
 	if err := os.Rename(tmp, m.path); err != nil {
@@ -160,5 +160,5 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dst, data, 0o644)
+	return os.WriteFile(dst, data, 0o600)
 }

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -28,13 +28,13 @@ func DefaultBinDir() string {
 
 // Install creates the claude shim in binDir (symlink on Unix, .cmd on Windows).
 func Install(binDir string) error {
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
 		return fmt.Errorf("creating bin dir: %w", err)
 	}
 
 	if runtime.GOOS == "windows" {
 		shimPath := filepath.Join(binDir, "claude.cmd")
-		return os.WriteFile(shimPath, []byte(cmdShim), 0o644)
+		return os.WriteFile(shimPath, []byte(cmdShim), 0o600)
 	}
 
 	self, err := os.Executable()
@@ -88,7 +88,7 @@ func RunAsLauncher(args []string) error {
 		return err
 	}
 
-	cmd := exec.Command(claudePath, args...)
+	cmd := exec.Command(claudePath, args...) //nolint:gosec // claudePath is resolved from PATH, not user input
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -21,7 +21,7 @@ type State struct {
 // Detect inspects homeDir for a v3 Juggernaut block.
 func Detect(homeDir string) (*State, error) {
 	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
-	data, err := os.ReadFile(settingsPath)
+	data, err := os.ReadFile(settingsPath) //nolint:gosec // path is constructed from homeDir, not user input
 	if os.IsNotExist(err) {
 		return &State{}, nil
 	}
@@ -153,5 +153,5 @@ func stripMarkerBlock(path, beginMarker, endMarker string) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	return true, os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o644)
+	return true, os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o600)
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -9,8 +9,8 @@
     "postinstall": "node install.js"
   },
   "dependencies": {
-    "tar": "^7.5.11",
-    "adm-zip": "^0.5.0"
+    "tar": "7.5.16",
+    "adm-zip": "0.5.17"
   },
   "os": ["darwin", "linux", "win32"],
   "cpu": ["x64", "arm64"],


### PR DESCRIPTION
Pulled the real repo config from Codacy dashboard using codacy-cli init with API token, then fixed every finding:

**Trivy (23 HIGH stdlib CVEs):**
- go.mod: 1.26.0 → 1.26.4

**Opengrep (file permissions):**
- config/manager.go: 0o755→0o700 (dir), 0o644→0o600 (files)
- launcher/launcher.go: 0o755→0o700 (dir), 0o644→0o600 (shim)
- migrate/migrate.go: 0o644→0o600 (shell profile writes)

**Opengrep (false positives suppressed):**
- launcher.go: exec.Command with nolint comment (path from PATH lookup, not user input)
- migrate.go: os.ReadFile with nolint comment (path from homeDir, not user input)

**ESLint:**
- Restored Node.js globals in eslint.config.mjs (overwritten by codacy-cli init)

**npm/package.json:**
- Pinned tar and adm-zip to exact versions (7.5.16, 0.5.17)