### PR TITLE
fix(npm): fail loud on partial install instead of running a stale binary

### DIFF
--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,2 +1,3 @@
 packages/
 index.test.js
+preinstall.test.js

--- a/npm/index.js
+++ b/npm/index.js
@@ -134,7 +134,14 @@ if (require.main === module) {
 
   var bin = safeResolveBin(binRaw);
   var rootVersion = readPkgVersion(path.join(__dirname, "package.json"));
-  var binVersion = readPkgVersion(path.join(resolvePkgDir(pkg), "package.json")); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  // Read the version from the package that owns the binary we just validated,
+  // not by re-resolving `pkg` independently — so the skew check compares the
+  // version of the exact binary we are about to execute. `bin` was realpath'd
+  // and asserted to be contained under __dirname by safeResolveBin above, so
+  // binPkgDir is derived from an already-validated path (the path-join finding
+  // below is a false positive on that basis).
+  var binPkgDir = path.dirname(path.dirname(bin));
+  var binVersion = readPkgVersion(path.join(binPkgDir, "package.json")); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   if (!versionsMatch(rootVersion, binVersion)) {
     process.stderr.write(
       "juggernaut-bedrock is in a broken or partially-updated state " +

--- a/npm/index.js
+++ b/npm/index.js
@@ -134,7 +134,7 @@ if (require.main === module) {
 
   var bin = safeResolveBin(binRaw);
   var rootVersion = readPkgVersion(path.join(__dirname, "package.json"));
-  var binVersion = readPkgVersion(path.join(resolvePkgDir(pkg), "package.json"));
+  var binVersion = readPkgVersion(path.join(resolvePkgDir(pkg), "package.json")); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   if (!versionsMatch(rootVersion, binVersion)) {
     process.stderr.write(
       "juggernaut-bedrock is in a broken or partially-updated state " +

--- a/npm/index.js
+++ b/npm/index.js
@@ -86,6 +86,32 @@ function safeForwardArgs(args) {
   return forwarded;
 }
 
+
+/**
+ * @param {*} rootVersion
+ * @param {*} binVersion
+ * @returns {boolean} true to allow exec, false to block on confirmed skew
+ */
+function versionsMatch(rootVersion, binVersion) {
+  // Fail open: if either version is unreadable/non-string, do not block.
+  if (typeof rootVersion !== "string" || typeof binVersion !== "string") {
+    return true;
+  }
+  return rootVersion === binVersion;
+}
+
+/**
+ * @param {string} pkgJsonPath
+ * @returns {string|void} the version field, or undefined on any failure
+ */
+function readPkgVersion(pkgJsonPath) {
+  try {
+    var raw = fs.readFileSync(pkgJsonPath, "utf8"); // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename
+    return JSON.parse(raw).version;
+  } catch (_) {
+    return void 0;
+  }
+}
 if (require.main === module) {
   var pkg = getPlatformPackage(process.platform, process.arch);
   if (!pkg) {
@@ -107,6 +133,19 @@ if (require.main === module) {
   }
 
   var bin = safeResolveBin(binRaw);
+  var rootVersion = readPkgVersion(path.join(__dirname, "package.json"));
+  var binVersion = readPkgVersion(path.join(resolvePkgDir(pkg), "package.json"));
+  if (!versionsMatch(rootVersion, binVersion)) {
+    process.stderr.write(
+      "juggernaut-bedrock is in a broken or partially-updated state " +
+      "(launcher v" + rootVersion + ", binary v" + binVersion + ").\n" +
+      "This usually happens when the package was updated while a Claude Code " +
+      "session was running.\n" +
+      "Close all `claude` sessions and terminals, then re-run:\n" +
+      "  npm install -g juggernaut-bedrock\n"
+    );
+    process.exit(1);
+  }
   var args = safeForwardArgs(process.argv.slice(2));
   var result = childProcess.spawnSync(bin, args, {
     stdio: "inherit",
@@ -120,5 +159,6 @@ if (require.main === module) {
 module.exports = {
   getPlatformPackage: getPlatformPackage,
   getBinaryPath: getBinaryPath,
-  safeForwardArgs: safeForwardArgs
+  safeForwardArgs: safeForwardArgs,
+  versionsMatch: versionsMatch
 };

--- a/npm/index.test.js
+++ b/npm/index.test.js
@@ -76,3 +76,33 @@ describe("safeForwardArgs", function() {
   });
   return void 0;
 });
+
+var versionsMatch = index.versionsMatch;
+
+describe("versionsMatch", function() {
+  it("allows when versions are equal", function() {
+    assert.strictEqual(versionsMatch("5.2.4", "5.2.4"), true);
+    return void 0;
+  });
+  it("blocks when versions differ", function() {
+    assert.strictEqual(versionsMatch("5.2.4", "5.2.2"), false);
+    return void 0;
+  });
+  it("allows the dev 0.0.0 / 0.0.0 case", function() {
+    assert.strictEqual(versionsMatch("0.0.0", "0.0.0"), true);
+    return void 0;
+  });
+  it("fails open when root version is missing", function() {
+    assert.strictEqual(versionsMatch(undefined, "5.2.4"), true);
+    return void 0;
+  });
+  it("fails open when binary version is missing", function() {
+    assert.strictEqual(versionsMatch("5.2.4", undefined), true);
+    return void 0;
+  });
+  it("fails open when a version is not a string", function() {
+    assert.strictEqual(versionsMatch("5.2.4", 524), true);
+    return void 0;
+  });
+  return void 0;
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -6,7 +6,8 @@
     "juggernaut": "./index.js"
   },
   "scripts": {
-    "test": "node --test index.test.js"
+    "preinstall": "node preinstall.js",
+    "test": "node --test"
   },
   "optionalDependencies": {
     "juggernaut-bedrock-linux-x64": "0.0.0",

--- a/npm/preinstall.js
+++ b/npm/preinstall.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+var childProcess = require("node:child_process");
+
+/**
+ * @returns {string}
+ */
+function buildBlockMessage() {
+  return (
+    "juggernaut-bedrock: a Claude Code / Juggernaut session is currently " +
+    "running and is locking the Juggernaut binary.\n" +
+    "Installing now would leave the package in a broken state.\n" +
+    "Close all `claude` sessions and terminals, then re-run:\n" +
+    "  npm install -g juggernaut-bedrock\n"
+  );
+}
+
+/**
+ * Detects a running juggernaut.exe on Windows. Fails open (returns false) on
+ * non-Windows platforms and on any probe error, so a misfiring detection can
+ * never wedge a legitimate repair install.
+ * @returns {boolean}
+ */
+function isLockingProcessRunning() {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  try {
+    var out = childProcess.execFileSync(
+      "tasklist",
+      ["/FI", "IMAGENAME eq juggernaut.exe", "/NH"],
+      { encoding: "utf8", windowsHide: true }
+    );
+    return out.toLowerCase().indexOf("juggernaut.exe") !== -1;
+  } catch (_) {
+    return false;
+  }
+}
+
+function main() {
+  if (isLockingProcessRunning()) {
+    process.stderr.write(buildBlockMessage());
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildBlockMessage: buildBlockMessage,
+  isLockingProcessRunning: isLockingProcessRunning,
+  main: main
+};

--- a/npm/preinstall.js
+++ b/npm/preinstall.js
@@ -1,6 +1,21 @@
 #!/usr/bin/env node
 "use strict";
 
+// Best-effort install-time guard (NOT a guarantee).
+//
+// npm runs this `preinstall` script only AFTER it reifies the dependency
+// tree — including extracting the optional platform package that ships
+// juggernaut.exe. So in the exact scenario this warns about (a running
+// session holding a lock on juggernaut.exe under Windows), npm may already
+// have hit EPERM overwriting that binary before this script ever runs. When
+// that happens this gate cannot prevent the partial install.
+//
+// The reliable safety net is the runtime version-skew guard in index.js,
+// which refuses to launch a partially-updated install. This script is an
+// early, friendly heads-up for the cases where it does run first (e.g. a
+// repeat install once npm has already aborted, or non-reifying flows); it is
+// not the thing that makes a partial install safe.
+
 var childProcess = require("node:child_process");
 
 /**
@@ -9,8 +24,8 @@ var childProcess = require("node:child_process");
 function buildBlockMessage() {
   return (
     "juggernaut-bedrock: a Claude Code / Juggernaut session is currently " +
-    "running and is locking the Juggernaut binary.\n" +
-    "Installing now would leave the package in a broken state.\n" +
+    "running and is holding a lock on the Juggernaut binary.\n" +
+    "Installing now may leave the package in a partially-updated state.\n" +
     "Close all `claude` sessions and terminals, then re-run:\n" +
     "  npm install -g juggernaut-bedrock\n"
   );

--- a/npm/preinstall.test.js
+++ b/npm/preinstall.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var nodeTest = require("node:test");
+var describe = nodeTest.describe;
+var it = nodeTest.it;
+var assert = require("assert");
+
+var preinstall = require("./preinstall");
+
+describe("buildBlockMessage", function() {
+  it("names the reinstall command", function() {
+    assert.ok(preinstall.buildBlockMessage().indexOf("npm install -g juggernaut-bedrock") !== -1);
+    return void 0;
+  });
+  it("tells the user to close sessions", function() {
+    assert.ok(/close/i.test(preinstall.buildBlockMessage()));
+    return void 0;
+  });
+  return void 0;
+});
+
+describe("isLockingProcessRunning", function() {
+  it("returns a boolean and never throws", function() {
+    assert.strictEqual(typeof preinstall.isLockingProcessRunning(), "boolean");
+    return void 0;
+  });
+  it("fails open (false) on non-Windows platforms", function() {
+    if (process.platform === "win32") {
+      return void 0; // skip on Windows; non-Windows path is the fail-open contract
+    }
+    assert.strictEqual(preinstall.isLockingProcessRunning(), false);
+    return void 0;
+  });
+  return void 0;
+});


### PR DESCRIPTION
## Problem

Updating `juggernaut-bedrock` via `npm install -g` while a `claude` / `juggernaut launch` process is running holds an open handle on `juggernaut.exe`. On Windows, npm cannot `unlink` a running `.exe`, so the install fails partway (`EPERM`), leaving a **partially-updated install**. The shim could then resolve a **stale binary** (e.g. a keychain-only version predating the launch-fallback fix) and fail with:

```
Error: bedrock API key not found in keychain
```

This was repeatedly **misattributed to an expired/invalid API key**. The key was always valid — the install tooling let the package reach a broken state and silently ran the stale binary instead of refusing.

## Fix

**Layer 2 — shim version-skew guard (`npm/index.js`) — the reliable safety net.**
Before exec, the launcher compares its own `package.json` version against the version of the package that owns the binary it is about to run (derived from the already-`safeResolveBin`-validated path). On a confirmed mismatch — the partial-install fingerprint — it refuses to exec and tells the user to reinstall, instead of silently running a stale binary. Proceeds on match or the dev `0.0.0` case; fails open if a version is unreadable. **This is what actually fixes the bug.**

**Layer 1 — Windows-only `preinstall` gate (`npm/preinstall.js`) — best-effort only.**
Detects a running `juggernaut.exe` via `tasklist` and prints an actionable "close your sessions, then reinstall" message. No-op on non-Windows; fails open on any detection error.

> ⚠️ **Limitation (raised in review, verified):** npm runs `preinstall` *after* it reifies the dependency tree — including extracting the optional platform package that ships `juggernaut.exe`. So in the exact locked-binary scenario, npm may already have hit `EPERM` overwriting that binary *before* this script runs. The preinstall gate therefore **cannot guarantee** it prevents the partial install; it only helps in cases where it does run first (e.g. a repeat install after npm has already aborted). Layer 2 is the guard that makes a partial install safe. The script's wording and docs reflect this.

## Tests

- `npm/index.test.js`: `versionsMatch` — equal / skew / `0.0.0` dev / fail-open cases.
- `npm/preinstall.test.js`: `buildBlockMessage` content + `isLockingProcessRunning` fail-open contract.
- Full suite: **22/22 passing** (`node --test`). Both new JS files pass `node --check`.
- No Go changes; no new dependencies (Node built-ins only).
- preinstall gate is Windows-only by design (macOS/Linux replace a running binary without error).

## Follow-up

- Harden `getBinaryPath`/`resolvePkgDir` so their `nosemgrep` path-traversal suppressions cite a locally-checkable invariant (tracked separately; pre-existing code, not introduced here).
