### PR TITLE
feat: add Bedrock connectivity check to doctor diagnostics

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/doctor"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
@@ -67,6 +70,8 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		r.Check("keychain", doctor.OK, "bearer token found")
 	}
 
+	checkConnectivity(r, home, token)
+
 	activationPaths := activation.InstalledTargets(home)
 	if len(activationPaths) > 0 {
 		r.Check("claude activation", doctor.OK, strings.Join(activationPaths, ", "))
@@ -114,6 +119,78 @@ func legacyArtifactStatus(home string) (doctor.Status, string) {
 		parts = append(parts, action.Action+": "+action.Path)
 	}
 	return doctor.Warn, strings.Join(parts, "; ") + " — run `juggernaut apply` to recover"
+}
+
+func checkConnectivity(r *doctor.Report, home, token string) {
+	cfg, err := loadBedrockConfig()
+	if err != nil {
+		r.Check("bedrock connectivity", doctor.Warn, "cannot load bedrock-config.json: "+err.Error())
+		return
+	}
+
+	// Read auth mode and region from user scope.
+	path, err := settingsPath(home, "user")
+	if err != nil {
+		r.Check("bedrock connectivity", doctor.Warn, "cannot resolve settings path: "+err.Error())
+		return
+	}
+	mgr := config.NewManager(path)
+	data, err := mgr.Read()
+	if err != nil {
+		r.Check("bedrock connectivity", doctor.Warn, "cannot read settings.json: "+err.Error())
+		return
+	}
+	block, ok := data["juggernaut"].(map[string]any)
+	if !ok {
+		r.Check("bedrock connectivity", doctor.Warn, "no juggernaut block in settings.json")
+		return
+	}
+	auth, ok := block["auth"].(map[string]any)
+	if !ok {
+		r.Check("bedrock connectivity", doctor.Warn, "no auth config in juggernaut block")
+		return
+	}
+	mode, ok := auth["mode"].(string)
+	if !ok {
+		r.Check("bedrock connectivity", doctor.Warn, "missing auth mode")
+		return
+	}
+	region, ok := auth["region"].(string)
+	if !ok {
+		r.Check("bedrock connectivity", doctor.Warn, "missing auth region")
+		return
+	}
+
+	modelID := cfg.Models.Haiku
+	result := checkBedrockConnectivity(mode, region, modelID, token)
+	status := doctor.OK
+	if result.IsFailure() {
+		status = doctor.Fail
+	}
+
+	elapsed := result.Elapsed.Round(time.Millisecond)
+	detail := fmt.Sprintf("%s (%s, %s, %s)", result.Message, mode, region, elapsed)
+	if result.StatusCode > 0 {
+		detail = fmt.Sprintf("%s, HTTP %d", detail, result.StatusCode)
+	}
+	r.Check("bedrock connectivity", status, detail)
+}
+
+func checkBedrockConnectivity(mode, region, modelID, token string) *bedrock.ConnectivityResult {
+	if authmode.IsBedrockAPIKey(mode) {
+		if token == "" {
+			return &bedrock.ConnectivityResult{
+				OK:       false,
+				AuthMode: mode,
+				Region:   region,
+				ModelID:  modelID,
+				Message:  "bedrock API key not found in keychain",
+			}
+		}
+		return bedrock.CheckAPIKeyConnectivity(token, region, modelID)
+	}
+	// IAM mode: check endpoint reachability (no SigV4 signing).
+	return bedrock.CheckIAMConnectivity(region, modelID)
 }
 
 func opusplanProblem(data map[string]any) (string, bool) {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -70,7 +70,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		r.Check("keychain", doctor.OK, "bearer token found")
 	}
 
