### PR TITLE
fix: flush Windows console input buffer before huh forms

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -273,6 +273,7 @@ func resolveApplyInputs(home string, bCfg *bedrock.Config) (authMode, region str
 	}
 
 	permMode := applyFlags.mode
+	flushConsoleInput()
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
@@ -329,6 +330,7 @@ func resolveCredential(authMode string) (string, error) {
 		return "", fmt.Errorf("no existing key found in keychain; re-run without --preserve-key to enter one")
 	}
 	var input string
+	flushConsoleInput()
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().

--- a/cmd/apply_other.go
+++ b/cmd/apply_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package cmd
+
+// flushConsoleInput is a no-op on non-Windows platforms.
+func flushConsoleInput() {
+}

--- a/cmd/apply_windows.go
+++ b/cmd/apply_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package cmd
+
+import (
+	xwindows "github.com/charmbracelet/x/windows"
+	"golang.org/x/sys/windows"
+)
+
+// flushConsoleInput drains the Windows console input buffer before starting
+// a new huh form, preventing stale input events from corrupting the next
+// form's input (Bubble Tea v1.x does not do this automatically).
+func flushConsoleInput() {
+	conin, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err == nil {
+		_ = xwindows.FlushConsoleInputBuffer(conin)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
+github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
+github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
 github.com/charmbracelet/x/xpty v0.1.2 h1:Pqmu4TEJ8KeA9uSkISKMU3f+C1F6OGBn8ABuGlqCbtI=
 github.com/charmbracelet/x/xpty v0.1.2/go.mod h1:XK2Z0id5rtLWcpeNiMYBccNNBrP2IJnzHI0Lq13Xzq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
## Problem

When running `juggernaut apply --auth=bedrock-api-key` on Windows PowerShell, the credential prompt returns an empty string. This happens because Bubble Tea v1.x does not call `FlushConsoleInputBuffer` before starting the input reader — stale events from the first `huh` form (`resolveApplyInputs`) are consumed by the second form (`resolveCredential`), leaving the password field empty.

## Fix

Add `flushConsoleInput()` which drains the Windows console input buffer before each `huh` form runs. This matches the fix already present in Bubble Tea v2 via ultraviolet (`xwindows.FlushConsoleInputBuffer` at `cancelreader_windows.go:48`).

- Windows-only code path via build tags (`cmd/apply_windows.go`)
- No-op stub for non-Windows (`cmd/apply_other.go`)
- Zero behavioral change on non-Windows platforms
- Uses `github.com/charmbracelet/x/windows` (same package ultraviolet uses)