### PR TITLE
Detect v4 npm-bridge shims in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Juggernaut will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Doctor now detects v4 npm-bridge shims, not just v3 ones.** `juggernaut doctor` previously only flagged legacy launcher shims that pointed at a `~/.juggernaut` tree. It now also flags any `juggernaut.ps1`/`.cmd`/`juggernaut` shim that delegates to an absolute target path which no longer exists (the v4 npm-bridge layout), which otherwise shadows the working npm binary on `PATH` with a dead-end error. The warning lists each stale file and the reason.
+
 ## [5.1.0] - 2026-06-22
 
 **Feature release.** Makes the `--storage` flag fully functional, migrates v3 Bedrock API keys automatically, and detects stale v3 installs.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -91,7 +91,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		r.Check("v4.2.6 artifacts", status, detail)
 	}
 	if detected, detail := activation.DetectV3Install(activation.DefaultBinDir(home)); detected {
-		r.Check("v3 install", doctor.Warn, detail)
+		r.Check("legacy shim", doctor.Warn, detail)
 	}
 
 	if doctorFlags.jsonOut {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -202,11 +202,11 @@ func TestDoctor_WarnsOnStaleV3Install(t *testing.T) {
 		_ = ExecuteArgs([]string{"doctor", "--scope=user"})
 	})
 
-	if !strings.Contains(out, "v3 install") {
-		t.Errorf("expected doctor to warn about v3 install, got:\n%s", out)
+	if !strings.Contains(out, "legacy shim") {
+		t.Errorf("expected doctor to warn about a legacy shim, got:\n%s", out)
 	}
 	if !strings.Contains(out, "npm install -g juggernaut-bedrock") {
-		t.Errorf("expected migration guidance in v3 warning, got:\n%s", out)
+		t.Errorf("expected migration guidance in the warning, got:\n%s", out)
 	}
 }
 

--- a/internal/activation/v3detect.go
+++ b/internal/activation/v3detect.go
@@ -3,12 +3,21 @@ package activation
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
 // v3InstallDirMarker is the file the v3 PowerShell installer wrote alongside its
 // shim to record the install directory.
 const v3InstallDirMarker = "juggernaut-install-dir.txt"
+
+// shimDelegationTarget matches the absolute path a legacy launcher shim delegates
+// to — either PowerShell `$target = '...'` or a `.cmd`'s leading `"..."` call.
+// Both v3 (~/.juggernaut) and v4 npm-bridge shims use one of these forms.
+var shimDelegationTargets = []*regexp.Regexp{
+	regexp.MustCompile(`(?m)\$target\s*=\s*['"]([^'"]+)['"]`),
+	regexp.MustCompile(`(?m)^\s*"([^"]+\.(?:ps1|cmd|exe))"`),
+}
 
 // DetectV3Install reports whether binDir contains artifacts from a pre-v5
 // (PowerShell/Bash installer) Juggernaut install. v5 ships only as an npm
@@ -25,14 +34,14 @@ func DetectV3Install(binDir string) (bool, string) {
 
 	for _, name := range []string{"juggernaut.ps1", "juggernaut.cmd", "juggernaut"} {
 		path := filepath.Join(binDir, name)
-		targets, readErr := shimTargetsJuggernautHome(path)
+		stale, readErr := staleShimReason(path)
 		switch {
-		case targets:
-			found = append(found, path)
+		case stale != "":
+			found = append(found, path+" ("+stale+")")
 		case readErr != nil:
 			// The file exists but couldn't be read; surface it conservatively
-			// rather than silently missing a possible v3 artifact.
-			found = append(found, path+" (unreadable; possible v3 shim)")
+			// rather than silently missing a possible stale shim.
+			found = append(found, path+" (unreadable; possible legacy shim)")
 		}
 	}
 
@@ -40,20 +49,40 @@ func DetectV3Install(binDir string) (bool, string) {
 		return false, ""
 	}
 	return true, strings.Join(found, "; ") +
-		" — legacy v3 install detected; reinstall with `npm install -g juggernaut-bedrock` and remove these stale shims"
+		" — legacy launcher shim(s) shadowing the npm binary; remove the listed file(s), then run `npm install -g juggernaut-bedrock` if needed"
 }
 
-// shimTargetsJuggernautHome reports whether the file at path is a shim that
-// delegates to a ~/.juggernaut install tree (the v3 layout). It returns a
-// non-nil error when the file exists but could not be read, so callers can
-// distinguish "definitely not a v3 shim" from "couldn't tell".
-func shimTargetsJuggernautHome(path string) (bool, error) {
+// staleShimReason returns a short reason when the file at path is a stale
+// Juggernaut launcher shim, or "" when it is not (or doesn't exist). A shim is
+// stale if it delegates to a ~/.juggernaut tree (the v3 layout) or to an
+// absolute target path that no longer exists (the v4 npm-bridge layout, whose
+// hardcoded target breaks after the real binary moves). It returns a non-nil
+// error only when the file exists but cannot be read.
+func staleShimReason(path string) (string, error) {
 	if !fileExists(path) {
-		return false, nil
+		return "", nil
 	}
 	data, err := os.ReadFile(path) // #nosec G304 // nosemgrep: gosec.G304-1, go_filesystem_rule-fileread -- path = constrained binDir (DefaultBinDir via safepath) + one of three fixed shim names
 	if err != nil {
-		return false, err
+		return "", err
 	}
-	return strings.Contains(string(data), ".juggernaut"), nil
+	body := string(data)
+	if strings.Contains(body, ".juggernaut") {
+		return "legacy v3 shim", nil
+	}
+	if target := shimDelegationTarget(body); target != "" && !fileExists(target) {
+		return "delegates to missing target " + target, nil
+	}
+	return "", nil
+}
+
+// shimDelegationTarget extracts the path a launcher shim delegates to, or ""
+// if the body isn't a recognizable delegating shim.
+func shimDelegationTarget(body string) string {
+	for _, re := range shimDelegationTargets {
+		if m := re.FindStringSubmatch(body); m != nil {
+			return strings.TrimSpace(m[1])
+		}
+	}
+	return ""
 }

--- a/internal/activation/v3detect_test.go
+++ b/internal/activation/v3detect_test.go
@@ -44,6 +44,64 @@ func TestDetectV3Install_FindsShimPointingAtJuggernautHome(t *testing.T) {
 	}
 }
 
