### PR TITLE
docs: add npm package README and enrich metadata

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,118 @@
+# juggernaut-bedrock
+
+**Claude Code → Amazon Bedrock in one command.**
+
+Juggernaut is a cross-platform CLI that wires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to [Amazon Bedrock](https://aws.amazon.com/bedrock/) instead of Anthropic's direct API. One install, one `apply`, then just run `claude` — no shell profile hacks, no manual env vars, no jq.
+
+Built for developers shipping with GenAI today: IAM and SSO for teams, API keys for solo runs, and a `doctor` command when something's off.
+
+<p align="center">
+  <a href="https://github.com/jpvelasco/juggernaut/actions/workflows/ci.yml"><img src="https://github.com/jpvelasco/juggernaut/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/jpvelasco/juggernaut/releases/latest"><img src="https://img.shields.io/github/v/release/jpvelasco/juggernaut" alt="Release"></a>
+  <a href="https://www.npmjs.com/package/juggernaut-bedrock"><img src="https://img.shields.io/npm/v/juggernaut-bedrock" alt="npm"></a>
+  <a href="https://app.codacy.com/gh/jpvelasco/juggernaut/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/2bf1e68b80964537b5c65350663c3073" alt="Codacy Grade"></a>
+</p>
+
+## Install
+
+```bash
+npm install -g juggernaut-bedrock
+```
+
+Or try it without installing globally:
+
+```bash
+npx juggernaut-bedrock version
+```
+
+Works on **macOS**, **Linux**, **Windows**, and **WSL** — `x64` and `arm64`.
+
+## Quickstart
+
+```bash
+# 1. Install (above)
+
+# 2. Configure — IAM/SSO (recommended) or interactive prompt
+juggernaut apply --auth=iam
+
+# 3. Launch Claude Code (token injected automatically)
+claude
+```
+
+Bedrock API key auth? Run `juggernaut apply` and follow the prompt — credentials land in your OS keychain, not your shell history.
+
+## What it does
+
+```
+juggernaut apply --auth=iam
+```
+
+That one command:
+
+1. **Writes** Bedrock config to `~/.claude/settings.json` (or project scope)
+2. **Sets** model IDs, region, effort level, and `CLAUDE_CODE_USE_BEDROCK=1` — only after credentials check out
+3. **Installs** a `claude` launcher shim that reads your token from the keychain and execs the real binary
+
+No `.bashrc` edits. No copying API keys into env vars. No "why isn't Bedrock routing?" at 2am.
+
+## Why Bedrock?
+
+| | Direct Anthropic API | Amazon Bedrock |
+|---|---------------------|----------------|
+| **Billing** | Separate account | Your AWS bill |
+| **Auth** | API keys | IAM, SSO, roles |
+| **Region** | Anthropic infra | Your chosen AWS region |
+| **Compliance** | Anthropic certs | SOC, HIPAA, FedRAMP via AWS |
+| **Network** | Public internet | VPC endpoints, PrivateLink |
+
+## Auth modes
+
+| Mode | Command | Best for |
+|------|---------|----------|
+| **IAM / SSO** | `juggernaut apply --auth=iam` | Teams, enterprise, existing AWS identity |
+| **Bedrock API key** | `juggernaut apply` | Solo devs, quick setup |
+| **Interactive** | `juggernaut apply` (no flags) | First run — guided prompts |
+| **Preview** | `juggernaut apply --dry-run` | See what would change, change nothing |
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `apply` | Configure Bedrock + install the `claude` shim |
+| `show` | Print your current Juggernaut config |
+| `doctor` | Diagnostics — block, credentials, launcher |
+| `migrate` | Upgrade from v3 shell installer to v4 Go binary |
+| `uninstall` | Remove config, token, and shim |
+| `version` | Print installed version (`--json` for machines) |
+
+## Default models
+
+| Tier | Model |
+|------|-------|
+| **Primary** | Claude Sonnet 4.6 |
+| **Opus** | Claude Opus 4.7 |
+| **Fast** | Claude Haiku 4.5 |
+
+Override any tier: `juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6`
+
+## Troubleshooting
+
+Stuck? Start here:
+
+```bash
+juggernaut doctor
+```
+
+Common fixes: complete Anthropic model access in the Bedrock console (403), refresh SSO (`aws sso login`), or re-run `juggernaut apply`.
+
+## Documentation
+
+Full docs, IAM policy, migration guide, and platform notes:
+
+**[github.com/jpvelasco/juggernaut](https://github.com/jpvelasco/juggernaut)**
+
+## License
+
+MIT — see [LICENSE](https://github.com/jpvelasco/juggernaut/blob/main/LICENSE).
+
+Juggernaut is an independent tool, not affiliated with Anthropic or Amazon Web Services.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "juggernaut-bedrock",
   "version": "4.0.1",
-  "description": "Configure Claude Code to use Amazon Bedrock — cross-platform installer",
+  "description": "Route Claude Code through Amazon Bedrock in one command — IAM, SSO, or API key. Cross-platform CLI for GenAI developers.",
   "bin": {
     "juggernaut": "./bin/juggernaut"
   },
@@ -14,11 +14,29 @@
   },
   "os": ["darwin", "linux", "win32"],
   "cpu": ["x64", "arm64"],
-  "keywords": ["claude", "bedrock", "aws", "anthropic", "claude-code"],
+  "keywords": [
+    "claude",
+    "claude-code",
+    "bedrock",
+    "amazon-bedrock",
+    "aws",
+    "anthropic",
+    "genai",
+    "ai-coding",
+    "llm",
+    "coding-agent",
+    "cli",
+    "iam",
+    "sso",
+    "developer-tools"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jpvelasco/juggernaut"
+  },
+  "bugs": {
+    "url": "https://github.com/jpvelasco/juggernaut/issues"
   },
   "homepage": "https://github.com/jpvelasco/juggernaut#readme"
 }


### PR DESCRIPTION
The [juggernaut-bedrock npm page](https://www.npmjs.com/package/juggernaut-bedrock) currently shows almost nothing because there was no \
pm/README.md\.

This adds a Ludus-style package README with quickstart, Bedrock comparison, auth modes, commands, and badges — plus a richer \package.json\ description and keywords for discoverability.

**Note:** The npm page updates on the next publish (patch release or next tag).