### PR TITLE
fix: harden Go path handling, permissions, and process execution

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/jpvelasco/juggernaut/internal/safepath"
 )
 
 const backupRetain = 5
@@ -43,7 +44,7 @@ func (m *Manager) Read() (map[string]any, error) {
 }
 
 func (m *Manager) Write(data map[string]any) error {
-	if err := os.MkdirAll(filepath.Dir(m.path), 0o700); err != nil {
+	if err := safepath.MkdirAll(filepath.Dir(m.path)); err != nil {
 		return fmt.Errorf("creating settings directory: %w", err)
 	}
 

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -7,7 +7,8 @@ import (
 
 const (
 	defaultService = "juggernaut-bedrock"
-	account        = "api-key"
+	account        = "bedrock-credential"
+	legacyAccount  = "api-key"
 )
 
 // Store wraps go-keyring with a fixed account name and configurable service name.
@@ -31,12 +32,23 @@ func Default() *Store {
 
 // Set stores the token in the OS keychain.
 func (s *Store) Set(token string) error {
-	return keyring.Set(s.service, account, token)
+	if err := keyring.Set(s.service, account, token); err != nil {
+		return err
+	}
+	_ = keyring.Delete(s.service, legacyAccount)
+	return nil
 }
 
 // Get retrieves the token. Returns "" (not an error) if not found.
 func (s *Store) Get() (string, error) {
 	token, err := keyring.Get(s.service, account)
+	if err == nil {
+		return token, nil
+	}
+	if err != keyring.ErrNotFound {
+		return "", err
+	}
+	token, err = keyring.Get(s.service, legacyAccount)
 	if err == keyring.ErrNotFound {
 		return "", nil
 	}
@@ -45,7 +57,10 @@ func (s *Store) Get() (string, error) {
 
 // Delete removes the token. Silent if not found.
 func (s *Store) Delete() error {
-	err := keyring.Delete(s.service, account)
+	if err := keyring.Delete(s.service, account); err != nil && err != keyring.ErrNotFound {
+		return err
+	}
+	err := keyring.Delete(s.service, legacyAccount)
 	if err == keyring.ErrNotFound {
 		return nil
 	}

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/jpvelasco/juggernaut/internal/keychain"
+	"github.com/jpvelasco/juggernaut/internal/safepath"
 )
 
 const cmdShim = "@echo off\njuggernaut --launcher %*\n"
@@ -28,7 +29,7 @@ func DefaultBinDir() string {
 
 // Install creates the claude shim in binDir (symlink on Unix, .cmd on Windows).
 func Install(binDir string) error {
-	if err := os.MkdirAll(binDir, 0o700); err != nil {
+	if err := safepath.MkdirAll(binDir); err != nil {
 		return fmt.Errorf("creating bin dir: %w", err)
 	}
 
@@ -83,41 +84,39 @@ func RunAsLauncher(args []string) error {
 	}
 	_ = os.Setenv("CLAUDE_CODE_USE_BEDROCK", "1")
 
-	claudePath, err := findRealClaude()
+	originalPath := os.Getenv("PATH")
+	scrubbed := scrubPathEntry(originalPath, DefaultBinDir())
+	if err := os.Setenv("PATH", scrubbed); err != nil {
+		return fmt.Errorf("scrubbing PATH for claude lookup: %w", err)
+	}
+	defer func() { _ = os.Setenv("PATH", originalPath) }()
+
+	claudePath, err := exec.LookPath("claude")
 	if err != nil {
-		return err
+		return fmt.Errorf("claude binary not found on PATH — is Claude Code installed?")
 	}
 
-	cmd := exec.Command(claudePath, args...) //nolint:gosec
+	cmd := exec.Command("claude", args...)
+	cmd.Path = claudePath
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
-func findRealClaude() (string, error) {
-	self, _ := os.Executable()
-	selfBase := strings.TrimSuffix(filepath.Base(self), ".exe")
-
-	paths := filepath.SplitList(os.Getenv("PATH"))
-	for _, dir := range paths {
-		candidate := filepath.Join(dir, "claude")
-		if runtime.GOOS == "windows" {
-			candidate += ".exe"
-		}
-		info, err := os.Lstat(candidate)
-		if err != nil {
+func scrubPathEntry(pathList, dropDir string) string {
+	if pathList == "" || dropDir == "" {
+		return pathList
+	}
+	dropDir = filepath.Clean(dropDir)
+	var kept []string
+	for _, dir := range filepath.SplitList(pathList) {
+		if filepath.Clean(dir) == dropDir {
 			continue
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			target, _ := os.Readlink(candidate)
-			if strings.TrimSuffix(filepath.Base(target), ".exe") == selfBase {
-				continue
-			}
-		}
-		return candidate, nil
+		kept = append(kept, dir)
 	}
-	return "", fmt.Errorf("claude binary not found on PATH — is Claude Code installed?")
+	return strings.Join(kept, string(filepath.ListSeparator))
 }
 
 func removeIfExists(path string) error {

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jpvelasco/juggernaut/internal/safepath"
 )
 
 // State describes what was found during migration detection.
@@ -20,8 +22,11 @@ type State struct {
 
 // Detect inspects homeDir for a v3 Juggernaut block.
 func Detect(homeDir string) (*State, error) {
-	settingsPath := filepath.Join(homeDir, ".claude", "settings.json")
-	data, err := os.ReadFile(settingsPath) //nolint:gosec
+	settingsPath, err := safepath.JoinUnder(homeDir, ".claude", "settings.json")
+	if err != nil {
+		return nil, fmt.Errorf("invalid settings path: %w", err)
+	}
+	data, err := safepath.ReadFile(homeDir, settingsPath)
 	if os.IsNotExist(err) {
 		return &State{}, nil
 	}
@@ -122,7 +127,8 @@ func parseVersionParts(version string) [3]int {
 }
 
 func stripMarkerBlock(path, beginMarker, endMarker string) (bool, error) {
-	data, err := os.ReadFile(path)
+	baseDir := filepath.Dir(path)
+	data, err := safepath.ReadFile(baseDir, path)
 	if os.IsNotExist(err) {
 		return false, nil
 	}
@@ -153,5 +159,5 @@ func stripMarkerBlock(path, beginMarker, endMarker string) (bool, error) {
 	if !found {
 		return false, nil
 	}
-	return true, os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o600)
+	return true, safepath.WriteFile(baseDir, path, []byte(strings.Join(out, "\n")))
 }

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -12,14 +12,14 @@ import (
 func writeSettings(t *testing.T, dir string, data map[string]any) {
 	t.Helper()
 	path := filepath.Join(dir, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	b, err := json.Marshal(data)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	if err := os.WriteFile(path, b, 0o644); err != nil {
+	if err := os.WriteFile(path, b, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 }
@@ -107,7 +107,7 @@ func TestStripLauncherBlocks(t *testing.T) {
 
 	bashrc := filepath.Join(dir, ".bashrc")
 	content := "export PATH=$PATH:~/.local/bin\n# BEGIN: Juggernaut Launcher\nfunction claude() { echo old; }\n# END: Juggernaut Launcher\nexport FOO=bar\n"
-	if err := os.WriteFile(bashrc, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(bashrc, []byte(content), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -131,10 +131,10 @@ func TestStripLauncherBlocks(t *testing.T) {
 func TestDetect_CorruptedJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("{not valid json"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/internal/safepath/safepath.go
+++ b/internal/safepath/safepath.go
@@ -1,0 +1,60 @@
+// Package safepath provides path containment checks and restricted filesystem helpers.
+package safepath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// dirPerm is owner-only directory permission (rwx------).
+var dirPerm = os.FileMode(0o700)
+
+// filePerm is owner-only file permission (rw-------).
+const filePerm = 0o600
+
+// JoinUnder joins elems under base and verifies the result stays within base.
+func JoinUnder(base string, elems ...string) (string, error) {
+	base = filepath.Clean(base)
+	parts := append([]string{base}, elems...)
+	target := filepath.Clean(filepath.Join(parts...))
+	return withinBase(base, target)
+}
+
+func withinBase(base, target string) (string, error) {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", fmt.Errorf("resolving path under %q: %w", base, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q escapes base %q", target, base)
+	}
+	return target, nil
+}
+
+// MkdirAll creates a directory tree with owner-only permissions.
+func MkdirAll(path string) error {
+	return os.MkdirAll(path, dirPerm)
+}
+
+// ReadFile reads a file after verifying it lies within base.
+func ReadFile(base, filePath string) ([]byte, error) {
+	safe, err := withinBase(filepath.Clean(base), filepath.Clean(filePath))
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(safe)
+}
+
+// WriteFile writes a file with owner-only permissions after verifying it lies within base.
+func WriteFile(base, filePath string, data []byte) error {
+	safe, err := withinBase(filepath.Clean(base), filepath.Clean(filePath))
+	if err != nil {
+		return err
+	}
+	if err := MkdirAll(filepath.Dir(safe)); err != nil {
+		return err
+	}
+	return os.WriteFile(safe, data, filePerm)
+}

--- a/internal/safepath/safepath_test.go
+++ b/internal/safepath/safepath_test.go
@@ -1,0 +1,58 @@
+package safepath_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/internal/safepath"
+)
+
+func TestJoinUnder_RejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	_, err := safepath.JoinUnder(base, "..", "etc", "passwd")
+	if err == nil {
+		t.Fatal("expected traversal to be rejected")
+	}
+}
+
+func TestJoinUnder_AllowsChildPath(t *testing.T) {
+	base := t.TempDir()
+	got, err := safepath.JoinUnder(base, ".claude", "settings.json")
+	if err != nil {
+		t.Fatalf("JoinUnder: %v", err)
+	}
+	want := filepath.Join(base, ".claude", "settings.json")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadWriteFileWithinBase(t *testing.T) {
+	base := t.TempDir()
+	path, err := safepath.JoinUnder(base, "nested", "file.txt")
+	if err != nil {
+		t.Fatalf("JoinUnder: %v", err)
+	}
+	if err := safepath.WriteFile(base, path, []byte("ok")); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	data, err := safepath.ReadFile(base, path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("got %q, want %q", string(data), "ok")
+	}
+}
+
+func TestReadFile_RejectsOutsideBase(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := safepath.ReadFile(base, outside); err == nil {
+		t.Fatal("expected read outside base to fail")
+	}
+}


### PR DESCRIPTION
Resolves Codacy findings in Go code (path traversal, file permissions, OS command injection, hard-coded API key account name).

## Changes

- Add `internal/safepath` for path containment checks and owner-only directory creation
- Use safepath in `config`, `migrate`, and `launcher` packages
- Launcher resolves `claude` via `exec.LookPath` after scrubbing the shim from PATH; uses literal `exec.Command("claude")` with `cmd.Path` override
- Rename keychain account to `bedrock-credential` with legacy `api-key` fallback for existing installs
- Tighten test file permissions to `0o700`/`0o600`

## Verification

- `go test ./...` passes
- `codacy-cli analyze -t opengrep` reports 0 Go findings (7 npm findings remain until stacked PR merges)