### PR TITLE
docs: document --allow-scripts flag for npm 9+ users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Single cross-platform binary that configures Claude Code to route through Amazon
 Published as [`juggernaut-bedrock`](https://www.npmjs.com/package/juggernaut-bedrock) on npm. Works everywhere Claude Code is installed.
 
 ```bash
-npm install -g juggernaut-bedrock
+npm install -g juggernaut-bedrock --allow-scripts=juggernaut-bedrock
 ```
+
+> The `--allow-scripts` flag is required because newer npm versions block postinstall scripts by default. The postinstall script downloads the platform binary from GitHub Releases and verifies its SHA-256 checksum.
 
 **curl (Unix / macOS / Linux / Git Bash / WSL):**
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -16,7 +16,7 @@ Built for developers shipping with GenAI today: IAM and SSO for teams, API keys 
 ## Install
 
 ```bash
-npm install -g juggernaut-bedrock
+npm install -g juggernaut-bedrock --allow-scripts=juggernaut-bedrock
 ```
 
 Or try it without installing globally:


### PR DESCRIPTION
npm 9+ blocks postinstall scripts by default. Without the flag, the install appears to succeed but no binary is downloaded. Documents the required flag in README and npm/README.