### PR TITLE
docs: add Codacy grade and Go Report Card badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
   <a href="https://github.com/jpvelasco/juggernaut/releases/latest"><img src="https://img.shields.io/github/v/release/jpvelasco/juggernaut" alt="Release"></a>
   <a href="https://github.com/jpvelasco/juggernaut/blob/main/LICENSE"><img src="https://img.shields.io/github/license/jpvelasco/juggernaut" alt="License"></a>
   <a href="https://github.com/jpvelasco/juggernaut/blob/main/go.mod"><img src="https://img.shields.io/github/go-mod/go-version/jpvelasco/juggernaut" alt="Go"></a>
+  <a href="https://goreportcard.com/report/github.com/jpvelasco/juggernaut"><img src="https://goreportcard.com/badge/github.com/jpvelasco/juggernaut" alt="Go Report Card"></a>
   <a href="https://www.npmjs.com/package/juggernaut-bedrock"><img src="https://img.shields.io/npm/v/juggernaut-bedrock" alt="npm"></a>
+  <a href="https://app.codacy.com/gh/jpvelasco/juggernaut/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/2bf1e68b80964537b5c65350663c3073" alt="Codacy Grade"></a>
 </p>
 
 <h1 align="center">Juggernaut</h1>


### PR DESCRIPTION
Adds badges to the repo front page:

- **Codacy Grade** (A) — links to the Codacy dashboard
- **Go Report Card** — matches Ludus README style