### PR TITLE
fix: use EchoModeNone for credential prompt on Windows

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/huh"
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
@@ -14,6 +15,11 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 	"github.com/spf13/cobra"
 )
+
+// credentialEchoMode is the EchoMode used for the Bedrock API key prompt.
+// Must be textinput.EchoNone, NOT textinput.EchoPassword — EchoPassword
+// breaks on Windows (keystrokes are silently dropped by the TUI input loop).
+const credentialEchoMode huh.EchoMode = huh.EchoMode(textinput.EchoNone)
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
@@ -335,7 +341,13 @@ func resolveCredential(authMode string) (string, error) {
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Bedrock API key").
-				EchoMode(huh.EchoModePassword).
+				EchoMode(credentialEchoMode).
+				DescriptionFunc(func() string {
+					if input == "" {
+						return "typing hidden — nothing echoed"
+					}
+					return "key entered"
+				}, &input).
 				Value(&input),
 		),
 	)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/huh"
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
@@ -653,6 +655,15 @@ func TestVersionInSync(t *testing.T) {
 	}
 	if bedrockConfig.Version != versionFile {
 		t.Errorf("bedrock-config.json version (%s) does not match VERSION file (%s)", bedrockConfig.Version, versionFile)
+	}
+}
+
+func TestCredentialEchoMode_IsEchoNone(t *testing.T) {
+	// EchoModePassword breaks on Windows (keystrokes are dropped by the TUI
+	// input loop). The credential prompt must use EchoNone instead.
+	// Regression test for: https://github.com/charmbracelet/bubbles/issues/865
+	if credentialEchoMode != huh.EchoMode(textinput.EchoNone) {
+		t.Fatalf("credential prompt must use EchoModeNone, got %v", credentialEchoMode)
 	}
 }
 


### PR DESCRIPTION
EchoModePassword drops keystrokes on Windows due to a conflict between the terminal echo handler and the TUI input loop. Switch to EchoModeNone so the credential prompt actually receives input.

Adds DescriptionFunc feedback ("typing hidden — nothing echoed" → "key entered") so users know input is being captured even though nothing is echoed.

Includes regression test to prevent reverting to EchoModePassword.