-	checkConnectivity(r, home, token)
+	checkConnectivity(r, home, token, scopes)
 
 	activationPaths := activation.InstalledTargets(home)
 	if len(activationPaths) > 0 {
@@ -121,15 +121,16 @@ func legacyArtifactStatus(home string) (doctor.Status, string) {
 	return doctor.Warn, strings.Join(parts, "; ") + " — run `juggernaut apply` to recover"
 }
 
-func checkConnectivity(r *doctor.Report, home, token string) {
+func checkConnectivity(r *doctor.Report, home, token string, scopes []string) {
 	cfg, err := loadBedrockConfig()
 	if err != nil {
 		r.Check("bedrock connectivity", doctor.Warn, "cannot load bedrock-config.json: "+err.Error())
 		return
 	}
 
-	// Read auth mode and region from user scope.
-	path, err := settingsPath(home, "user")
+	// Use the same scope(s) as the settings checks.
+	scope := scopes[0]
+	path, err := settingsPath(home, scope)
 	if err != nil {
 		r.Check("bedrock connectivity", doctor.Warn, "cannot resolve settings path: "+err.Error())
 		return

--- a/internal/bedrock/connectivity.go
+++ b/internal/bedrock/connectivity.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 )
 
 const defaultTimeout = 15 * time.Second
@@ -43,7 +45,7 @@ func CheckAPIKeyConnectivity(token, region, modelID string) *ConnectivityResult 
 	if err != nil {
 		return &ConnectivityResult{
 			OK:       false,
-			AuthMode: "bedrock-api-key",
+			AuthMode: authmode.BedrockAPIKey,
 			Region:   region,
 			ModelID:  modelID,
 			Message:  fmt.Sprintf("failed to build request body: %v", err),
@@ -55,7 +57,7 @@ func CheckAPIKeyConnectivity(token, region, modelID string) *ConnectivityResult 
 	if err != nil {
 		return &ConnectivityResult{
 			OK:       false,
-			AuthMode: "bedrock-api-key",
+			AuthMode: authmode.BedrockAPIKey,
 			Region:   region,
 			ModelID:  modelID,
 			Message:  fmt.Sprintf("failed to create request: %v", err),
@@ -70,7 +72,7 @@ func CheckAPIKeyConnectivity(token, region, modelID string) *ConnectivityResult 
 	if err != nil {
 		return &ConnectivityResult{
 			OK:       false,
-			AuthMode: "bedrock-api-key",
+			AuthMode: authmode.BedrockAPIKey,
 			Region:   region,
 			ModelID:  modelID,
 			Message:  fmt.Sprintf("request failed: %v", err),
@@ -89,7 +91,7 @@ func CheckAPIKeyConnectivity(token, region, modelID string) *ConnectivityResult 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return &ConnectivityResult{
 			OK:         true,
-			AuthMode:   "bedrock-api-key",
+			AuthMode:   authmode.BedrockAPIKey,
 			Region:     region,
 			ModelID:    modelID,
 			StatusCode: resp.StatusCode,
@@ -102,7 +104,7 @@ func CheckAPIKeyConnectivity(token, region, modelID string) *ConnectivityResult 
 	detail := formatResponseError(resp.StatusCode, respBody)
 	return &ConnectivityResult{
 		OK:         false,
-		AuthMode:   "bedrock-api-key",
+		AuthMode:   authmode.BedrockAPIKey,
 		Region:     region,
 		ModelID:    modelID,
 		StatusCode: resp.StatusCode,

--- a/internal/bedrock/connectivity.go
+++ b/internal/bedrock/connectivity.go
@@ -1,0 +1,300 @@
+// Package bedrock provides connectivity diagnostics for the Bedrock API.
+package bedrock
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const defaultTimeout = 15 * time.Second
+
+// ConnectivityResult holds the outcome of a Bedrock connectivity check.
+type ConnectivityResult struct {
+	OK          bool
+	AuthMode    string
+	Region      string
+	ModelID     string
+	StatusCode  int
+	Message     string
+	Elapsed     time.Duration
+}
+
+// CheckAPIKeyConnectivity makes a lightweight InvokeModel call to verify that
+// the Bedrock API key is valid and can reach the configured region.
+// It uses a minimal prompt ("hi") and a small max_tokens_to_sample to keep
+// the request cheap.
+func CheckAPIKeyConnectivity(token, region, modelID string) *ConnectivityResult {
+	start := time.Now()
+
+	modelID = stripRegionPrefix(modelID)
+	url := fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke", region, modelID)
+
+	body, err := json.Marshal(map[string]any{
+		"messages":          []map[string]string{{"role": "user", "content": "hi"}},
+		"max_tokens":        1,
+		"anthropic_version": "bedrock-2023-05-31",
+	})
+	if err != nil {
+		return &ConnectivityResult{
+			OK:       false,
+			AuthMode: "bedrock-api-key",
+			Region:   region,
+			ModelID:  modelID,
+			Message:  fmt.Sprintf("failed to build request body: %v", err),
+			Elapsed:  time.Since(start),
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return &ConnectivityResult{
+			OK:       false,
+			AuthMode: "bedrock-api-key",
+			Region:   region,
+			ModelID:  modelID,
+			Message:  fmt.Sprintf("failed to create request: %v", err),
+			Elapsed:  time.Since(start),
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	client := &http.Client{Timeout: defaultTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return &ConnectivityResult{
+			OK:       false,
+			AuthMode: "bedrock-api-key",
+			Region:   region,
+			ModelID:  modelID,
+			Message:  fmt.Sprintf("request failed: %v", err),
+			Elapsed:  time.Since(start),
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		respBody = []byte{}
+	}
+
+	elapsed := time.Since(start)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return &ConnectivityResult{
+			OK:         true,
+			AuthMode:   "bedrock-api-key",
+			Region:     region,
+			ModelID:    modelID,
+			StatusCode: resp.StatusCode,
+			Message:    "connected",
+			Elapsed:    elapsed,
+		}
+	}
+
+	// Try to extract a useful error message from the response.
+	detail := formatResponseError(resp.StatusCode, respBody)
+	return &ConnectivityResult{
+		OK:         false,
+		AuthMode:   "bedrock-api-key",
+		Region:     region,
+		ModelID:    modelID,
+		StatusCode: resp.StatusCode,
+		Message:    detail,
+		Elapsed:    elapsed,
+	}
+}
+
+// CheckIAMConnectivity verifies that AWS credentials are configured and can
+// reach the Bedrock endpoint. This does NOT perform SigV4 signing (that
+// requires the AWS SDK); instead it makes an unauthenticated request to
+// confirm network reachability and that the region is valid.
+// Returns a result indicating whether the endpoint is reachable, regardless
+// of auth. IAM auth validation is left to Claude Code at runtime.
+func CheckIAMConnectivity(region, modelID string) *ConnectivityResult {
+	start := time.Now()
+
+	modelID = stripRegionPrefix(modelID)
+	url := fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke", region, modelID)
+
+	body, err := json.Marshal(map[string]any{
+		"messages":          []map[string]string{{"role": "user", "content": "hi"}},
+		"max_tokens":        1,
+		"anthropic_version": "bedrock-2023-05-31",
+	})
+	if err != nil {
+		return &ConnectivityResult{
+			OK:       false,
+			AuthMode: "iam",
+			Region:   region,
+			ModelID:  modelID,
+			Message:  fmt.Sprintf("failed to build request body: %v", err),
+			Elapsed:  time.Since(start),
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return &ConnectivityResult{
+			OK:       false,
+			AuthMode: "iam",
+			Region:   region,
+			ModelID:  modelID,
+			Message:  fmt.Sprintf("failed to create request: %v", err),
+			Elapsed:  time.Since(start),
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: defaultTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return &ConnectivityResult{
+			OK:       false,
+			AuthMode: "iam",
+			Region:   region,
+			ModelID:  modelID,
+			Message:  fmt.Sprintf("request failed: %v", err),
+			Elapsed:  time.Since(start),
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		respBody = []byte{}
+	}
+
+	elapsed := time.Since(start)
+
+	// For IAM, a 403 is expected because we don't sign the request.
+	// That means the endpoint is reachable and the region/model are valid.
+	if resp.StatusCode == 403 {
+		msg := string(respBody)
+		if containsAuthError(msg) {
+			return &ConnectivityResult{
+				OK:         true,
+				AuthMode:   "iam",
+				Region:     region,
+				ModelID:    modelID,
+				StatusCode: resp.StatusCode,
+				Message:    "endpoint reachable (IAM auth required — Claude Code will sign requests)",
+				Elapsed:    elapsed,
+			}
+		}
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return &ConnectivityResult{
+			OK:         true,
+			AuthMode:   "iam",
+			Region:     region,
+			ModelID:    modelID,
+			StatusCode: resp.StatusCode,
+			Message:    "connected",
+			Elapsed:    elapsed,
+		}
+	}
+
+	detail := formatResponseError(resp.StatusCode, respBody)
+	return &ConnectivityResult{
+		OK:         false,
+		AuthMode:   "iam",
+		Region:     region,
+		ModelID:    modelID,
+		StatusCode: resp.StatusCode,
+		Message:    detail,
+		Elapsed:    elapsed,
+	}
+}
+
+// IsFailure returns true if the connectivity check indicates a real problem.
+func (r *ConnectivityResult) IsFailure() bool {
+	return !r.OK
+}
+
+// IsAuthFailure returns true if the failure is an authentication or
+// authorization error (401/403).
+func (r *ConnectivityResult) IsAuthFailure() bool {
+	return r.StatusCode == 401 || r.StatusCode == 403
+}
+
+// stripRegionPrefix removes the Bedrock inference profile region prefix
+// (global., us., eu., apac.) so the model ID is valid for direct API calls.
+func stripRegionPrefix(modelID string) string {
+	for _, prefix := range []string{"global.", "us.", "eu.", "apac."} {
+		if strings.HasPrefix(modelID, prefix) {
+			return strings.TrimPrefix(modelID, prefix)
+		}
+	}
+	return modelID
+}
+
+func formatResponseError(status int, body []byte) string {
+	msg := string(body)
+
+	// Try to parse as JSON to extract a message field.
+	var v struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	}
+	if err := json.Unmarshal(body, &v); err == nil && v.Message != "" {
+		return fmt.Sprintf("HTTP %d: %s", status, v.Message)
+	}
+	if err := json.Unmarshal(body, &v); err == nil && v.Type != "" {
+		return fmt.Sprintf("HTTP %d: %s", status, v.Type)
+	}
+
+	// Truncate long raw responses.
+	if len(msg) > 200 {
+		msg = msg[:200] + "..."
+	}
+	return fmt.Sprintf("HTTP %d: %s", status, msg)
+}
+
+func containsAuthError(body string) bool {
+	lower := body
+	for _, s := range []string{
+		"authorization",
+		"credential",
+		"signature",
+		"unauthorized",
+		"forbidden",
+		"access denied",
+	} {
+		if contains(lower, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			c := s[i+j]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			if c != substr[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// ErrNoAuthConfigured is returned when no auth mode is configured for the
+// connectivity check.
+var ErrNoAuthConfigured = errors.New("no Bedrock auth mode configured")


### PR DESCRIPTION
Adds a real Bedrock connectivity check to `juggernaut doctor`. Makes a lightweight InvokeModel call to verify the configured Bedrock region and model are reachable.

- **IAM mode**: sends an unauthenticated request; a 403 with auth error content means the endpoint is reachable (Claude Code will sign requests at runtime)
- **Bedrock API key mode**: sends a Bearer-token authenticated request with a minimal prompt
- Reports elapsed time and HTTP status code in the doctor output