### PR TITLE
fix: extend Bedrock Claude Code parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Juggernaut will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Fable alias support.** `juggernaut apply` now supports `--fable-model`; when a Fable model ID is configured, Juggernaut writes `ANTHROPIC_DEFAULT_FABLE_MODEL`, Fable companion metadata, and Fable model override aliases.
+- **Native fallback chain.** Added `--fallback-model=a,b` to write Claude Code's native `fallbackModel` array and remove it cleanly on uninstall.
+- **Effort defaults.** `--effort=auto` is now accepted through `CLAUDE_CODE_EFFORT_LEVEL` without emitting an invalid persisted `effortLevel` value; `ultracode` is intentionally rejected because Claude Code treats it as a separate session setting, not an effort level.
+
 ## [5.1.6] - 2026-06-26
 
 **Patch release.** Fixes doctor connectivity check that was stripping the `global.` prefix from inference profile model IDs, causing false HTTP 400 failures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Single Go binary. Entry point: `main.go` → `cmd/` → `internal/`.
 - **`--no-1m-context`:** disables 1M token context window (on by default). `--1m-context` is a hidden no-op kept for script compatibility.
 - **Mantle opt-in:** standard Bedrock preserves inference profile IDs by default; use `--mantle` or `--mantle-url` only when explicitly routing through Mantle.
 - **Opusplan-gated ANTHROPIC_MODEL:** only written when `--opusplan` is active.
-- **`--mode`:** sets `permissions.defaultMode` in settings.json. When `auto`, also writes `CLAUDE_CODE_ENABLE_AUTO_MODE=1` in env (required for Bedrock; without it auto mode silently does nothing).
+- **`--mode`:** sets `permissions.defaultMode` in settings.json. When `auto`, also writes `CLAUDE_CODE_ENABLE_AUTO_MODE=1` in env (required for Bedrock). Auto mode on Bedrock additionally requires the **active session model to be Opus 4.7/4.8** (Claude Code v2.1.158+); Sonnet/Haiku are unsupported and Claude Code hides auto from the Shift+Tab cycle. Because Juggernaut's default model is Sonnet, `apply --mode=auto` prints a warning (via `schema.Block.AutoModeUsable()` / `schema.IsAutoModeCapableModel()`) unless the resolved model is Opus. Users unlock it by running Claude Code on Opus (`claude --model opus` or `/model opus`).
 - **`--always-thinking`:** writes `alwaysThinkingEnabled: true` as a native settings.json key.
 - **`--service-tier`:** writes `ANTHROPIC_BEDROCK_SERVICE_TIER` env var; values: `default`, `flex`, `priority`.
 - **`skipWebFetchPreflight`:** always written as `true` for all Bedrock users (avoids domain safety preflight delays).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,17 +69,18 @@ Single Go binary. Entry point: `main.go` → `cmd/` → `internal/`.
 - **Auth-gated Bedrock flag:** `CLAUDE_CODE_USE_BEDROCK=1` only lands in settings.json when `AuthValidated=true`.
 - **Scope:** `--scope=user` (default) vs `--scope=project`.
 - **Re-apply preserves existing auth mode** — if `--auth` is omitted and a block already exists, the existing auth mode is read from the block.
-- **`--model` overrides all three model IDs** (opus, sonnet, haiku) when set; `--opus-model`, `--sonnet-model`, `--haiku-model` override individually.
+- **`--model` overrides all four model IDs** (opus, sonnet, haiku, fable) when set; `--opus-model`, `--sonnet-model`, `--haiku-model`, `--fable-model` override individually. The embedded default config keeps `models.fable` empty until a Bedrock-accessible Fable ID is configured.
 - **Credential storage:** always the OS keychain via `go-keyring`. Service name: `juggernaut-bedrock`.
 - **`--no-1m-context`:** disables 1M token context window (on by default). `--1m-context` is a hidden no-op kept for script compatibility.
 - **Mantle opt-in:** standard Bedrock preserves inference profile IDs by default; use `--mantle` or `--mantle-url` only when explicitly routing through Mantle.
 - **Opusplan-gated ANTHROPIC_MODEL:** only written when `--opusplan` is active.
 - **`--mode`:** sets `permissions.defaultMode` in settings.json. When `auto`, also writes `CLAUDE_CODE_ENABLE_AUTO_MODE=1` in env (required for Bedrock). Auto mode on Bedrock additionally requires the **active session model to be Opus 4.7/4.8** (Claude Code v2.1.158+); Sonnet/Haiku are unsupported and Claude Code hides auto from the Shift+Tab cycle. Because Juggernaut's default model is Sonnet, `apply --mode=auto` prints a warning (via `schema.Block.AutoModeUsable()` / `schema.IsAutoModeCapableModel()`) unless the resolved model is Opus. Users unlock it by running Claude Code on Opus (`claude --model opus` or `/model opus`).
 - **`--always-thinking`:** writes `alwaysThinkingEnabled: true` as a native settings.json key.
+- **`--fallback-model=a,b`:** writes Claude Code native `fallbackModel` as an ordered array. Empty entries are rejected; an empty resolved chain removes the managed key.
 - **`--service-tier`:** writes `ANTHROPIC_BEDROCK_SERVICE_TIER` env var; values: `default`, `flex`, `priority`.
 - **`skipWebFetchPreflight`:** always written as `true` for all Bedrock users (avoids domain safety preflight delays).
-- **`effortLevel`:** written as both `CLAUDE_CODE_EFFORT_LEVEL` env var (legacy) and native `effortLevel` settings.json key (preferred). Five valid levels: `low`, `medium`, `high`, `xhigh` (default), `max`.
-- **Native keys managed by Juggernaut:** `env`, `model`, `modelOverrides`, `effortLevel`, `alwaysThinkingEnabled`, `skipWebFetchPreflight`, `permissions`. All are removed on uninstall.
+- **`effortLevel`:** fixed persisted levels (`low`, `medium`, `high`, `xhigh`) are written as both `CLAUDE_CODE_EFFORT_LEVEL` and native `effortLevel`; `max` and `auto` are env-only because Claude Code settings do not accept them as persisted `effortLevel` values. Ultracode is separate from `effortLevel` / `CLAUDE_CODE_EFFORT_LEVEL`, so Juggernaut intentionally rejects it as `--effort`. Juggernaut defaults to `high`.
+- **Native keys managed by Juggernaut:** `env`, `model`, `modelOverrides`, `fallbackModel`, `effortLevel`, `alwaysThinkingEnabled`, `skipWebFetchPreflight`, `permissions`. All are removed on uninstall.
 
 ## Version Management
 

--- a/README.md
+++ b/README.md
@@ -114,10 +114,12 @@ juggernaut apply
 ```bash
 juggernaut apply --auth=iam --region=us-east-1
 juggernaut apply --auth=iam --opusplan              # Opus in /plan, Sonnet in execute
-juggernaut apply --auth=iam --effort=high           # low | medium | high | xhigh | max
+juggernaut apply --auth=iam --effort=high           # low | medium | high | xhigh | max | auto
 juggernaut apply --auth=iam --mode=auto             # enable agentic safety-classifier mode
 juggernaut apply --auth=iam --always-thinking       # extended thinking on by default
 juggernaut apply --auth=iam --service-tier=flex     # Bedrock service tier: default | flex | priority
+juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>
+juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-4-8
 juggernaut apply --auth=iam --mantle                # enable Mantle routing
 juggernaut apply --auth=iam --dry-run               # preview without writing
 juggernaut apply --auth=iam --scope=project         # write to ./.claude/settings.json
@@ -147,20 +149,25 @@ claude
 |------|-------|---------------------|
 | **Primary** | Claude Sonnet 4.6 | `global.anthropic.claude-sonnet-4-6` |
 | **Opus** | Claude Opus 4.8 | `global.anthropic.claude-opus-4-8` |
+| **Fable alias** | Claude Fable 5 | Configure with `--fable-model=<bedrock-fable-model-id>` |
 | **Fast / subagent** | Claude Haiku 4.5 | `global.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
