### PR TITLE
fix: use /v4 module path for Go v4 semver tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     main: .
     binary: juggernaut
     ldflags:
-      - -s -w -X github.com/jpvelasco/juggernaut/cmd.Version={{.Version}}
+      - -s -w -X github.com/jpvelasco/juggernaut/v4/cmd.Version={{.Version}}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build test lint clean codacy codacy-sync
 
 build:
-	go build -ldflags "-X github.com/jpvelasco/juggernaut/cmd.Version=$(shell cat VERSION)" -o bin/juggernaut .
+	go build -ldflags "-X github.com/jpvelasco/juggernaut/v4/cmd.Version=$(shell cat VERSION)" -o bin/juggernaut .
 
 test:
 	go test ./... -v

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -6,13 +6,13 @@ import (
 	"os"
 
 	"github.com/charmbracelet/huh"
-	"github.com/jpvelasco/juggernaut/internal/authmode"
-	"github.com/jpvelasco/juggernaut/internal/bedrock"
-	"github.com/jpvelasco/juggernaut/internal/config"
-	"github.com/jpvelasco/juggernaut/internal/keychain"
-	"github.com/jpvelasco/juggernaut/internal/launcher"
-	"github.com/jpvelasco/juggernaut/internal/migrate"
-	"github.com/jpvelasco/juggernaut/internal/schema"
+	"github.com/jpvelasco/juggernaut/v4/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v4/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v4/internal/config"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v4/internal/launcher"
+	"github.com/jpvelasco/juggernaut/v4/internal/migrate"
+	"github.com/jpvelasco/juggernaut/v4/internal/schema"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/authmode"
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 func TestApply_DryRun_IAM(t *testing.T) {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/jpvelasco/juggernaut/internal/config"
-	"github.com/jpvelasco/juggernaut/internal/doctor"
-	"github.com/jpvelasco/juggernaut/internal/keychain"
-	"github.com/jpvelasco/juggernaut/internal/launcher"
+	"github.com/jpvelasco/juggernaut/v4/internal/config"
+	"github.com/jpvelasco/juggernaut/v4/internal/doctor"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v4/internal/launcher"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jpvelasco/juggernaut/internal/bedrock"
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 // embeddedConfigBytes holds bedrock-config.json bytes injected at startup from main.go.

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jpvelasco/juggernaut/internal/authmode"
-	"github.com/jpvelasco/juggernaut/internal/keychain"
-	"github.com/jpvelasco/juggernaut/internal/launcher"
-	"github.com/jpvelasco/juggernaut/internal/migrate"
+	"github.com/jpvelasco/juggernaut/v4/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v4/internal/launcher"
+	"github.com/jpvelasco/juggernaut/v4/internal/migrate"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/jpvelasco/juggernaut/internal/launcher"
+	"github.com/jpvelasco/juggernaut/v4/internal/launcher"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/jpvelasco/juggernaut/internal/config"
+	"github.com/jpvelasco/juggernaut/v4/internal/config"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jpvelasco/juggernaut/internal/config"
-	"github.com/jpvelasco/juggernaut/internal/keychain"
-	"github.com/jpvelasco/juggernaut/internal/launcher"
-	"github.com/jpvelasco/juggernaut/internal/migrate"
+	"github.com/jpvelasco/juggernaut/v4/internal/config"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v4/internal/launcher"
+	"github.com/jpvelasco/juggernaut/v4/internal/migrate"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jpvelasco/juggernaut
+module github.com/jpvelasco/juggernaut/v4
 
 go 1.26.4
 

--- a/internal/bedrock/config_test.go
+++ b/internal/bedrock/config_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v4/internal/bedrock"
 )
 
 func TestLoad(t *testing.T) {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 const backupRetain = 5

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/config"
+	"github.com/jpvelasco/juggernaut/v4/internal/config"
 )
 
 func TestReadMissing(t *testing.T) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/doctor"
+	"github.com/jpvelasco/juggernaut/v4/internal/doctor"
 )
 
 func TestReport_AllOK(t *testing.T) {

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
 )
 
 func testStore() *keychain.Store {

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -9,8 +9,8 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/jpvelasco/juggernaut/internal/keychain"
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 const cmdShim = "@echo off\njuggernaut --launcher %*\n"

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/launcher"
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/launcher"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 func TestInstall(t *testing.T) {

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 // State describes what was found during migration detection.

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/migrate"
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/migrate"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 func writeSettings(t *testing.T, dir string, data map[string]any) {

--- a/internal/safepath/safepath_test.go
+++ b/internal/safepath/safepath_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
 func TestJoinUnder_RejectsTraversal(t *testing.T) {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -6,7 +6,7 @@ import (
 	"maps"
 	"time"
 
-	"github.com/jpvelasco/juggernaut/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v4/internal/bedrock"
 )
 
 // SchemaVersion is the current version of the Juggernaut settings.json block.

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -3,8 +3,8 @@ package schema_test
 import (
 	"testing"
 
-	"github.com/jpvelasco/juggernaut/internal/bedrock"
-	"github.com/jpvelasco/juggernaut/internal/schema"
+	"github.com/jpvelasco/juggernaut/v4/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v4/internal/schema"
 )
 
 func testConfig() *bedrock.Config {

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	_ "embed"
 
-	"github.com/jpvelasco/juggernaut/cmd"
+	"github.com/jpvelasco/juggernaut/v4/cmd"
 )
 
 //go:embed bedrock-config.json


### PR DESCRIPTION
Fixes dead Go Report Card badge.

**Root cause:** \proxy.golang.org\ rejects \4.0.1\ with:
\module path must match major version (github.com/jpvelasco/juggernaut/v4)\

The module was declared as \github.com/jpvelasco/juggernaut\ but tagged at v4.x — invalid per Go module versioning. Ludus works because it tags v0.x.

**Fix:** \go.mod\ → \github.com/jpvelasco/juggernaut/v4\, all imports updated, ldflags in Makefile/GoReleaser updated.

**After merge:** needs a new tag (\4.0.2\) for the proxy and Go Report Card to index the module.