### PR TITLE
chore(ci): upgrade codacy-cli to 1.0.0-main.380 (Trivy 0.71.0)

### DIFF
--- a/.github/workflows/codacy-local.yml
+++ b/.github/workflows/codacy-local.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CODACY_CLI_V2_VERSION: 1.0.0-main.376.sha.799aab5
+      CODACY_CLI_V2_VERSION: 1.0.0-main.380.sha.27e119a
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Bumps the pinned `CODACY_CLI_V2_VERSION` in `codacy-local.yml` from `1.0.0-main.376.sha.799aab5` (April 14) to `1.0.0-main.380.sha.27e119a` (June 11).

The previous pin bundled Trivy 0.70.0. Trivy exits non-zero when a newer version is available, even with zero findings, causing the Codacy Local Analysis job to fail with a false positive.

This upgrade brings in Trivy 0.71.0 and fixes the job.