### PR TITLE
fix(codacy): exclude npm from ESLint engine and fix nosemgrep rule IDs

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -10,3 +10,4 @@ engines:
       - ".remember/**"
       - ".codacy/**"
       - "mcps/**"
+      - "npm/**"

--- a/npm/index.js
+++ b/npm/index.js
@@ -41,7 +41,6 @@ function containsPackage(pkgName) {
 
 /**
  * @param {string} pkgName
- * @param {string} platform
  * @returns {string}
  */
 function resolvePkgDir(pkgName) {
@@ -71,7 +70,7 @@ if (require.main === module) {
   }
 
   var bin = getBinaryPath(pkg, process.platform);
-  // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename
+  // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename
   if (!fs.existsSync(bin)) {
     process.stderr.write(
       "juggernaut-bedrock: binary not found at " + bin + "\n" +
@@ -81,7 +80,7 @@ if (require.main === module) {
     process.exit(1);
   }
 
-  // nosemgrep: javascript.lang.security.detect-child-process, javascript_exec_rule-child-process
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
   var result = child_process.spawnSync(bin, process.argv.slice(2), {
     stdio: "inherit",
     env: process.env


### PR DESCRIPTION
## Summary

- Excludes `npm/**` from the `eslint-8` engine in `.codacy.yml` — all 19 ESLint dashboard findings are plugin rules (flowtype, import/no-nodejs-modules, n/*, es-x, fp, security, playwright) that don't apply to a plain Node launcher script
- Fixes nosemgrep ID for `fs.existsSync`: adds the missing `.detect-non-literal-fs-filename` suffix so the suppression matches the actual Codacy rule
- Fixes nosemgrep ID for `spawnSync`: corrects to `detect-child-process.detect-child-process` to match the Semgrep pattern fired on the dashboard
- Removes stale `@param {string} platform` from `resolvePkgDir` JSDoc (function only takes `pkgName`)

## Test plan

- [ ] Local `codacy-checks full` passes with 0 ESLint findings and 0 opengrep findings
- [ ] CI passes
- [ ] After merge: trigger `run.sh reanalyze` and confirm dashboard issue count drops to 0