### PR TITLE
fix: four correctness issues from code review

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -68,7 +68,10 @@ func init() {
 }
 
 func runApply(_ *cobra.Command, _ []string) error {
-	home := homeDir()
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
 
 	bCfg, err := loadBedrockConfig()
 	if err != nil {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -34,7 +34,6 @@ var applyFlags struct {
 	effort        string
 	opusplan      bool
 	noOpusplan    bool
-	use1m         bool
 	no1m          bool
 	noMantle      bool
 	mantleURL     string
@@ -57,7 +56,6 @@ func init() {
 	f.StringVar(&applyFlags.effort, "effort", "xhigh", "effort level: low|medium|high|xhigh|max")
 	f.BoolVar(&applyFlags.opusplan, "opusplan", false, "route planning to Opus, execution to Sonnet")
 	f.BoolVar(&applyFlags.noOpusplan, "no-opusplan", false, "disable opusplan")
-	f.BoolVar(&applyFlags.use1m, "1m-context", true, "enable 1M token context")
 	f.BoolVar(&applyFlags.no1m, "no-1m-context", false, "disable 1M token context")
 	f.BoolVar(&applyFlags.noMantle, "no-mantle", false, "disable Mantle routing")
 	f.StringVar(&applyFlags.mantleURL, "mantle-url", "", "custom Mantle base URL")
@@ -160,21 +158,23 @@ func commitApply(home, authMode, token string, block *schema.Block) error {
 		return err
 	}
 
-	installLauncherShimIfMissing()
+	if err := installLauncherShimIfMissing(); err != nil {
+		return fmt.Errorf("installing claude shim: %w", err)
+	}
 	fmt.Println("Configuration written successfully.")
 	return nil
 }
 
-func installLauncherShimIfMissing() {
+func installLauncherShimIfMissing() error {
 	binDir := launcher.DefaultBinDir()
 	if launcher.IsInstalled(binDir) {
-		return
+		return nil
 	}
 	if err := launcher.Install(binDir); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not install claude shim: %v\n", err)
-		return
+		return err
 	}
 	fmt.Printf("  ✓ Installed claude shim → %s\n", binDir)
+	return nil
 }
 
 func resolveApplyInputs(home string, bCfg *bedrock.Config) (authMode, region string, opusplan bool, err error) {
@@ -295,7 +295,9 @@ func runMigrationIfNeeded(home string, dryRun bool) error {
 
 	if authmode.IsBedrockAPIKey(state.AuthMode) {
 		token, err := keychain.Default().Get()
-		if err == nil && token != "" {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "  Warning: could not read bearer token for migration:", err)
+		} else if token != "" {
 			if err := keychain.Default().Set(token); err != nil {
 				fmt.Fprintln(os.Stderr, "  Warning: could not transfer bearer token:", err)
 			} else {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -158,23 +158,21 @@ func commitApply(home, authMode, token string, block *schema.Block) error {
 		return err
 	}
 
-	if err := installLauncherShimIfMissing(); err != nil {
-		return fmt.Errorf("installing claude shim: %w", err)
-	}
+	installLauncherShimIfMissing()
 	fmt.Println("Configuration written successfully.")
 	return nil
 }
 
-func installLauncherShimIfMissing() error {
+func installLauncherShimIfMissing() {
 	binDir := launcher.DefaultBinDir()
 	if launcher.IsInstalled(binDir) {
-		return nil
+		return
 	}
 	if err := launcher.Install(binDir); err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "Warning: could not install claude shim: %v\n", err)
+		return
 	}
 	fmt.Printf("  ✓ Installed claude shim → %s\n", binDir)
-	return nil
 }
 
 func resolveApplyInputs(home string, bCfg *bedrock.Config) (authMode, region string, opusplan bool, err error) {
@@ -293,13 +291,16 @@ func runMigrationIfNeeded(home string, dryRun bool) error {
 
 	fmt.Println("Migrating to Juggernaut v4...")
 
+	keychainOK := true
 	if authmode.IsBedrockAPIKey(state.AuthMode) {
 		token, err := keychain.Default().Get()
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "  Warning: could not read bearer token for migration:", err)
+			keychainOK = false
 		} else if token != "" {
 			if err := keychain.Default().Set(token); err != nil {
 				fmt.Fprintln(os.Stderr, "  Warning: could not transfer bearer token:", err)
+				keychainOK = false
 			} else {
 				fmt.Println("  ✓ Bearer token transferred to go-keyring")
 			}
@@ -311,6 +312,11 @@ func runMigrationIfNeeded(home string, dryRun bool) error {
 		fmt.Printf("  ✓ Removed legacy launcher block from %s\n", p)
 	}
 
-	fmt.Println("Migration complete. No credentials were re-entered.")
+	if !keychainOK {
+		fmt.Println("Migration complete with warnings. Re-enter your credentials:")
+		fmt.Println("  juggernaut apply --auth=bedrock-api-key")
+	} else {
+		fmt.Println("Migration complete. No credentials were re-entered.")
+	}
 	return nil
 }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -317,7 +317,7 @@ func runMigrationIfNeeded(home string, dryRun bool) error {
 
 	if !keychainOK {
 		fmt.Println("Migration complete with warnings. Re-enter your credentials:")
-		fmt.Println("  juggernaut apply --auth=bedrock-api-key")
+		fmt.Println("  juggernaut apply --auth=" + authmode.BedrockAPIKey)
 	} else {
 		fmt.Println("Migration complete. No credentials were re-entered.")
 	}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -57,6 +57,10 @@ func init() {
 	f.BoolVar(&applyFlags.opusplan, "opusplan", false, "route planning to Opus, execution to Sonnet")
 	f.BoolVar(&applyFlags.noOpusplan, "no-opusplan", false, "disable opusplan")
 	f.BoolVar(&applyFlags.no1m, "no-1m-context", false, "disable 1M token context")
+	// Deprecated: --1m-context was always the default and is now a no-op. Kept for script compatibility.
+	var deprecated1m bool
+	f.BoolVar(&deprecated1m, "1m-context", true, "")
+	_ = f.MarkHidden("1m-context")
 	f.BoolVar(&applyFlags.noMantle, "no-mantle", false, "disable Mantle routing")
 	f.StringVar(&applyFlags.mantleURL, "mantle-url", "", "custom Mantle base URL")
 	f.StringVar(&applyFlags.scope, "scope", "user", "settings scope: user or project")

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -28,7 +28,10 @@ func init() {
 }
 
 func runDoctor(_ *cobra.Command, _ []string) error {
-	home := homeDir()
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
 	r := doctor.NewReport()
 
 	bCfg, err := loadBedrockConfig()

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -65,6 +65,9 @@ func settingsPath(homeDir, scope string) (string, error) {
 	if scope == "project" {
 		return filepath.Join(".", ".claude", "settings.json"), nil
 	}
+	if homeDir == "" {
+		return "", fmt.Errorf("could not determine home directory")
+	}
 	return safepath.JoinUnder(homeDir, ".claude", "settings.json")
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -54,7 +54,11 @@ func homeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h
 	}
-	return os.Getenv("USERPROFILE")
+	if h := os.Getenv("USERPROFILE"); h != "" {
+		return h
+	}
+	h, _ := os.UserHomeDir()
+	return h
 }
 
 func settingsPath(homeDir, scope string) (string, error) {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -50,23 +50,23 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-func homeDir() string {
+func homeDir() (string, error) {
 	if h := os.Getenv("HOME"); h != "" {
-		return h
+		return h, nil
 	}
 	if h := os.Getenv("USERPROFILE"); h != "" {
-		return h
+		return h, nil
 	}
-	h, _ := os.UserHomeDir()
-	return h
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return h, nil
 }
 
 func settingsPath(homeDir, scope string) (string, error) {
 	if scope == "project" {
 		return filepath.Join(".", ".claude", "settings.json"), nil
-	}
-	if homeDir == "" {
-		return "", fmt.Errorf("could not determine home directory")
 	}
 	return safepath.JoinUnder(homeDir, ".claude", "settings.json")
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -71,7 +71,9 @@ func runMigrate(_ *cobra.Command, _ []string) error {
 
 	if authmode.IsBedrockAPIKey(state.AuthMode) {
 		token, err := keychain.Default().Get()
-		if err == nil && token != "" {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "  Warning: could not read bearer token:", err)
+		} else if token != "" {
 			if err := keychain.Default().Set(token); err != nil {
 				fmt.Fprintln(os.Stderr, "  Warning: could not transfer bearer token:", err)
 			} else {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -25,7 +25,10 @@ func init() {
 }
 
 func runMigrate(_ *cobra.Command, _ []string) error {
-	home := homeDir()
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
 
 	state, err := migrate.Detect(home)
 	if err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -26,7 +26,10 @@ func init() {
 }
 
 func runShow(_ *cobra.Command, _ []string) error {
-	home := homeDir()
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
 	scopes := []string{"user", "project"}
 	if showFlags.scope != "" {
 		scopes = []string{showFlags.scope}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/jpvelasco/juggernaut/v4/internal/config"
 	"github.com/spf13/cobra"
@@ -39,11 +40,13 @@ func runShow(_ *cobra.Command, _ []string) error {
 	for _, scope := range scopes {
 		path, perr := settingsPath(home, scope)
 		if perr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not determine %s scope path: %v\n", scope, perr)
 			continue
 		}
 		mgr := config.NewManager(path)
 		data, err := mgr.Read()
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not read %s settings: %v\n", scope, err)
 			continue
 		}
 		results[scope] = data["juggernaut"]

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -36,7 +36,10 @@ func init() {
 }
 
 func runUninstall(_ *cobra.Command, _ []string) error {
-	home := homeDir()
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
 
 	if aborted, err := confirmUninstallAborted(); aborted || err != nil {
 		return err


### PR DESCRIPTION
## Summary

- **\`homeDir()\` missing \`os.UserHomeDir()\` fallback** (\`cmd/helpers.go:53\`) — when \`\$HOME\` and \`\$USERPROFILE\` are both unset (Docker, CI, \`sudo\` installs), the function returned \`""\` and \`settingsPath\` silently wrote config to \`.claude/settings.json\` relative to CWD. Now matches \`DefaultBinDir()\`'s three-step fallback. \`homeDir()\` signature changed to \`(string, error)\`; all 5 callers fail fast.

- **Migration swallowed \`keychain.Get()\` errors** (\`cmd/apply.go\` and \`cmd/migrate.go\`) — non-\`ErrNotFound\` errors are now warned to stderr; final message distinguishes partial migration from success.

- **\`--1m-context\` flag was dead** (\`cmd/apply.go:60\`) — \`applyFlags.use1m\` was registered but never read. Removed the active flag; kept as a hidden no-op for script backwards compatibility. \`--no-1m-context\` remains the canonical control.

- **Shim install failure masked as success** (\`cmd/apply.go:163\`) — reverted to a warning (consistent with \`migrate.go\`); shim install failure does not abort a successful \`settings.json\` write.

- **\`show.go\` silently skipped scopes on error** — now prints a warning to stderr, consistent with \`doctor.go\` and \`uninstall.go\`.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./...\` passes
- [x] \`juggernaut apply --no-1m-context\` still works; \`--1m-context\` hidden from \`--help\` but still accepted
- [x] In an env with \`\$HOME\` unset, verify config writes to the correct absolute path