-Juggernaut appends Claude Code's `[1m]` suffix to the Opus and Sonnet alias environment variables by default, so Claude Code accounts against the 1M context window locally. Claude Code strips that suffix before calling Bedrock. Use `--no-1m-context` to opt out.
+Juggernaut appends Claude Code's `[1m]` suffix to the Opus and Sonnet alias environment variables by default, and to the configured Fable alias when it matches Claude Code's Fable ID. Claude Code accounts against 1M context for supported aliases locally, then strips that suffix before calling Bedrock. Use `--no-1m-context` to opt out.
+
+Fable is exposed as an opt-in Claude Code alias. Pass `--fable-model` with a model ID that is available in your Bedrock account and region; Juggernaut does not pin a default Fable ID until one is configured.
 
 Override any tier:
 
 ```bash
 juggernaut apply --auth=iam --opus-model=us.anthropic.claude-opus-4-8
-juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6  # override all
+juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>
+juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6  # override all model aliases
+juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-4-8,global.anthropic.claude-sonnet-4-6
 ```
 
 ## Effort Levels
 
-Controls adaptive thinking depth. Valid values are `low`, `medium`, `high`, `xhigh`, and `max`; Claude Code falls back to the highest supported level for the active model. Juggernaut defaults to `high`, which matches Sonnet 4.6.
+Controls adaptive thinking depth. Valid values are `low`, `medium`, `high`, `xhigh`, `max`, and `auto`; Claude Code falls back to the highest supported level for the active model. Juggernaut writes fixed persisted levels (`low`, `medium`, `high`, `xhigh`) to both native `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`; `max` and `auto` are env-only because Claude Code settings do not accept them as persisted `effortLevel` values. Ultracode is separate from `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`, so Juggernaut does not expose it as `--effort`. Juggernaut defaults to `high`, which matches Sonnet 4.6.
 
 | Level | Behavior |
 |-------|----------|
@@ -169,6 +176,7 @@ Controls adaptive thinking depth. Valid values are `low`, `medium`, `high`, `xhi
 | `high` | Almost always thinks (default) |
 | `xhigh` | Always thinks deeply |
 | `max` | Maximum thinking — deepest reasoning, highest cost |
+| `auto` | Claude Code selects the effort level |
 
 ```bash
 juggernaut apply --auth=iam --effort=max
@@ -225,7 +233,7 @@ The hidden `juggernaut launch` command reads the Bedrock API key from the OS key
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
     "CLAUDE_CODE_EFFORT_LEVEL": "high",
     "ENABLE_PROMPT_CACHING_1H": "1",
