### PR TITLE
fix(schema): strip global. prefix from model IDs when Mantle is enabled

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -4,6 +4,7 @@ package schema
 import (
 	"fmt"
 	"maps"
+	"strings"
 	"time"
 
 	"github.com/jpvelasco/juggernaut/v4/internal/bedrock"
@@ -123,6 +124,14 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	haiku := opts.HaikuModel
 	if haiku == "" {
 		haiku = cfg.Models.Haiku
+	}
+
+	// Mantle uses anthropic.* model IDs; global.* cross-region inference profiles
+	// are incompatible with Mantle routing. Strip the prefix when Mantle is enabled.
+	if opts.UseMantle {
+		opus = strings.TrimPrefix(opus, "global.")
+		sonnet = strings.TrimPrefix(sonnet, "global.")
+		haiku = strings.TrimPrefix(haiku, "global.")
 	}
 
 	env := make(map[string]string, len(cfg.Environment))

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -229,6 +229,50 @@ func TestNativeKeys_AlwaysThinking(t *testing.T) {
 	}
 }
 
+func TestBuild_Mantle_StripsGlobalPrefix(t *testing.T) {
+	opts := schema.Options{
+		AuthMode:      "iam",
+		Region:        "us-west-2",
+		Effort:        "xhigh",
+		Scope:         "user",
+		Version:       "4.0.0",
+		AuthValidated: true,
+		UseMantle:     true,
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.Models.Opus != "anthropic.claude-opus-4-8" {
+		t.Errorf("expected opus without global. prefix, got %s", block.Models.Opus)
+	}
+	if block.Models.Sonnet != "anthropic.claude-sonnet-4-6" {
+		t.Errorf("expected sonnet without global. prefix, got %s", block.Models.Sonnet)
+	}
+	if block.Models.Haiku != "anthropic.claude-haiku-4-5-20251001-v1:0" {
+		t.Errorf("expected haiku without global. prefix, got %s", block.Models.Haiku)
+	}
+}
+
+func TestBuild_NoMantle_KeepsGlobalPrefix(t *testing.T) {
+	opts := schema.Options{
+		AuthMode:      "iam",
+		Region:        "us-west-2",
+		Effort:        "xhigh",
+		Scope:         "user",
+		Version:       "4.0.0",
+		AuthValidated: true,
+		UseMantle:     false,
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.Models.Opus != "global.anthropic.claude-opus-4-8" {
+		t.Errorf("expected opus with global. prefix preserved, got %s", block.Models.Opus)
+	}
+}
+
 func TestBuild_NoBedrockFlagWithoutValidation(t *testing.T) {
 	opts := schema.Options{
 		AuthMode:      "iam",


### PR DESCRIPTION
Mantle routes requests using `anthropic.*` model IDs. Cross-region inference profiles (`global.anthropic.*`) are incompatible with Mantle routing. When Mantle is enabled (the default), `global.` prefixes are stripped so model IDs are in the correct format for Mantle.

Without Mantle (`--no-mantle`), the `global.` prefix is preserved for cross-region inference via standard Bedrock Invoke.