+// A v4-era npm-bridge shim delegates to an absolute target path (not ~/.juggernaut).
+// When that target no longer exists, the shim is stale and shadows the working npm
+// binary on PATH — doctor must flag it even though it doesn't mention ".juggernaut".
+func TestDetectV3Install_FindsV4BridgeShimWithMissingTarget(t *testing.T) {
+	binDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "gone", "juggernaut.ps1")
+	shim := "param([Parameter(ValueFromRemainingArguments=$true)][string[]]$PassArgs)\n" +
+		"$target = '" + missing + "'\n" +
+		"if (-not (Test-Path $target)) { Write-Error 'not found'; exit 1 }\n" +
+		"& $target @PassArgs\n"
+	if err := os.WriteFile(filepath.Join(binDir, "juggernaut.ps1"), []byte(shim), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	detected, detail := DetectV3Install(binDir)
+	if !detected {
+		t.Fatal("expected a bridge shim with a missing target to be detected")
+	}
+	if detail == "" {
+		t.Error("expected a non-empty detail")
+	}
+}
+
+// A .cmd bridge shim pointing at a missing target must also be flagged.
+func TestDetectV3Install_FindsCmdBridgeShimWithMissingTarget(t *testing.T) {
+	binDir := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "gone", "juggernaut.cmd")
+	shim := "@echo off\r\n\"" + missing + "\" %*\r\nexit /b %ERRORLEVEL%\r\n"
+	if err := os.WriteFile(filepath.Join(binDir, "juggernaut.cmd"), []byte(shim), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	detected, _ := DetectV3Install(binDir)
+	if !detected {
+		t.Fatal("expected a .cmd bridge shim with a missing target to be detected")
+	}
+}
+
+// A shim whose delegation target still exists is NOT stale — don't flag a working
+// bridge (avoids false positives on a healthy install layout).
+func TestDetectV3Install_IgnoresBridgeShimWithExistingTarget(t *testing.T) {
+	binDir := t.TempDir()
+	targetDir := t.TempDir()
+	target := filepath.Join(targetDir, "juggernaut.ps1")
+	if err := os.WriteFile(target, []byte("# real target\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shim := "$target = '" + target + "'\n& $target @args\n"
+	if err := os.WriteFile(filepath.Join(binDir, "juggernaut.ps1"), []byte(shim), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	detected, _ := DetectV3Install(binDir)
+	if detected {
+		t.Error("a bridge shim whose target exists should not be flagged as stale")
+	}
+}
+
 // A shim that exists but can't be read (here: the path is a directory, so
 // os.ReadFile fails) should be reported conservatively rather than silently
 // ignored — a possible v3 artifact is worth surfacing in doctor.


### PR DESCRIPTION
## Summary

Found while updating a real machine from v5.0.4 → v5.1.0: `npm install -g juggernaut-bedrock@latest` succeeded, but `juggernaut version` still failed with:

```
juggernaut shim: npm v5 target not found at F:\home\jpvelasco\.local\juggernaut.ps1. Run: npm install -g juggernaut-bedrock@latest
```

A leftover **v4-era npm-bridge shim** at `~/.local/bin/juggernaut.ps1` shadowed npm's real shim on `PATH` and delegated to a hardcoded absolute target that no longer existed — and its own advice ("run npm install") didn't fix it, because npm installs to a different prefix.

The v5.1.0 `doctor` v3-detection didn't catch this: it only flagged shims referencing a `~/.juggernaut` tree. This v4 bridge layout points at `F:\home\...\.local\juggernaut.ps1`, so it slipped through.

## Change

Broaden `staleShimReason` to flag a launcher shim as stale when **either**:
- it references a `~/.juggernaut` tree (v3 layout, unchanged), **or**
- it delegates to an absolute target path that no longer exists (v4 npm-bridge layout) — the target is parsed from PowerShell `$target='...'` or a `.cmd`'s leading `"..."` call.

A bridge shim whose target still exists is **not** flagged (guards against false positives). The doctor check is renamed `legacy shim` and the remediation message lists each stale file with its reason.

Scope is detection + guidance only — Juggernaut still never deletes shim files itself.

## Tests
- v4-bridge `.ps1` and `.cmd` shims with missing targets → detected
- bridge shim with an existing target → not flagged
- existing v3 (`~/.juggernaut`) and unreadable-shim cases → still pass

`go test ./...` green, `go vet` clean, cross-compiles.