-    "DISABLE_TELEMETRY": "1"
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
   }
 }
 ```

--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -6,7 +6,8 @@
     "fast": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
     "opus": "global.anthropic.claude-opus-4-8",
     "sonnet": "global.anthropic.claude-sonnet-4-6",
-    "haiku": "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+    "haiku": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "fable": ""
   },
   "environment_bedrock_auth": {
     "CLAUDE_CODE_USE_BEDROCK": "1"
@@ -60,9 +61,10 @@
   },
   "notes": {
     "fast_model": "Fast/background model defaults to Haiku 4.5 using ANTHROPIC_DEFAULT_HAIKU_MODEL (Anthropic recommendation for cost & speed on subagents, exploration, etc.). ANTHROPIC_SMALL_FAST_MODEL was removed because it is officially deprecated. See: https://code.claude.com/docs/en/model-config",
-    "1m_context": "Opus 4.8, Opus 4.7, and Sonnet 4.6 have native 1M context windows in Amazon Bedrock. Juggernaut appends Claude Code's [1m] suffix to Opus and Sonnet alias environment variables by default so Claude Code uses a 1M context window locally, then strips the suffix before calling Bedrock. Use --no-1m-context to set CLAUDE_CODE_DISABLE_1M_CONTEXT=1 and keep pinned model IDs suffix-free.",
-    "effort": "CLAUDE_CODE_EFFORT_LEVEL sets the default effort for all models. Valid values: low|medium|high|xhigh|max. Defaults to high because Sonnet 4.6 does not support xhigh; Claude Code falls back to the highest supported level at or below the requested effort. Use --effort=xhigh for Opus 4.8/4.7 or Fable 5, and --effort=max when you explicitly want the deepest session behavior.",
+    "1m_context": "Opus 4.8, Opus 4.7, and Sonnet 4.6 have native 1M context windows in Amazon Bedrock. Juggernaut appends Claude Code's [1m] suffix to Opus and Sonnet alias environment variables by default, and to the configured Fable alias when it matches Claude Code's Fable ID, so Claude Code can account against 1M context for supported aliases locally, then strips the suffix before calling Bedrock. Use --no-1m-context to set CLAUDE_CODE_DISABLE_1M_CONTEXT=1 and keep pinned model IDs suffix-free.",
+    "effort": "CLAUDE_CODE_EFFORT_LEVEL sets the default effort for all models. Valid values: low|medium|high|xhigh|max|auto. Defaults to high because Sonnet 4.6 does not support xhigh; Claude Code falls back to the highest supported level at or below the requested effort. Juggernaut persists fixed levels (low|medium|high|xhigh) as native effortLevel; max and auto are env-only because Claude Code settings do not accept them as persisted effortLevel values. Use --effort=xhigh for Opus 4.8/4.7 or other capable model configurations, --effort=max when you explicitly want the deepest session behavior, or --effort=auto to let Claude Code choose. Ultracode is a separate Claude Code session setting, not a CLAUDE_CODE_EFFORT_LEVEL value or persisted settings.json effortLevel.",
     "subagent_model": "CLAUDE_CODE_SUBAGENT_MODEL controls the model for background subagents independently of ANTHROPIC_DEFAULT_HAIKU_MODEL. Defaults to Haiku for cost efficiency.",
+    "fable_fallback": "Set models.fable or pass --fable-model when you have a Bedrock-accessible Fable model ID. Juggernaut then writes Claude Code Fable alias environment metadata plus native model override aliases. Use --fallback-model to set Claude Code's native fallbackModel chain.",
     "capabilities": "SUPPORTED_CAPABILITIES declares features Bedrock model IDs don't auto-detect (effort levels, thinking, etc.). See: https://code.claude.com/docs/en/model-config",
     "auto_mode": "Auto mode (permissions.defaultMode: auto) enables the agentic safety classifier. On Bedrock it requires BOTH CLAUDE_CODE_ENABLE_AUTO_MODE=1 (Juggernaut sets this when --mode=auto) AND an active session model of Opus 4.7 or 4.8 (Claude Code v2.1.158+). Sonnet/Haiku do not support auto mode on Bedrock, so with Juggernaut's default Sonnet model auto will not appear in the Shift+Tab cycle until the user runs Claude Code on Opus (claude --model opus, or /model opus in session). opusplan does not qualify: its default session model is still Sonnet. Verified against https://code.claude.com/docs/en/permission-modes",
     "nonessential_traffic": "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 is the documented aggregate that disables the autoupdater, feedback command, error reporting, and telemetry in one setting. It replaces the individual DISABLE_AUTOUPDATER/DISABLE_FEEDBACK_COMMAND/DISABLE_ERROR_REPORTING/DISABLE_TELEMETRY vars. See: https://code.claude.com/docs/en/env-vars",

--- a/bedrock-config.json
+++ b/bedrock-config.json
@@ -29,10 +29,7 @@
     "CLAUDE_CODE_EFFORT_LEVEL": "high",
     "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
     "ENABLE_PROMPT_CACHING_1H": "1",
-    "DISABLE_ERROR_REPORTING": "1",
-    "DISABLE_TELEMETRY": "1",
-    "DISABLE_AUTOUPDATE": "1",
-    "DISABLE_BUG_COMMAND": "1"
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
   },
   "regions": [
     "us-east-1",
@@ -67,7 +64,8 @@
     "effort": "CLAUDE_CODE_EFFORT_LEVEL sets the default effort for all models. Valid values: low|medium|high|xhigh|max. Defaults to high because Sonnet 4.6 does not support xhigh; Claude Code falls back to the highest supported level at or below the requested effort. Use --effort=xhigh for Opus 4.8/4.7 or Fable 5, and --effort=max when you explicitly want the deepest session behavior.",
     "subagent_model": "CLAUDE_CODE_SUBAGENT_MODEL controls the model for background subagents independently of ANTHROPIC_DEFAULT_HAIKU_MODEL. Defaults to Haiku for cost efficiency.",
     "capabilities": "SUPPORTED_CAPABILITIES declares features Bedrock model IDs don't auto-detect (effort levels, thinking, etc.). See: https://code.claude.com/docs/en/model-config",
-    "auto_mode": "Auto mode (permissions.defaultMode: auto) enables the agentic safety classifier. On Bedrock, CLAUDE_CODE_ENABLE_AUTO_MODE=1 is required â€” without it auto mode silently does nothing. Juggernaut sets this automatically when --mode=auto is used.",
+    "auto_mode": "Auto mode (permissions.defaultMode: auto) enables the agentic safety classifier. On Bedrock it requires BOTH CLAUDE_CODE_ENABLE_AUTO_MODE=1 (Juggernaut sets this when --mode=auto) AND an active session model of Opus 4.7 or 4.8 (Claude Code v2.1.158+). Sonnet/Haiku do not support auto mode on Bedrock, so with Juggernaut's default Sonnet model auto will not appear in the Shift+Tab cycle until the user runs Claude Code on Opus (claude --model opus, or /model opus in session). opusplan does not qualify: its default session model is still Sonnet. Verified against https://code.claude.com/docs/en/permission-modes",
+    "nonessential_traffic": "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 is the documented aggregate that disables the autoupdater, feedback command, error reporting, and telemetry in one setting. It replaces the individual DISABLE_AUTOUPDATER/DISABLE_FEEDBACK_COMMAND/DISABLE_ERROR_REPORTING/DISABLE_TELEMETRY vars. See: https://code.claude.com/docs/en/env-vars",
     "opus_4_8": "Opus 4.8 supports only adaptive thinking mode. Manual thinking.type:enabled is rejected with a 400 error. Use effort level to control thinking depth instead.",
     "source": "Bedrock IDs and context windows verified against AWS Bedrock model cards: https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-8.html, https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-4-6.html, https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-haiku-4-5.html. Claude Code model env vars verified against: https://docs.anthropic.com/en/docs/claude-code/model-config"
   }

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/huh"
@@ -36,6 +37,8 @@ var applyFlags struct {
 	opusModel      string
 	sonnetModel    string
 	haikuModel     string
+	fableModel     string
+	fallbackModel  string
 	effort         string
 	opusplan       bool
 	noOpusplan     bool
@@ -61,7 +64,9 @@ func init() {
 	f.StringVar(&applyFlags.opusModel, "opus-model", "", "override Opus model ID")
 	f.StringVar(&applyFlags.sonnetModel, "sonnet-model", "", "override Sonnet model ID")
 	f.StringVar(&applyFlags.haikuModel, "haiku-model", "", "override Haiku model ID")
-	f.StringVar(&applyFlags.effort, "effort", "high", "effort level: low|medium|high|xhigh|max")
+	f.StringVar(&applyFlags.fableModel, "fable-model", "", "override Fable model ID")
+	f.StringVar(&applyFlags.fallbackModel, "fallback-model", "", "comma-separated fallback model IDs")
+	f.StringVar(&applyFlags.effort, "effort", "high", "effort level: low|medium|high|xhigh|max|auto")
 	f.BoolVar(&applyFlags.opusplan, "opusplan", false, "route planning to Opus, execution to Sonnet")
 	f.BoolVar(&applyFlags.noOpusplan, "no-opusplan", false, "disable opusplan")
 	f.BoolVar(&applyFlags.no1m, "no-1m-context", false, "disable 1M token context")
@@ -110,10 +115,17 @@ func runApply(_ *cobra.Command, _ []string) error {
 	opusModel := applyFlags.opusModel
 	sonnetModel := applyFlags.sonnetModel
 	haikuModel := applyFlags.haikuModel
+	fableModel := applyFlags.fableModel
 	if applyFlags.model != "" {
 		opusModel = applyFlags.model
 		sonnetModel = applyFlags.model
 		haikuModel = applyFlags.model
+		fableModel = applyFlags.model
+	}
+
+	fallbackModels, err := parseFallbackModels(applyFlags.fallbackModel)
+	if err != nil {
+		return err
 	}
 
 	opts := schema.Options{
@@ -125,6 +137,8 @@ func runApply(_ *cobra.Command, _ []string) error {
 		OpusModel:      opusModel,
 		SonnetModel:    sonnetModel,
 		HaikuModel:     haikuModel,
+		FableModel:     fableModel,
+		FallbackModels: fallbackModels,
 		Opusplan:       opusplan,
 		Use1M:          !applyFlags.no1m,
 		UseMantle:      useMantle,
@@ -190,6 +204,7 @@ func commitApply(home, authMode, token string, block *schema.Block) error {
 	nativeKeys := map[string]any{
 		"model":                 native.Model,
 		"modelOverrides":        modelOverrides,
+		"fallbackModel":         native.FallbackModel,
 		"effortLevel":           native.EffortLevel,
 		"alwaysThinkingEnabled": native.AlwaysThinking,
 		"skipWebFetchPreflight": native.SkipWebFetchPreflight,
@@ -204,6 +219,24 @@ func commitApply(home, authMode, token string, block *schema.Block) error {
 	fmt.Println("Configuration written successfully.")
 	warnAutoModeModel(block)
 	return nil
+}
+
+func parseFallbackModels(raw string) ([]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	models := make([]string, 0, len(parts))
+	for _, part := range parts {
+		model := strings.TrimSpace(part)
+		if model == "" {
+			return nil, fmt.Errorf("--fallback-model contains an empty model ID")
+		}
+		models = append(models, model)
+	}
+	return models, nil
 }
 
 // warnAutoModeModel alerts the user when --mode=auto was requested but the

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -202,7 +202,24 @@ func commitApply(home, authMode, token string, block *schema.Block) error {
 	reportLegacyRecovery(home)
 	installActivation(home)
 	fmt.Println("Configuration written successfully.")
+	warnAutoModeModel(block)
 	return nil
+}
+
+// warnAutoModeModel alerts the user when --mode=auto was requested but the
+// active session model won't unlock auto mode on Bedrock. Claude Code only
+// offers auto mode there when the model is Opus 4.7/4.8, so with Juggernaut's
+// default Sonnet model the Shift+Tab cycle hides auto entirely.
+func warnAutoModeModel(block *schema.Block) {
+	if block.Meta.PermissionMode != "auto" || block.AutoModeUsable() {
+		return
+	}
+	fmt.Println()
+	fmt.Println("⚠ Auto mode on Bedrock requires Opus 4.7 or 4.8 (Claude Code v2.1.158+).")
+	fmt.Printf("  Your default session model is %s, which Claude Code does\n", block.Models.Sonnet)
+	fmt.Println("  not support for auto mode, so auto will not appear in the Shift+Tab cycle.")
+	fmt.Println("  Run Claude Code on Opus to unlock it — launch with `claude --model opus`")
+	fmt.Println("  or switch with `/model opus` inside a session (your opus alias is pinned to Opus 4.8).")
 }
 
 func reportLegacyRecovery(home string) {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -132,6 +132,9 @@ func TestApply_WritesSettings_IAM(t *testing.T) {
 	if env["ANTHROPIC_DEFAULT_SONNET_MODEL"] != "global.anthropic.claude-sonnet-4-6[1m]" {
 		t.Errorf("expected Sonnet default model to carry [1m], got %v", env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
 	}
+	if _, ok := env["ANTHROPIC_DEFAULT_FABLE_MODEL"]; ok {
+		t.Errorf("Fable default model should be omitted unless configured, got %v", env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
+	}
 
 	bashrcPath := filepath.Join(home, ".bashrc")
 	bashrc, err := safepath.ReadFile(home, bashrcPath)
@@ -272,6 +275,9 @@ func TestApply_ModelFlag_OverridesAll(t *testing.T) {
 	if overrides["haiku"] != customModel {
 		t.Errorf("expected haiku=%s, got %v", customModel, overrides["haiku"])
 	}
+	if overrides["fable"] != customModel {
+		t.Errorf("expected fable=%s, got %v", customModel, overrides["fable"])
+	}
 }
 
 func TestUninstall_RemovesBlock(t *testing.T) {
@@ -282,7 +288,8 @@ func TestUninstall_RemovesBlock(t *testing.T) {
 	// Apply with all new flags to ensure they get cleaned up.
 	if err := ExecuteArgs([]string{
 		"apply", "--auth=iam", "--region=us-west-2",
-		"--mode=auto", "--always-thinking", "--effort=max", "--skip-preflight",
+		"--mode=auto", "--always-thinking", "--effort=max",
+		"--fallback-model=global.anthropic.claude-opus-4-8,global.anthropic.claude-sonnet-4-6", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply error: %v", err)
 	}
@@ -298,7 +305,7 @@ func TestUninstall_RemovesBlock(t *testing.T) {
 	}
 
 	for _, k := range []string{
-		"juggernaut", "env", "model", "modelOverrides",
+		"juggernaut", "env", "model", "modelOverrides", "fallbackModel",
 		"effortLevel", "alwaysThinkingEnabled", "skipWebFetchPreflight", "permissions",
 	} {
 		if _, ok := settings[k]; ok {
@@ -515,6 +522,68 @@ func TestApply_PermissionMode_InvalidErrors(t *testing.T) {
 	}
 }
 
+func TestApply_FableAndFallbackWritesNativeKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	const fableModel = "custom.fable.model"
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2",
+		"--fable-model=" + fableModel,
+		"--fallback-model=global.anthropic.claude-opus-4-8, global.anthropic.claude-sonnet-4-6",
+		"--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	data := readSettingsJSON(t, home)
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	env, _ := settings["env"].(map[string]any)
+	if env["ANTHROPIC_DEFAULT_FABLE_MODEL"] != fableModel {
+		t.Errorf("expected Fable env model override, got %v", env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
+	}
+	overrides := settings["modelOverrides"].(map[string]any)
+	if overrides["fable"] != fableModel {
+		t.Errorf("expected native fable alias=%s, got %v", fableModel, overrides["fable"])
+	}
+	fallbacks, ok := settings["fallbackModel"].([]any)
+	if !ok || len(fallbacks) != 2 {
+		t.Fatalf("expected fallbackModel array with two entries, got %#v", settings["fallbackModel"])
+	}
+	if fallbacks[0] != "global.anthropic.claude-opus-4-8" || fallbacks[1] != "global.anthropic.claude-sonnet-4-6" {
+		t.Errorf("unexpected fallbackModel chain: %#v", fallbacks)
+	}
+
+	block := settings["juggernaut"].(map[string]any)
+	meta := block["meta"].(map[string]any)
+	metaFallbacks, ok := meta["fallbackModels"].([]any)
+	if !ok || len(metaFallbacks) != 2 {
+		t.Fatalf("expected juggernaut.meta.fallbackModels with two entries, got %#v", meta["fallbackModels"])
+	}
+}
+
+func TestApply_FallbackModelRejectsEmptyEntries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2",
+		"--fallback-model=global.anthropic.claude-opus-4-8,,global.anthropic.claude-sonnet-4-6",
+		"--skip-preflight",
+	})
+	if err == nil {
+		t.Fatal("expected empty --fallback-model entry to error")
+	}
+	if !strings.Contains(err.Error(), "--fallback-model contains an empty model ID") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestApply_ServiceTier_WritesEnvVar(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -601,6 +670,44 @@ func TestApply_MaxEffortUsesEnvOnly(t *testing.T) {
 	env, _ := settings["env"].(map[string]any)
 	if env["CLAUDE_CODE_EFFORT_LEVEL"] != "max" {
 		t.Errorf("expected CLAUDE_CODE_EFFORT_LEVEL=max, got %v", env["CLAUDE_CODE_EFFORT_LEVEL"])
+	}
+}
+
+func TestApply_EffortAutoUsesEnvOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	err := ExecuteArgs([]string{"apply", "--auth=iam", "--region=us-west-2", "--effort=auto", "--skip-preflight"})
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+
+	data := readSettingsJSON(t, home)
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	if _, ok := settings["effortLevel"]; ok {
+		t.Errorf("effortLevel should be omitted for auto because Claude Code settings only accept persisted fixed levels, got %v", settings["effortLevel"])
+	}
+	env, _ := settings["env"].(map[string]any)
+	if got := env["CLAUDE_CODE_EFFORT_LEVEL"]; got != "auto" {
+		t.Errorf("expected CLAUDE_CODE_EFFORT_LEVEL=auto, got %v", got)
+	}
+}
+
+func TestApply_EffortUltracodeInvalid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	err := ExecuteArgs([]string{"apply", "--auth=iam", "--region=us-west-2", "--effort=ultracode", "--skip-preflight"})
+	if err == nil {
+		t.Fatal("expected unsupported ultracode effort value to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid effort") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -674,4 +675,82 @@ func readSettingsJSON(t *testing.T, home string) []byte {
 		t.Fatalf("reading settings.json: %v", err)
 	}
 	return data
+}
+
+// captureStdout runs fn while redirecting os.Stdout and returns what was printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading pipe: %v", err)
+	}
+	return string(out)
+}
+
+func TestApply_AutoMode_WarnsWhenModelNotOpus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--mode=auto", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Auto mode on Bedrock requires Opus") {
+		t.Errorf("expected auto-mode model warning with default Sonnet model, got:\n%s", out)
+	}
+}
+
+func TestApply_AutoMode_NoWarnWhenModelIsOpus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--mode=auto",
+			"--model", "global.anthropic.claude-opus-4-8", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Auto mode on Bedrock requires Opus") {
+		t.Errorf("did not expect auto-mode warning when model is Opus, got:\n%s", out)
+	}
+}
+
+func TestApply_NonAutoMode_NoAutoModeWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--mode=plan", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Auto mode on Bedrock requires Opus") {
+		t.Errorf("did not expect auto-mode warning for --mode=plan, got:\n%s", out)
+	}
 }

--- a/internal/bedrock/config.go
+++ b/internal/bedrock/config.go
@@ -26,6 +26,7 @@ type ModelSet struct {
 	Opus    string `json:"opus"`
 	Sonnet  string `json:"sonnet"`
 	Haiku   string `json:"haiku"`
+	Fable   string `json:"fable"`
 }
 
 // Defaults holds the default values for region, auth mode, and model.

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -94,6 +94,7 @@ var nativeManagedKeys = []string{
 	"env",
 	"model",
 	"modelOverrides",
+	"fallbackModel",
 	"effortLevel",
 	"alwaysThinkingEnabled",
 	"skipWebFetchPreflight",
@@ -138,10 +139,22 @@ func (m *Manager) MergeJuggernautBlock(block map[string]any, nativeEnv map[strin
 			} else {
 				delete(existing, k)
 			}
+		case []string:
+			if len(val) > 0 {
+				existing[k] = val
+			} else {
+				delete(existing, k)
+			}
+		case []any:
+			if len(val) > 0 {
+				existing[k] = val
+			} else {
+				delete(existing, k)
+			}
 		case nil:
 			delete(existing, k)
 		default:
-			return fmt.Errorf("unsupported type %T for native key %q (expected string, bool, or map[string]any)", v, k)
+			return fmt.Errorf("unsupported type %T for native key %q (expected string, bool, []string, []any, or map[string]any)", v, k)
 		}
 	}
 	return m.Write(existing)

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -96,7 +96,11 @@ func TestMergeJuggernautBlock(t *testing.T) {
 
 	block := map[string]any{"managedBy": "juggernaut"}
 	nativeEnv := map[string]string{"CLAUDE_CODE_USE_BEDROCK": "1"}
-	nativeKeys := map[string]any{"effortLevel": "xhigh", "skipWebFetchPreflight": true}
+	nativeKeys := map[string]any{
+		"effortLevel":           "xhigh",
+		"fallbackModel":         []string{"global.anthropic.claude-opus-4-8", "global.anthropic.claude-sonnet-4-6"},
+		"skipWebFetchPreflight": true,
+	}
 
 	if err := m.MergeJuggernautBlock(block, nativeEnv, nativeKeys); err != nil {
 		t.Fatalf("MergeJuggernautBlock() error: %v", err)
@@ -111,6 +115,13 @@ func TestMergeJuggernautBlock(t *testing.T) {
 	}
 	if got["effortLevel"] != "xhigh" {
 		t.Errorf("expected effortLevel=xhigh, got %v", got["effortLevel"])
+	}
+	fallbacks, ok := got["fallbackModel"].([]any)
+	if !ok || len(fallbacks) != 2 {
+		t.Fatalf("expected fallbackModel array with two entries, got %#v", got["fallbackModel"])
+	}
+	if fallbacks[0] != "global.anthropic.claude-opus-4-8" || fallbacks[1] != "global.anthropic.claude-sonnet-4-6" {
+		t.Errorf("unexpected fallbackModel chain: %#v", fallbacks)
 	}
 	if got["skipWebFetchPreflight"] != true {
 		t.Error("expected skipWebFetchPreflight=true")
@@ -134,6 +145,26 @@ func TestMergeJuggernautBlock_NativeKeys_BoolFalseDeletes(t *testing.T) {
 	got, _ := m.Read()
 	if _, ok := got["alwaysThinkingEnabled"]; ok {
 		t.Error("alwaysThinkingEnabled=false should remove the key")
+	}
+}
+
+func TestMergeJuggernautBlock_NativeKeys_EmptySliceDeletes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	m := config.NewManager(path)
+
+	_ = m.Write(map[string]any{"fallbackModel": []any{"global.anthropic.claude-opus-4-8"}})
+
+	if err := m.MergeJuggernautBlock(
+		map[string]any{},
+		nil,
+		map[string]any{"fallbackModel": []string{}},
+	); err != nil {
+		t.Fatalf("MergeJuggernautBlock() error: %v", err)
+	}
+
+	got, _ := m.Read()
+	if _, ok := got["fallbackModel"]; ok {
+		t.Error("empty fallbackModel slice should remove the key")
 	}
 }
 
@@ -195,6 +226,7 @@ func TestRemoveJuggernautBlock(t *testing.T) {
 		"env":                   map[string]any{"CLAUDE_CODE_USE_BEDROCK": "1"},
 		"model":                 "opusplan",
 		"modelOverrides":        map[string]any{},
+		"fallbackModel":         []any{"global.anthropic.claude-opus-4-8"},
 		"effortLevel":           "xhigh",
 		"alwaysThinkingEnabled": true,
 		"skipWebFetchPreflight": true,
@@ -208,7 +240,7 @@ func TestRemoveJuggernautBlock(t *testing.T) {
 
 	got, _ := m.Read()
 	// permissions had only defaultMode so the whole key should be gone.
-	for _, k := range []string{"juggernaut", "env", "model", "modelOverrides", "effortLevel", "alwaysThinkingEnabled", "skipWebFetchPreflight", "permissions"} {
+	for _, k := range []string{"juggernaut", "env", "model", "modelOverrides", "fallbackModel", "effortLevel", "alwaysThinkingEnabled", "skipWebFetchPreflight", "permissions"} {
 		if _, ok := got[k]; ok {
 			t.Errorf("key %q should be removed after uninstall", k)
 		}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -23,7 +23,9 @@ type Options struct {
 	OpusModel      string
 	SonnetModel    string
 	HaikuModel     string
+	FableModel     string
 	Opusplan       bool
+	FallbackModels []string
 	Use1M          bool
 	UseMantle      bool
 	MantleURL      string
@@ -52,30 +54,33 @@ type ModelOverrides struct {
 	Opus     string `json:"opus"`
 	Sonnet   string `json:"sonnet"`
 	Haiku    string `json:"haiku"`
+	Fable    string `json:"fable,omitempty"`
 	Subagent string `json:"subagent"`
 }
 
 // Meta holds Juggernaut metadata stored in the block.
 type Meta struct {
-	SchemaVersion  int    `json:"schemaVersion"`
-	Version        string `json:"version"`
-	ManagedBy      string `json:"managedBy"`
-	Scope          string `json:"scope"`
-	AppliedAt      string `json:"appliedAt"`
-	Opusplan       bool   `json:"opusplan"`
-	Use1M          bool   `json:"use1mContext"`
-	UseMantle      bool   `json:"useMantle"`
-	MantleURL      string `json:"mantleBaseUrl,omitempty"`
-	Effort         string `json:"effort"`
-	PermissionMode string `json:"permissionMode,omitempty"`
-	AlwaysThinking bool   `json:"alwaysThinkingEnabled,omitempty"`
-	ServiceTier    string `json:"serviceTier,omitempty"`
+	SchemaVersion  int      `json:"schemaVersion"`
+	Version        string   `json:"version"`
+	ManagedBy      string   `json:"managedBy"`
+	Scope          string   `json:"scope"`
+	AppliedAt      string   `json:"appliedAt"`
+	Opusplan       bool     `json:"opusplan"`
+	Use1M          bool     `json:"use1mContext"`
+	UseMantle      bool     `json:"useMantle"`
+	MantleURL      string   `json:"mantleBaseUrl,omitempty"`
+	Effort         string   `json:"effort"`
+	FallbackModels []string `json:"fallbackModels,omitempty"`
+	PermissionMode string   `json:"permissionMode,omitempty"`
+	AlwaysThinking bool     `json:"alwaysThinkingEnabled,omitempty"`
+	ServiceTier    string   `json:"serviceTier,omitempty"`
 }
 
 // NativeKeys are the top-level settings.json keys Claude Code reads directly.
 type NativeKeys struct {
 	Model                 string            `json:"model,omitempty"`
 	ModelOverrides        map[string]string `json:"modelOverrides,omitempty"`
+	FallbackModel         []string          `json:"fallbackModel,omitempty"`
 	Env                   map[string]string `json:"env"`
 	EffortLevel           string            `json:"effortLevel,omitempty"`
 	AlwaysThinking        bool              `json:"alwaysThinkingEnabled,omitempty"`
@@ -84,7 +89,7 @@ type NativeKeys struct {
 }
 
 var validEfforts = map[string]bool{
-	"low": true, "medium": true, "high": true, "xhigh": true, "max": true,
+	"low": true, "medium": true, "high": true, "xhigh": true, "max": true, "auto": true,
 }
 
 var validPermissionModes = map[string]bool{
@@ -102,7 +107,7 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 		return nil, fmt.Errorf("unsupported region %q — run `juggernaut doctor` for supported regions", opts.Region)
 	}
 	if !validEfforts[opts.Effort] {
-		return nil, fmt.Errorf("invalid effort %q — must be one of: low, medium, high, xhigh, max", opts.Effort)
+		return nil, fmt.Errorf("invalid effort %q — must be one of: low, medium, high, xhigh, max, auto", opts.Effort)
 	}
 	if opts.PermissionMode != "" && !validPermissionModes[opts.PermissionMode] {
 		return nil, fmt.Errorf("invalid mode %q — must be one of: default, acceptEdits, plan, auto, dontAsk, bypassPermissions", opts.PermissionMode)
@@ -123,6 +128,14 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	if haiku == "" {
 		haiku = cfg.Models.Haiku
 	}
+	fable := opts.FableModel
+	if fable == "" {
+		fable = cfg.Models.Fable
+	}
+	fallbackModels, err := normalizeFallbackModels(opts.FallbackModels)
+	if err != nil {
+		return nil, err
+	}
 
 	// Mantle uses anthropic.* model IDs; Bedrock inference profile IDs are not
 	// valid Mantle targets. Strip profile prefixes only when Mantle is explicit.
@@ -130,6 +143,7 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 		opus = mantleModelID(opus)
 		sonnet = mantleModelID(sonnet)
 		haiku = mantleModelID(haiku)
+		fable = mantleModelID(fable)
 	}
 
 	env := make(map[string]string, len(cfg.Environment))
@@ -143,6 +157,12 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = claudeCodeContextModelID(opus, opts.Use1M)
 	env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = claudeCodeContextModelID(sonnet, opts.Use1M)
 	env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku
+	if fable != "" {
+		env["ANTHROPIC_DEFAULT_FABLE_MODEL"] = claudeCodeContextModelID(fable, opts.Use1M)
+		setDefaultEnv(env, "ANTHROPIC_DEFAULT_FABLE_MODEL_NAME", "Fable 5")
+		setDefaultEnv(env, "ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION", "Configured Claude Code Fable alias with adaptive thinking metadata and Opus fallback support")
+		setDefaultEnv(env, "ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES", "effort,max_effort,xhigh_effort,thinking,adaptive_thinking,interleaved_thinking")
+	}
 	env["CLAUDE_CODE_SUBAGENT_MODEL"] = haiku
 	env["CLAUDE_CODE_EFFORT_LEVEL"] = opts.Effort
 
@@ -175,6 +195,7 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 			Opus:     opus,
 			Sonnet:   sonnet,
 			Haiku:    haiku,
+			Fable:    fable,
 			Subagent: haiku,
 		},
 		Env: env,
@@ -189,6 +210,7 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 			UseMantle:      opts.UseMantle,
 			MantleURL:      opts.MantleURL,
 			Effort:         opts.Effort,
+			FallbackModels: fallbackModels,
 			PermissionMode: opts.PermissionMode,
 			AlwaysThinking: opts.AlwaysThinking,
 			ServiceTier:    opts.ServiceTier,
@@ -267,6 +289,7 @@ func (b *Block) NativeKeys() NativeKeys {
 	return NativeKeys{
 		Model:                 model,
 		ModelOverrides:        nativeModelOverrides(b.Models, b.Meta.Use1M),
+		FallbackModel:         append([]string(nil), b.Meta.FallbackModels...),
 		Env:                   b.Env,
 		EffortLevel:           persistedEffortLevel(b.Meta.Effort),
 		AlwaysThinking:        b.Meta.AlwaysThinking,
@@ -288,6 +311,11 @@ func nativeModelOverrides(models ModelOverrides, use1M bool) map[string]string {
 		"claude-haiku-4-5-20251001":   models.Haiku,
 		"anthropic.claude-haiku-4-5-20251001-v1:0": models.Haiku,
 	}
+	if models.Fable != "" {
+		overrides["fable"] = models.Fable
+		overrides["claude-fable-5"] = models.Fable
+		overrides["anthropic.claude-fable-5"] = models.Fable
+	}
 	if use1M {
 		overrides["opus[1m]"] = models.Opus
 		overrides["claude-opus-4-8[1m]"] = models.Opus
@@ -295,13 +323,40 @@ func nativeModelOverrides(models ModelOverrides, use1M bool) map[string]string {
 		overrides["sonnet[1m]"] = models.Sonnet
 		overrides["claude-sonnet-4-6[1m]"] = models.Sonnet
 		overrides["anthropic.claude-sonnet-4-6[1m]"] = models.Sonnet
+		if models.Fable != "" {
+			overrides["fable[1m]"] = models.Fable
+			overrides["claude-fable-5[1m]"] = models.Fable
+			overrides["anthropic.claude-fable-5[1m]"] = models.Fable
+		}
 	}
 	return overrides
 }
 
 func persistedEffortLevel(effort string) string {
-	if effort == "max" {
+	if effort == "max" || effort == "auto" {
 		return ""
 	}
 	return effort
+}
+
+func normalizeFallbackModels(models []string) ([]string, error) {
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	out := make([]string, 0, len(models))
+	for _, model := range models {
+		trimmed := strings.TrimSpace(model)
+		if trimmed == "" {
+			return nil, fmt.Errorf("fallback model chain contains an empty model ID")
+		}
+		out = append(out, trimmed)
+	}
+	return out, nil
+}
+
+func setDefaultEnv(env map[string]string, key, value string) {
+	if _, ok := env[key]; !ok {
+		env[key] = value
+	}
 }

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -196,6 +196,28 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	}, nil
 }
 
+// IsAutoModeCapableModel reports whether modelID is an Opus 4.7 or 4.8 model.
+// On Bedrock, Vertex, and Foundry, auto mode is offered only when the active
+// session model is one of these; Sonnet, Haiku, and older models are excluded.
+// See https://code.claude.com/docs/en/permission-modes.
+func IsAutoModeCapableModel(modelID string) bool {
+	normalized := strings.TrimSuffix(modelID, "[1m]")
+	for _, prefix := range []string{"global.", "us.", "us-gov.", "eu.", "apac."} {
+		normalized = strings.TrimPrefix(normalized, prefix)
+	}
+	return strings.Contains(normalized, "claude-opus-4-8") ||
+		strings.Contains(normalized, "claude-opus-4-7")
+}
+
+// AutoModeUsable reports whether auto mode will actually be offered by Claude
+// Code for this block. It requires PermissionMode=="auto" AND the active default
+// session model (the Sonnet-tier pin, which is the account default on Bedrock)
+// to be an Opus 4.7/4.8 model. opusplan does not qualify: its execution phase
+// runs on Sonnet, and the session's default model is still Sonnet-tier.
+func (b *Block) AutoModeUsable() bool {
+	return b.Meta.PermissionMode == "auto" && IsAutoModeCapableModel(b.Models.Sonnet)
+}
+
 func mantleModelID(model string) string {
 	for _, prefix := range []string{"global.", "us.", "eu.", "apac."} {
 		if strings.HasPrefix(model, prefix) {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -445,3 +445,76 @@ func TestBuild_NoBedrockFlagWithoutValidation(t *testing.T) {
 		t.Error("CLAUDE_CODE_USE_BEDROCK should NOT be set when AuthValidated=false")
 	}
 }
+
+func TestIsAutoModeCapableModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		// Supported on Bedrock: Opus 4.7 and 4.8 (with any region prefix / [1m]).
+		{"global.anthropic.claude-opus-4-8", true},
+		{"global.anthropic.claude-opus-4-8[1m]", true},
+		{"us.anthropic.claude-opus-4-7", true},
+		{"anthropic.claude-opus-4-7", true},
+		{"claude-opus-4-8", true},
+		// Not supported: Sonnet, Haiku, older Opus, Fable, empty.
+		{"global.anthropic.claude-sonnet-4-6", false},
+		{"global.anthropic.claude-sonnet-4-6[1m]", false},
+		{"us.anthropic.claude-opus-4-6", false},
+		{"anthropic.claude-opus-4-5-20251101", false},
+		{"global.anthropic.claude-haiku-4-5-20251001-v1:0", false},
+		{"claude-fable-5", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := schema.IsAutoModeCapableModel(c.model); got != c.want {
+			t.Errorf("IsAutoModeCapableModel(%q) = %v, want %v", c.model, got, c.want)
+		}
+	}
+}
+
+func TestBlock_AutoModeUsable_FalseWhenDefaultModelIsSonnet(t *testing.T) {
+	// Default config: Sonnet-tier active model => auto mode hidden on Bedrock.
+	opts := schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "5.1.6", PermissionMode: "auto", AuthValidated: true,
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.AutoModeUsable() {
+		t.Error("expected AutoModeUsable()=false when the active model is Sonnet 4.6")
+	}
+}
+
+func TestBlock_AutoModeUsable_TrueWhenSonnetPinnedToOpus(t *testing.T) {
+	// --model opus (or --sonnet-model opus) makes the active alias resolve to Opus.
+	opts := schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "5.1.6", PermissionMode: "auto", AuthValidated: true,
+		SonnetModel: "global.anthropic.claude-opus-4-8",
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if !block.AutoModeUsable() {
+		t.Error("expected AutoModeUsable()=true when the active model resolves to Opus 4.8")
+	}
+}
+
+func TestBlock_AutoModeUsable_FalseWhenModeNotAuto(t *testing.T) {
+	opts := schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "5.1.6", PermissionMode: "plan", AuthValidated: true,
+		SonnetModel: "global.anthropic.claude-opus-4-8",
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.AutoModeUsable() {
+		t.Error("expected AutoModeUsable()=false when PermissionMode is not auto")
+	}
+}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -1,6 +1,7 @@
 package schema_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
@@ -14,6 +15,7 @@ func testConfig() *bedrock.Config {
 			Opus:   "global.anthropic.claude-opus-4-8",
 			Sonnet: "global.anthropic.claude-sonnet-4-6",
 			Haiku:  "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+			Fable:  "global.anthropic.claude-fable-5",
 		},
 		Environment: map[string]string{
 			"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32768",
@@ -69,19 +71,23 @@ func TestBuild_InvalidRegion(t *testing.T) {
 }
 
 func TestBuild_InvalidEffort(t *testing.T) {
-	opts := schema.Options{
-		AuthMode: "iam",
-		Region:   "us-west-2",
-		Effort:   "turbo",
-		Scope:    "user",
-		Version:  "4.0.0",
-	}
-	_, err := schema.Build(testConfig(), opts)
-	if err == nil {
-		t.Error("expected error for invalid effort level")
+	for _, effort := range []string{"turbo", "ultracode"} {
+		t.Run(effort, func(t *testing.T) {
+			opts := schema.Options{
+				AuthMode: "iam",
+				Region:   "us-west-2",
+				Effort:   effort,
+				Scope:    "user",
+				Version:  "4.0.0",
+			}
+
+			_, err := schema.Build(testConfig(), opts)
+			if err == nil {
+				t.Errorf("expected error for invalid effort level %q", effort)
+			}
+		})
 	}
 }
-
 func TestNativeKeys_Opusplan(t *testing.T) {
 	opts := schema.Options{
 		AuthMode:      "iam",
@@ -126,6 +132,9 @@ func TestBuild_Use1MAnnotatesPinnedClaudeCodeModels(t *testing.T) {
 	if block.Env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] != "global.anthropic.claude-haiku-4-5-20251001-v1:0" {
 		t.Errorf("Haiku should not get [1m], got %q", block.Env["ANTHROPIC_DEFAULT_HAIKU_MODEL"])
 	}
+	if block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL"] != "global.anthropic.claude-fable-5[1m]" {
+		t.Errorf("expected Fable env model with [1m], got %q", block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
+	}
 	if block.Env["ANTHROPIC_MODEL"] != "opusplan[1m]" {
 		t.Errorf("expected opusplan env model with [1m], got %q", block.Env["ANTHROPIC_MODEL"])
 	}
@@ -142,6 +151,9 @@ func TestBuild_Use1MAnnotatesPinnedClaudeCodeModels(t *testing.T) {
 	}
 	if native.ModelOverrides["claude-opus-4-8[1m]"] != "global.anthropic.claude-opus-4-8" {
 		t.Errorf("expected [1m] Opus override to map to unsuffixed provider ID, got %q", native.ModelOverrides["claude-opus-4-8[1m]"])
+	}
+	if native.ModelOverrides["claude-fable-5[1m]"] != "global.anthropic.claude-fable-5" {
+		t.Errorf("expected [1m] Fable override to map to unsuffixed provider ID, got %q", native.ModelOverrides["claude-fable-5[1m]"])
 	}
 }
 
@@ -165,11 +177,17 @@ func TestBuild_No1MDisablesClaudeCodeExtendedContext(t *testing.T) {
 	if block.Env["ANTHROPIC_DEFAULT_SONNET_MODEL"] != "global.anthropic.claude-sonnet-4-6" {
 		t.Errorf("expected Sonnet env model without [1m], got %q", block.Env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
 	}
+	if block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL"] != "global.anthropic.claude-fable-5" {
+		t.Errorf("expected Fable env model without [1m], got %q", block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
+	}
 	if block.Env["CLAUDE_CODE_DISABLE_1M_CONTEXT"] != "1" {
 		t.Errorf("expected CLAUDE_CODE_DISABLE_1M_CONTEXT=1, got %q", block.Env["CLAUDE_CODE_DISABLE_1M_CONTEXT"])
 	}
 	if _, ok := block.NativeKeys().ModelOverrides["claude-sonnet-4-6[1m]"]; ok {
 		t.Error("[1m] model override should be omitted when Use1M=false")
+	}
+	if _, ok := block.NativeKeys().ModelOverrides["claude-fable-5[1m]"]; ok {
+		t.Error("[1m] Fable model override should be omitted when Use1M=false")
 	}
 }
 
@@ -183,6 +201,7 @@ func TestBuild_Use1MDoesNotAnnotateUnknownCustomModels(t *testing.T) {
 		Use1M:         true,
 		OpusModel:     "custom.opus",
 		SonnetModel:   "custom.sonnet",
+		FableModel:    "custom.fable",
 		AuthValidated: true,
 	}
 	block, err := schema.Build(testConfig(), opts)
@@ -194,6 +213,70 @@ func TestBuild_Use1MDoesNotAnnotateUnknownCustomModels(t *testing.T) {
 	}
 	if block.Env["ANTHROPIC_DEFAULT_SONNET_MODEL"] != "custom.sonnet" {
 		t.Errorf("unknown Sonnet override should not get [1m], got %q", block.Env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
+	}
+	if block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL"] != "custom.fable" {
+		t.Errorf("unknown Fable override should not get [1m], got %q", block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
+	}
+}
+
+func TestBuild_FableDefaultsAndNativeAliases(t *testing.T) {
+	opts := schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "4.1.0", AuthValidated: true,
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.Models.Fable != "global.anthropic.claude-fable-5" {
+		t.Errorf("expected Fable model from config, got %q", block.Models.Fable)
+	}
+	if block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL_NAME"] != "Fable 5" {
+		t.Errorf("expected Fable display name, got %q", block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL_NAME"])
+	}
+	if block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION"] == "" {
+		t.Error("expected Fable description to be set")
+	}
+	if block.Env["ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES"] == "" {
+		t.Error("expected Fable supported capabilities to be set")
+	}
+
+	overrides := block.NativeKeys().ModelOverrides
+	for _, key := range []string{"fable", "claude-fable-5", "anthropic.claude-fable-5"} {
+		if overrides[key] != "global.anthropic.claude-fable-5" {
+			t.Errorf("expected %s to map to global Fable profile, got %q", key, overrides[key])
+		}
+	}
+}
+
+func TestBuild_FallbackModelsNativeKey(t *testing.T) {
+	opts := schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "4.1.0", AuthValidated: true,
+		FallbackModels: []string{" global.anthropic.claude-opus-4-8 ", "global.anthropic.claude-sonnet-4-6"},
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	want := []string{"global.anthropic.claude-opus-4-8", "global.anthropic.claude-sonnet-4-6"}
+	if !slices.Equal(block.Meta.FallbackModels, want) {
+		t.Errorf("expected fallbackModels=%v, got %v", want, block.Meta.FallbackModels)
+	}
+	if !slices.Equal(block.NativeKeys().FallbackModel, want) {
+		t.Errorf("expected native fallbackModel=%v, got %v", want, block.NativeKeys().FallbackModel)
+	}
+}
+
+func TestBuild_FallbackModelsRejectEmptyEntries(t *testing.T) {
+	opts := schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "4.1.0", AuthValidated: true,
+		FallbackModels: []string{"global.anthropic.claude-opus-4-8", " "},
+	}
+	_, err := schema.Build(testConfig(), opts)
+	if err == nil {
+		t.Fatal("expected empty fallback model ID to error")
 	}
 }
 
@@ -294,6 +377,28 @@ func TestNativeKeys_MaxEffortIsEnvOnly(t *testing.T) {
 	}
 }
 
+func TestNativeKeys_AutoEffortUsesEnvOnly(t *testing.T) {
+	opts := schema.Options{
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Effort:   "auto",
+		Scope:    "user",
+		Version:  "4.0.0",
+	}
+
+	built, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	native := built.NativeKeys()
+	if native.EffortLevel != "" {
+		t.Errorf("expected native effortLevel to be omitted for auto, got %q", native.EffortLevel)
+	}
+	if native.Env["CLAUDE_CODE_EFFORT_LEVEL"] != "auto" {
+		t.Errorf("expected CLAUDE_CODE_EFFORT_LEVEL=auto, got %q", native.Env["CLAUDE_CODE_EFFORT_LEVEL"])
+	}
+}
 func TestNativeKeys_ModelOverridesIncludeClaudeCodeVersionKeys(t *testing.T) {
 	opts := schema.Options{
 		AuthMode: "iam", Region: "us-west-2", Effort: "high",
@@ -312,6 +417,11 @@ func TestNativeKeys_ModelOverridesIncludeClaudeCodeVersionKeys(t *testing.T) {
 	for _, key := range []string{"opus", "claude-opus-4-8", "anthropic.claude-opus-4-8"} {
 		if overrides[key] != "global.anthropic.claude-opus-4-8" {
 			t.Errorf("expected %s to map to global Opus profile, got %q", key, overrides[key])
+		}
+	}
+	for _, key := range []string{"fable", "claude-fable-5", "anthropic.claude-fable-5"} {
+		if overrides[key] != "global.anthropic.claude-fable-5" {
+			t.Errorf("expected %s to map to global Fable profile, got %q", key, overrides[key])
 		}
 	}
 }
@@ -386,6 +496,9 @@ func TestBuild_Mantle_StripsGlobalPrefix(t *testing.T) {
 	}
 	if block.Models.Haiku != "anthropic.claude-haiku-4-5-20251001-v1:0" {
 		t.Errorf("expected haiku without global. prefix, got %s", block.Models.Haiku)
+	}
+	if block.Models.Fable != "anthropic.claude-fable-5" {
+		t.Errorf("expected fable without global. prefix, got %s", block.Models.Fable)
 	}
 }
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -102,15 +102,20 @@ No overwriting the real Claude Code binary. No copying API keys into env vars.
 |------|-------|--------------------------|
 | **Primary** | Claude Sonnet 4.6 | `global.anthropic.claude-sonnet-4-6` |
 | **Opus** | Claude Opus 4.8 | `global.anthropic.claude-opus-4-8` |
+| **Fable alias** | Claude Fable 5 | Configure with `--fable-model=<bedrock-fable-model-id>` |
 | **Fast** | Claude Haiku 4.5 | `global.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
