### PR TITLE
fix(ci): update actions/cache SHA in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: "1.26"
 
-      - uses: actions/cache@0c907a854f007fb01a9d7b5c060e6593ce0b0e94  # v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}


### PR DESCRIPTION
The actions/cache SHA in the release workflow is invalid, causing the v5.2.2 release to fail. This pins it to the correct v4 SHA.