### PR TITLE
fix(npm): resolve binary path via require.resolve instead of hardcoded packages/ dir

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -5,8 +5,6 @@ var path = require("path");
 var child_process = require("child_process");
 var fs = require("fs");
 
-var PACKAGES_DIR = path.join(__dirname, "packages");
-
 var PLATFORM_MAP = {
   "linux-x64": "juggernaut-bedrock-linux-x64",
   "linux-arm64": "juggernaut-bedrock-linux-arm64",
@@ -46,12 +44,20 @@ function containsPackage(pkgName) {
  * @param {string} platform
  * @returns {string}
  */
+function resolvePkgDir(pkgName) {
+  try {
+    return path.dirname(require.resolve(pkgName + "/package.json"));
+  } catch (_) {
+    return path.join(__dirname, "packages", pkgName);
+  }
+}
+
 function getBinaryPath(pkgName, platform) {
   if (!containsPackage(pkgName)) {
     throw new Error("unexpected package name: " + pkgName);
   }
   var binaryName = platform === "win32" ? "juggernaut.exe" : "juggernaut";
-  return path.join(PACKAGES_DIR, pkgName, "bin", binaryName); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  return path.join(resolvePkgDir(pkgName), "bin", binaryName);
 }
 
 if (require.main === module) {

--- a/npm/index.js
+++ b/npm/index.js
@@ -48,7 +48,7 @@ function resolvePkgDir(pkgName) {
   try {
     return path.dirname(require.resolve(pkgName + "/package.json"));
   } catch (_) {
-    return path.join(__dirname, "packages", pkgName);
+    return path.join(__dirname, "packages", pkgName); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   }
 }
 
@@ -57,7 +57,7 @@ function getBinaryPath(pkgName, platform) {
     throw new Error("unexpected package name: " + pkgName);
   }
   var binaryName = platform === "win32" ? "juggernaut.exe" : "juggernaut";
-  return path.join(resolvePkgDir(pkgName), "bin", binaryName);
+  return path.join(resolvePkgDir(pkgName), "bin", binaryName); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Root cause

On `npm install -g juggernaut-bedrock`, optional sub-packages (e.g. `juggernaut-bedrock-linux-x64`) are installed as **siblings** in `node_modules/`, not inside the main package's `packages/` subdirectory. The code was constructing the binary path as `${__dirname}/packages/${pkgName}/bin/juggernaut`, which only exists in the repo — not in a real install.

## Fix

Use `require.resolve(pkgName + "/package.json")` to locate the installed sub-package directory, with a fallback to the local `packages/` directory for dev/test environments where the sub-packages aren't installed as npm packages.

## Verified

Installed `juggernaut-bedrock@4.2.2` locally, patched `index.js` with the fix, confirmed `juggernaut version` outputs `4.2.2` correctly.