### PR TITLE
fix: restore AWS_BEARER_TOKEN_BEDROCK env var for Bedrock API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ claude() {
 # END: Juggernaut Claude Activation
 ```
 
-The hidden `juggernaut launch` command reads the Bedrock API key from the OS keychain when your settings use `bedrock-api-key`, sets `ANTHROPIC_API_KEY` and `CLAUDE_CODE_USE_BEDROCK=1`, resolves the real Anthropic `claude` binary without recursing into Juggernaut, and launches Claude Code with your original arguments.
+The hidden `juggernaut launch` command reads the Bedrock API key from the OS keychain when your settings use `bedrock-api-key`, sets `AWS_BEARER_TOKEN_BEDROCK` and `CLAUDE_CODE_USE_BEDROCK=1`, resolves the real Anthropic `claude` binary without recursing into Juggernaut, and launches Claude Code with your original arguments.
 
 ```json
 {

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -270,9 +270,9 @@ func LaunchWithOptions(opts LaunchOptions) error {
 		if token == "" {
 			return fmt.Errorf("bedrock API key not found in keychain; run `juggernaut apply --auth=%s`", authmode.BedrockAPIKey)
 		}
-		env = setEnv(env, "ANTHROPIC_API_KEY", token)
+		env = setEnv(env, "AWS_BEARER_TOKEN_BEDROCK", token)
 	} else if len(modes) > 0 {
-		env = unsetEnv(env, "ANTHROPIC_API_KEY")
+		env = unsetEnv(env, "AWS_BEARER_TOKEN_BEDROCK")
 	}
 
 	claudePath, err := ResolveClaudeBinary(opts.Path)

--- a/internal/activation/activation_test.go
+++ b/internal/activation/activation_test.go
@@ -212,8 +212,8 @@ func TestLaunchInjectsAPIKeyToken(t *testing.T) {
 			return "token-value", nil
 		},
 		Runner: func(_ string, _ []string, env []string) error {
-			if got := envValue(env, "ANTHROPIC_API_KEY"); got != "token-value" {
-				t.Fatalf("ANTHROPIC_API_KEY=%q", got)
+			if got := envValue(env, "AWS_BEARER_TOKEN_BEDROCK"); got != "token-value" {
+				t.Fatalf("AWS_BEARER_TOKEN_BEDROCK=%q", got)
 			}
 			if got := envValue(env, "CLAUDE_CODE_USE_BEDROCK"); got != "1" {
 				t.Fatalf("CLAUDE_CODE_USE_BEDROCK=%q", got)
@@ -240,8 +240,8 @@ func TestLaunchIAMDoesNotReadKeychain(t *testing.T) {
 			return "", errors.New("keychain should not be read for IAM")
 		},
 		Runner: func(_ string, _ []string, env []string) error {
-			if got := envValue(env, "ANTHROPIC_API_KEY"); got != "" {
-				t.Fatalf("ANTHROPIC_API_KEY should be unset, got %q", got)
+			if got := envValue(env, "AWS_BEARER_TOKEN_BEDROCK"); got != "" {
+				t.Fatalf("AWS_BEARER_TOKEN_BEDROCK should be unset, got %q", got)
 			}
 			if got := envValue(env, "CLAUDE_CODE_USE_BEDROCK"); got != "1" {
 				t.Fatalf("CLAUDE_CODE_USE_BEDROCK=%q", got)
@@ -284,15 +284,15 @@ func TestLaunch_BedrockAPIKey_UsesDefaultKeychain(t *testing.T) {
 	}
 }
 
-func TestLaunch_IAM_UnsetsAnthropicAPIKeyIfPreSet(t *testing.T) {
+func TestLaunch_IAM_UnsetsBearerTokenIfPreSet(t *testing.T) {
 	home := t.TempDir()
 	writeSettings(t, home, "iam")
 	realDir := t.TempDir()
 	realClaude := filepath.Join(realDir, platformNames().claude)
 	writeExecutableFile(t, realDir, realClaude, "real claude")
 
-	// Pre-set ANTHROPIC_API_KEY in the environment to verify unsetEnv runs.
-	t.Setenv("ANTHROPIC_API_KEY", "should-be-removed")
+	// Pre-set AWS_BEARER_TOKEN_BEDROCK in the environment to verify unsetEnv runs.
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "should-be-removed")
 
 	err := LaunchWithOptions(LaunchOptions{
 		Home: home,
@@ -301,8 +301,8 @@ func TestLaunch_IAM_UnsetsAnthropicAPIKeyIfPreSet(t *testing.T) {
 			return "", errors.New("keychain should not be read for IAM")
 		},
 		Runner: func(_ string, _ []string, env []string) error {
-			if got := envValue(env, "ANTHROPIC_API_KEY"); got != "" {
-				t.Fatalf("ANTHROPIC_API_KEY should be unset for IAM mode, got %q", got)
+			if got := envValue(env, "AWS_BEARER_TOKEN_BEDROCK"); got != "" {
+				t.Fatalf("AWS_BEARER_TOKEN_BEDROCK should be unset for IAM mode, got %q", got)
 			}
 			if got := envValue(env, "CLAUDE_CODE_USE_BEDROCK"); got != "1" {
 				t.Fatalf("CLAUDE_CODE_USE_BEDROCK=%q", got)


### PR DESCRIPTION
Claude Code uses `AWS_BEARER_TOKEN_BEDROCK` for Bedrock API key authentication — not `ANTHROPIC_API_KEY` (which is for direct Anthropic API). 

Commit `586d89b` incorrectly changed the env var to `ANTHROPIC_API_KEY` based on a faulty binary inspection. This caused all releases since v5.1.3 to set the wrong env var, resulting in "API error · Retrying" failures when using Bedrock API key auth.

This PR restores `AWS_BEARER_TOKEN_BEDROCK`, confirmed by the official Claude Code docs:
- https://code.claude.com/docs/en/amazon-bedrock
- https://code.claude.com/docs/en/env-vars

**Files changed:**
- `internal/activation/activation.go` — setEnv/unsetEnv use `AWS_BEARER_TOKEN_BEDROCK`
- `internal/activation/activation_test.go` — tests check for the correct env var
- `README.md` — documentation references the correct env var