### PR TITLE
fix: skip API key prompt when keychain already has a token

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -250,28 +250,29 @@ func resolveCredential(authMode string) (string, error) {
 	if applyFlags.bedrockKey != "" {
 		return applyFlags.bedrockKey, nil
 	}
-	if applyFlags.preserveKey {
-		token, err := keychain.Default().Get()
-		if err != nil {
-			return "", fmt.Errorf("reading existing key: %w", err)
-		}
-		if token != "" {
-			return token, nil
-		}
+	token, err := keychain.Default().Get()
+	if err != nil {
+		return "", fmt.Errorf("reading existing key: %w", err)
 	}
-	var token string
+	if token != "" {
+		return token, nil
+	}
+	if applyFlags.preserveKey {
+		return "", fmt.Errorf("no existing key found in keychain; re-run without --preserve-key to enter one")
+	}
+	var input string
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Bedrock API key").
 				EchoMode(huh.EchoModePassword).
-				Value(&token),
+				Value(&input),
 		),
 	)
 	if err := form.Run(); err != nil {
 		return "", err
 	}
-	return token, nil
+	return input, nil
 }
 
 func runMigrationIfNeeded(home string, dryRun bool) error {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -252,9 +252,11 @@ func resolveCredential(authMode string) (string, error) {
 	}
 	token, err := keychain.Default().Get()
 	if err != nil {
-		return "", fmt.Errorf("reading existing key: %w", err)
-	}
-	if token != "" {
+		if applyFlags.preserveKey {
+			return "", fmt.Errorf("reading existing key: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Warning: could not read keychain (will prompt for key): %v\n", err)
+	} else if token != "" {
 		return token, nil
 	}
 	if applyFlags.preserveKey {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v4/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
 	"github.com/jpvelasco/juggernaut/v4/internal/safepath"
 )
 
@@ -166,6 +168,69 @@ func TestUninstall_RemovesBlock(t *testing.T) {
 	}
 	if _, ok := settings["env"]; ok {
 		t.Error("env key should be removed after uninstall")
+	}
+}
+
+// setupIsolatedKeychain sets JUGGERNAUT_KEYCHAIN_SERVICE to an isolated test
+// service name and returns a cleanup function that deletes the test entry.
+func setupIsolatedKeychain(t *testing.T) {
+	t.Helper()
+	svc := "juggernaut-apply-test-" + t.Name()
+	t.Setenv("JUGGERNAUT_KEYCHAIN_SERVICE", svc)
+}
+
+func TestApply_BedrockKey_FromKeychainNoReprompt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupIsolatedKeychain(t)
+
+	// Pre-seed the keychain (simulates post-migration state).
+	store := keychain.Default()
+	if err := store.Set("migrated-api-key"); err != nil {
+		t.Skipf("keychain backend unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Delete() })
+
+	// apply without --bedrock-key — should use keychain, not prompt.
+	if err := ExecuteArgs([]string{
+		"apply",
+		"--auth=" + authmode.BedrockAPIKey,
+		"--region=us-west-2",
+		"--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	// Settings should have been written.
+	readSettingsJSON(t, home)
+}
+
+func TestApply_PreserveKey_ErrorsIfKeychainEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupIsolatedKeychain(t)
+
+	// Ensure keychain is empty.
+	store := keychain.Default()
+	if err := store.Set("probe"); err != nil {
+		t.Skipf("keychain backend unavailable: %v", err)
+	}
+	_ = store.Delete()
+
+	err := ExecuteArgs([]string{
+		"apply",
+		"--auth=" + authmode.BedrockAPIKey,
+		"--preserve-key",
+		"--region=us-west-2",
+		"--skip-preflight",
+	})
+	if err == nil {
+		t.Fatal("expected error when keychain is empty and --preserve-key is set")
+	}
+	if !strings.Contains(err.Error(), "no existing key found in keychain") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jpvelasco/juggernaut/v4/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v4/internal/keychain"
@@ -171,24 +172,37 @@ func TestUninstall_RemovesBlock(t *testing.T) {
 	}
 }
 
-// setupIsolatedKeychain sets JUGGERNAUT_KEYCHAIN_SERVICE to an isolated test
-// service name and returns a cleanup function that deletes the test entry.
-func setupIsolatedKeychain(t *testing.T) {
+// setupIsolatedKeychain sets JUGGERNAUT_KEYCHAIN_SERVICE to a short fixed
+// service name and skips the test if the keychain backend is unavailable.
+// The name is intentionally short — macOS security(1) hangs on long names.
+func setupIsolatedKeychain(t *testing.T) *keychain.Store {
 	t.Helper()
-	svc := "juggernaut-apply-test-" + t.Name()
-	t.Setenv("JUGGERNAUT_KEYCHAIN_SERVICE", svc)
+	t.Setenv("JUGGERNAUT_KEYCHAIN_SERVICE", "jug-cmd-test")
+	store := keychain.Default()
+	// Probe with a timeout: if Set hangs, the test would block for 10 min.
+	done := make(chan error, 1)
+	go func() { done <- store.Set("probe") }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Skipf("keychain backend unavailable: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Skip("keychain backend timed out")
+	}
+	_ = store.Delete()
+	return store
 }
 
 func TestApply_BedrockKey_FromKeychainNoReprompt(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
-	setupIsolatedKeychain(t)
+	store := setupIsolatedKeychain(t)
 
 	// Pre-seed the keychain (simulates post-migration state).
-	store := keychain.Default()
 	if err := store.Set("migrated-api-key"); err != nil {
-		t.Skipf("keychain backend unavailable: %v", err)
+		t.Fatalf("seeding keychain: %v", err)
 	}
 	t.Cleanup(func() { _ = store.Delete() })
 
@@ -210,14 +224,8 @@ func TestApply_PreserveKey_ErrorsIfKeychainEmpty(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
-	setupIsolatedKeychain(t)
-
-	// Ensure keychain is empty.
-	store := keychain.Default()
-	if err := store.Set("probe"); err != nil {
-		t.Skipf("keychain backend unavailable: %v", err)
-	}
-	_ = store.Delete()
+	store := setupIsolatedKeychain(t)
+	t.Cleanup(func() { _ = store.Delete() })
 
 	err := ExecuteArgs([]string{
 		"apply",

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -2,6 +2,8 @@
 package keychain
 
 import (
+	"os"
+
 	keyring "github.com/zalando/go-keyring"
 )
 
@@ -26,8 +28,12 @@ func NewStore(service string) *Store {
 	return &Store{service: service}
 }
 
-// Default returns a Store using the production service name.
+// Default returns a Store using the production service name, or the value of
+// JUGGERNAUT_KEYCHAIN_SERVICE if set (used by tests to isolate keychain state).
 func Default() *Store {
+	if svc := os.Getenv("JUGGERNAUT_KEYCHAIN_SERVICE"); svc != "" {
+		return NewStore(svc)
+	}
 	return NewStore(defaultService)
 }
 


### PR DESCRIPTION
## Summary

- After v3→v4 migration, `resolveCredential` was prompting for the API key even though migration had just transferred it to the keychain
- Root cause: keychain lookup was gated behind `--preserve-key`; removed the gate so keychain is always checked before prompting
- `--preserve-key` now returns an explicit error if no key is found instead of silently falling through to the prompt

## Test plan

- [ ] Fresh Linux install via npm: `juggernaut apply --auth=bedrock-api-key` — should prompt once, store key
- [ ] Subsequent `juggernaut apply --auth=bedrock-api-key` — should not prompt (key already in keychain)
- [ ] v3→v4 migration path: run `juggernaut apply --auth=bedrock-api-key` after upgrading — should migrate and not reprompt
- [ ] `--preserve-key` with no keychain entry — should error clearly
- [ ] `go test ./...` passes