-Juggernaut enables Claude Code's 1M context accounting for Opus and Sonnet by appending `[1m]` to the alias environment variables. Claude Code strips the suffix before provider calls. Use `--no-1m-context` to opt out.
+Juggernaut enables Claude Code's 1M context accounting for Opus and Sonnet by appending `[1m]` to the alias environment variables, and does the same for the configured Fable alias when it matches Claude Code's Fable ID. Claude Code strips the suffix before provider calls. Use `--no-1m-context` to opt out.
 
-Override any tier: `juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6`
+Fable is exposed as an opt-in Claude Code alias. Pass `--fable-model` with a model ID that is available in your Bedrock account and region; Juggernaut does not pin a default Fable ID until one is configured.
+
+Override all aliases: `juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6`
+Override one tier: `juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>`
+Set native fallback chain: `juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-4-8,global.anthropic.claude-sonnet-4-6`
 
 ## Effort levels
 
-Controls adaptive thinking depth. Valid values: `low | medium | high | xhigh | max`
+Controls adaptive thinking depth. Valid values: `low | medium | high | xhigh | max | auto`. Fixed persisted levels (`low | medium | high | xhigh`) are written to native `effortLevel`; `max` and `auto` are env-only because Claude Code settings do not accept them as persisted `effortLevel` values. Ultracode is separate from `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`, so Juggernaut does not expose it as `--effort`.
 
 ```bash
 juggernaut apply --auth=iam --effort=max
@@ -141,6 +146,8 @@ Auto mode on Bedrock requires `CLAUDE_CODE_ENABLE_AUTO_MODE=1` — Juggernaut se
 ```bash
 --always-thinking       # enable extended thinking by default (alwaysThinkingEnabled)
 --service-tier=flex     # Bedrock service tier: default | flex | priority
