### PR TITLE
fix: suppress false-positive Codacy findings, fix ESLint errors

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,3 +2,9 @@
 exclude_paths:
   - ".remember/**"
   - ".codacy/**"
+
+engines:
+  opengrep:
+    exclude_paths:
+      - ".remember/**"
+      - ".codacy/**"

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -88,7 +88,7 @@ func RunAsLauncher(args []string) error {
 		return err
 	}
 
-	cmd := exec.Command(claudePath, args...) //nolint:gosec // claudePath is resolved from PATH, not user input
+	cmd := exec.Command(claudePath, args...) //nolint:gosec
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -21,7 +21,7 @@ type State struct {
 // Detect inspects homeDir for a v3 Juggernaut block.
 func Detect(homeDir string) (*State, error) {
 	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
-	data, err := os.ReadFile(settingsPath) //nolint:gosec // path is constructed from homeDir, not user input
+	data, err := os.ReadFile(settingsPath) //nolint:gosec
 	if os.IsNotExist(err) {
 		return &State{}, nil
 	}

--- a/npm/install.js
+++ b/npm/install.js
@@ -25,7 +25,8 @@ function httpsGet(url) {
     https
       .get(url, { headers: { "User-Agent": "juggernaut-npm-installer/1.0" } }, (res) => {
         if (res.statusCode === 301 || res.statusCode === 302) {
-          return httpsGet(res.headers.location).then(resolve).catch(reject);
+          httpsGet(res.headers.location).then(resolve).catch(reject);
+          return;
         }
         const chunks = [];
         res.on("data", (chunk) => chunks.push(chunk));
@@ -43,7 +44,8 @@ function downloadFile(url, dest) {
       https
         .get(fetchUrl, { headers: { "User-Agent": "juggernaut-npm-installer/1.0" } }, (res) => {
           if (res.statusCode === 301 || res.statusCode === 302) {
-            return fetch(res.headers.location);
+            fetch(res.headers.location);
+            return;
           }
           res.pipe(file);
           file.on("finish", () => file.close(resolve));


### PR DESCRIPTION
Real fixes:
- ESLint consistent-return in npm/install.js redirect handlers
- Exclude .remember/ and .codacy/ from ESLint and opengrep

Suppression approach:
- nolint:gosec on exec.Command and os.ReadFile (paths from internal sources, not user input)
- Remaining opengrep findings are confirmed false positives to dismiss in Codacy dashboard:
  - Permission rules flag 0o700/0o600 which are MORE restrictive than defaults
  - Path/fs findings flag paths from os.tmpdir() and homeDir, not user input