### PR TITLE
fix(npm): resolve remaining 25 Codacy findings

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -15,13 +15,30 @@ var PLATFORM_MAP = {
   "win32-x64": "juggernaut-bedrock-win32-x64"
 };
 
+var VALID_PACKAGES = [
+  "juggernaut-bedrock-linux-x64",
+  "juggernaut-bedrock-linux-arm64",
+  "juggernaut-bedrock-darwin-x64",
+  "juggernaut-bedrock-darwin-arm64",
+  "juggernaut-bedrock-win32-x64"
+];
+
+/**
+ * @param {string} platform
+ * @param {string} arch
+ * @returns {string|void}
+ */
 function getPlatformPackage(platform, arch) {
-  return PLATFORM_MAP[platform + "-" + arch] || null;
+  return PLATFORM_MAP[platform + "-" + arch] || void 0;
 }
 
+/**
+ * @param {string} pkgName
+ * @param {string} platform
+ * @returns {string}
+ */
 function getBinaryPath(pkgName, platform) {
-  var validPackages = Object.keys(PLATFORM_MAP).map(function(k) { return PLATFORM_MAP[k]; });
-  if (validPackages.indexOf(pkgName) === -1) {
+  if (VALID_PACKAGES.indexOf(pkgName) === -1) {
     throw new Error("unexpected package name: " + pkgName);
   }
   var binaryName = platform === "win32" ? "juggernaut.exe" : "juggernaut";
@@ -35,25 +52,26 @@ if (require.main === module) {
       "juggernaut-bedrock: unsupported platform " + process.platform + "/" + process.arch + "\n" +
       "Please file an issue: https://github.com/jpvelasco/juggernaut/issues\n"
     );
-    process.exit(1); // nosemgrep: eslint.n_no-process-exit
+    process.exit(1); // nosemgrep: n_no-process-exit
   }
 
   var bin = getBinaryPath(pkg, process.platform);
-  if (!fs.existsSync(bin)) { // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename
+  // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename
+  if (!fs.existsSync(bin)) { // nosemgrep: n_no-sync
     process.stderr.write(
       "juggernaut-bedrock: binary not found at " + bin + "\n" +
       "Try reinstalling: npm install -g juggernaut-bedrock\n" +
       "If the problem persists, file an issue: https://github.com/jpvelasco/juggernaut/issues\n"
     );
-    process.exit(1); // nosemgrep: eslint.n_no-process-exit
+    process.exit(1); // nosemgrep: n_no-process-exit
   }
 
-  // nosemgrep: javascript.lang.security.detect-child-process
-  var result = child_process.spawnSync(bin, process.argv.slice(2), {
+  // nosemgrep: javascript.lang.security.detect-child-process, javascript_exec_rule-child-process
+  var result = child_process.spawnSync(bin, process.argv.slice(2), { // nosemgrep: n_no-sync
     stdio: "inherit",
     env: process.env
   });
-  process.exit(result.status !== null ? result.status : 1); // nosemgrep: eslint.n_no-process-exit
+  process.exit(result.status !== null ? result.status : 1); // nosemgrep: n_no-process-exit
 }
 
 module.exports = { getPlatformPackage: getPlatformPackage, getBinaryPath: getBinaryPath };

--- a/npm/index.test.js
+++ b/npm/index.test.js
@@ -3,8 +3,8 @@
 var nodeTest = require("node:test");
 var describe = nodeTest.describe;
 var it = nodeTest.it;
-var path = require("path");
-var assert = require("assert");
+var path = require("node:path");
+var assert = require("node:assert");
 
 var index = require("./index");
 var getPlatformPackage = index.getPlatformPackage;
@@ -31,15 +31,14 @@ describe("getPlatformPackage", function() {
     assert.strictEqual(getPlatformPackage("win32", "x64"), "juggernaut-bedrock-win32-x64");
     return void 0;
   });
-  it("returns null for unsupported platform", function() {
-    assert.ok(getPlatformPackage("freebsd", "x64") === void 0 || getPlatformPackage("freebsd", "x64") === null);
+  it("returns undefined for unsupported platform", function() {
+    assert.strictEqual(getPlatformPackage("freebsd", "x64"), void 0);
     return void 0;
   });
-  it("returns null for unsupported arch", function() {
-    assert.ok(getPlatformPackage("linux", "ia32") === void 0 || getPlatformPackage("linux", "ia32") === null);
+  it("returns undefined for unsupported arch", function() {
+    assert.strictEqual(getPlatformPackage("linux", "ia32"), void 0);
     return void 0;
   });
-  return void 0;
 });
 
 describe("getBinaryPath", function() {
@@ -58,5 +57,4 @@ describe("getBinaryPath", function() {
     assert.ok(result.includes(path.join("packages", "juggernaut-bedrock-darwin-arm64")));
     return void 0;
   });
-  return void 0;
 });

--- a/npm/package.json
+++ b/npm/package.json
@@ -33,6 +33,9 @@
     "sso",
     "developer-tools"
   ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Second round of Codacy fixes in npm package files.

- Add JSDoc `@param` annotations to satisfy flowtype rule
- Replace `Object.keys(PLATFORM_MAP).map(...)` with static `VALID_PACKAGES` array (removes `Object.keys` ES5 finding)
- Replace `|| null` with `|| void 0` (no-nil compliance)
- Use `node:assert` and `node:path` instead of bare module names (no-hide-core-modules, no-nodejs-modules)
- Add `engines: {node: ">=18.0.0"}` to package.json (fixes no-unsupported-features for node:test)
- Remove `return void 0` from `describe` callbacks (fixes playwright/valid-describe-callback)
- nosemgrep suppressions for unavoidable CLI patterns: process.exit, spawnSync, existsSync, child_process