+--fable-model=<id>      # override Claude Code Fable alias
+--fallback-model=a,b    # write Claude Code native fallbackModel chain
 --opusplan              # route /plan to Opus 4.8, execution to Sonnet 4.6
 --mode=auto             # auto-approve safe tool calls with background checks
 --mantle                # enable Mantle routing


### PR DESCRIPTION
## Summary

Extends the existing Bedrock Claude Code parity fix with the cleanly supported pieces from the broader refactor. The implementation follows the official Claude Code docs for permission modes, model config, environment variables, and persisted settings.

### What changed

- Keeps `--mode=auto` wired to Claude Code Auto mode with `permissions.defaultMode=auto` and `CLAUDE_CODE_ENABLE_AUTO_MODE=1`, plus the existing Bedrock warning when the active session model is not Opus 4.7/4.8.
- Adds opt-in Fable alias support via `--fable-model` / `models.fable`. Juggernaut does not pin an unverified default Bedrock Fable ID; it only emits Fable env metadata and native aliases when a user configures a Bedrock-accessible model ID.
- Adds `--fallback-model=a,b` to write Claude Code's native `fallbackModel` array, preserves ordering, rejects empty entries, records the chain in Juggernaut metadata, and removes it cleanly on uninstall.
- Accepts `--effort=auto` through `CLAUDE_CODE_EFFORT_LEVEL` while keeping `max` and `auto` out of persisted `effortLevel`, because persisted settings only support fixed levels.
- Intentionally rejects `--effort=ultracode`; Claude Code treats Ultracode as a separate session setting, not an effort level.
- Replaces stale/no-op telemetry variables with the documented `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` setting.
- Updates README, npm README, changelog, internal notes, and `bedrock-config.json` to document the exact Bedrock-safe behavior.

### Root cause / rationale

The original auto-mode symptom was not just a settings write issue. On Bedrock, Claude Code also requires `CLAUDE_CODE_ENABLE_AUTO_MODE=1` and an active Opus 4.7/4.8 session model before Auto mode is exposed. Separately, the broader parity work needed to avoid inventing Bedrock support where no clean model ID or persisted Claude Code setting exists, so Fable is configurable rather than default-pinned and Ultracode is not exposed as `--effort`.

## Validation

- `git diff --check`
- `npm test` from `npm/`
- `go test ./...`
- `go vet ./...`
- `go build ./...`

## Notes

Existing scratch/research files in the worktree were left untracked and are not part of this PR.