### PR TITLE
fix(release): use script file for GoReleaser after hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,20 +30,7 @@ checksum:
 
 after:
   hooks:
-    - cmd: sh
-      args:
-        - -c
-        - |
-          set -e
-          cp dist/juggernaut_linux_amd64_v1/juggernaut       npm/packages/juggernaut-bedrock-linux-x64/bin/juggernaut
-          cp dist/juggernaut_linux_arm64_v8.0/juggernaut     npm/packages/juggernaut-bedrock-linux-arm64/bin/juggernaut
-          cp dist/juggernaut_darwin_amd64_v1/juggernaut      npm/packages/juggernaut-bedrock-darwin-x64/bin/juggernaut
-          cp dist/juggernaut_darwin_arm64_v8.0/juggernaut    npm/packages/juggernaut-bedrock-darwin-arm64/bin/juggernaut
-          cp dist/juggernaut_windows_amd64_v1/juggernaut.exe npm/packages/juggernaut-bedrock-win32-x64/bin/juggernaut.exe
-          chmod +x npm/packages/juggernaut-bedrock-linux-x64/bin/juggernaut
-          chmod +x npm/packages/juggernaut-bedrock-linux-arm64/bin/juggernaut
-          chmod +x npm/packages/juggernaut-bedrock-darwin-x64/bin/juggernaut
-          chmod +x npm/packages/juggernaut-bedrock-darwin-arm64/bin/juggernaut
+    - sh scripts/copy-npm-binaries.sh
 
 release:
   github:

--- a/scripts/copy-npm-binaries.sh
+++ b/scripts/copy-npm-binaries.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+cp dist/juggernaut_linux_amd64_v1/juggernaut       npm/packages/juggernaut-bedrock-linux-x64/bin/juggernaut
+cp dist/juggernaut_linux_arm64_v8.0/juggernaut     npm/packages/juggernaut-bedrock-linux-arm64/bin/juggernaut
+cp dist/juggernaut_darwin_amd64_v1/juggernaut      npm/packages/juggernaut-bedrock-darwin-x64/bin/juggernaut
+cp dist/juggernaut_darwin_arm64_v8.0/juggernaut    npm/packages/juggernaut-bedrock-darwin-arm64/bin/juggernaut
+cp dist/juggernaut_windows_amd64_v1/juggernaut.exe npm/packages/juggernaut-bedrock-win32-x64/bin/juggernaut.exe
+chmod +x npm/packages/juggernaut-bedrock-linux-x64/bin/juggernaut
+chmod +x npm/packages/juggernaut-bedrock-linux-arm64/bin/juggernaut
+chmod +x npm/packages/juggernaut-bedrock-darwin-x64/bin/juggernaut
+chmod +x npm/packages/juggernaut-bedrock-darwin-arm64/bin/juggernaut


### PR DESCRIPTION
GoReleaser v2 `after.hooks` only accepts string commands, not the `cmd`/`args` object format used by `before.hooks`. Extracts the binary-copy logic to `scripts/copy-npm-binaries.sh` and references it as a simple string.