### PR TITLE
fix(npm): make resolvePkgDir self-defending so its path-traversal suppression is honest

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -40,13 +40,21 @@ function containsPackage(pkgName) {
 }
 
 /**
+ * Resolves the directory of a platform package. Self-defending: it rejects any
+ * name not in the VALID_PACKAGES allowlist before building a path, so the
+ * fallback path.join below can only ever join a known constant package name
+ * (no separators, no "..") under __dirname and cannot be made to escape it.
  * @param {string} pkgName
  * @returns {string}
  */
 function resolvePkgDir(pkgName) {
+  if (!containsPackage(pkgName)) {
+    throw new Error("unexpected package name: " + pkgName);
+  }
   try {
     return path.dirname(require.resolve(pkgName + "/package.json"));
   } catch (_) {
+    // pkgName is allowlist-validated above, so this join stays under __dirname.
     return path.join(__dirname, "packages", pkgName); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   }
 }
@@ -56,6 +64,8 @@ function getBinaryPath(pkgName, platform) {
     throw new Error("unexpected package name: " + pkgName);
   }
   var binaryName = platform === "win32" ? "juggernaut.exe" : "juggernaut";
+  // pkgName validated above and again inside resolvePkgDir; binaryName is a
+  // local constant. The joined path therefore cannot escape the package dir.
   return path.join(resolvePkgDir(pkgName), "bin", binaryName); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
 }
 
@@ -166,6 +176,7 @@ if (require.main === module) {
 module.exports = {
   getPlatformPackage: getPlatformPackage,
   getBinaryPath: getBinaryPath,
+  resolvePkgDir: resolvePkgDir,
   safeForwardArgs: safeForwardArgs,
   versionsMatch: versionsMatch
 };

--- a/npm/index.test.js
+++ b/npm/index.test.js
@@ -9,6 +9,7 @@ var assert = require("assert");
 var index = require("./index");
 var getPlatformPackage = index.getPlatformPackage;
 var getBinaryPath = index.getBinaryPath;
+var resolvePkgDir = index.resolvePkgDir;
 var safeForwardArgs = index.safeForwardArgs;
 
 describe("getPlatformPackage", function() {
@@ -57,6 +58,27 @@ describe("getBinaryPath", function() {
   it("path is under npm/packages/", function() {
     var result = getBinaryPath("juggernaut-bedrock-darwin-arm64", "darwin");
     assert.ok(result.includes(path.join("packages", "juggernaut-bedrock-darwin-arm64")));
+    return void 0;
+  });
+  it("rejects an unknown package name", function() {
+    assert.throws(function() {
+      getBinaryPath("../../etc/passwd", "linux");
+    }, /unexpected package name/);
+    return void 0;
+  });
+  return void 0;
+});
+
+describe("resolvePkgDir", function() {
+  it("resolves a known package name", function() {
+    var result = resolvePkgDir("juggernaut-bedrock-linux-x64");
+    assert.ok(result.includes("juggernaut-bedrock-linux-x64"));
+    return void 0;
+  });
+  it("rejects an unknown package name (self-defending, not just via getBinaryPath)", function() {
+    assert.throws(function() {
+      resolvePkgDir("../../etc/passwd");
+    }, /unexpected package name/);
     return void 0;
   });
   return void 0;


### PR DESCRIPTION
## Background

Follow-up to #222. During that review we hardened the version-skew read to derive its path from an already-validated value. This PR addresses the *other* lazy line flagged in the same review: `resolvePkgDir`'s `nosemgrep` suppression asserted a safety it did not locally guarantee.

## Problem

`resolvePkgDir(pkgName)` joined `pkgName` into a filesystem path (`path.join(__dirname, "packages", pkgName)`) with **no local validation** — it trusted whoever called it. The allowlist check (`containsPackage`) lived only in `getBinaryPath`. So the `// nosemgrep: ...path-join-resolve-traversal` on that line was a hand-wave: the justification depended on a check in a different function.

## Fix

Make `resolvePkgDir` **self-defending**: validate `pkgName` against the `VALID_PACKAGES` allowlist at the top of the function, before building any path. This is defense-in-depth (redundant with `getBinaryPath`'s check; no happy-path behavior change — `pkg` always comes from the hardcoded `PLATFORM_MAP`), and it makes each function independently safe.

Both suppression comments now cite a **locally-checkable invariant**: an allowlisted constant package name (no path separators, no `..`), joined under `__dirname`, cannot escape the package directory.

## Tests

- `resolvePkgDir`: resolves a known name; **rejects** an unknown/traversing name (`../../etc/passwd`) — proving it's self-defending, not reliant on `getBinaryPath`.
- `getBinaryPath`: added an explicit rejection test for an unknown name.
- Full suite: **25/25 passing** (`node --test`); `node --check` clean.
- Live launch path verified unchanged (resolves `win32-x64`, no regression).
- No new dependencies; Node built-ins only.
