### PR TITLE
fix: log warning when FlushConsoleInputBuffer fails; add smoke test; tidy go.mod

### DIFF
--- a/cmd/apply_windows.go
+++ b/cmd/apply_windows.go
@@ -3,6 +3,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	xwindows "github.com/charmbracelet/x/windows"
 	"golang.org/x/sys/windows"
 )
@@ -12,7 +15,10 @@ import (
 // form's input (Bubble Tea v1.x does not do this automatically).
 func flushConsoleInput() {
 	conin, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
-	if err == nil {
-		_ = xwindows.FlushConsoleInputBuffer(conin)
+	if err != nil {
+		return
+	}
+	if err := xwindows.FlushConsoleInputBuffer(conin); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not flush console input buffer: %v\n", err)
 	}
 }

--- a/cmd/apply_windows_test.go
+++ b/cmd/apply_windows_test.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package cmd
+
+import "testing"
+
+func TestFlushConsoleInput_NoPanic(t *testing.T) {
+	flushConsoleInput()
+}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/charmbracelet/x/windows v0.2.2 // indirect
+	github.com/charmbracelet/x/windows v0.2.2
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -39,6 +39,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.15.0 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.37.0
 	golang.org/x/text v0.23.0 // indirect
 )


### PR DESCRIPTION
Follow-up to #194.

- Log a warning to stderr when FlushConsoleInputBuffer fails instead of silently dropping the error
- Add no-panic smoke test for flushConsoleInput()
- Remove // indirect from directly imported deps in go.mod