### PR TITLE
fix: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Resolves [Code Scanning alert #5](https://github.com/jpvelasco/juggernaut/security/code-scanning/5) and [#9](https://github.com/jpvelasco/juggernaut/security/code-scanning/9).

Both are \ctions/missing-workflow-permissions\ on \lint\ and \	est\ jobs in \.github/workflows/ci.yml\. Adds workflow-level \permissions: contents: read\, matching \codacy-local.yml\.