### PR TITLE
fix(release): publish GitHub release automatically on tag push

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,4 +48,10 @@ release:
     owner: jpvelasco
     name: juggernaut
   name_template: "v{{.Version}}"
-  draft: true
+  # Publish the GitHub release immediately on tag push. With draft: true,
+  # GoReleaser uploads assets but leaves the release unpublished, and nothing
+  # in release.yml un-drafts it — so every release since #212 required a manual
+  # `gh release edit --draft=false`. The npm publish steps run regardless, which
+  # masked the broken GitHub-release half. Keep this false so a tag push fully
+  # publishes with no manual step.
+  draft: false


### PR DESCRIPTION
## Problem

The release is **not fully automatic** — and hasn't been since PR #212 (2026-06-27).

PR #212 added `draft: true` to `.goreleaser.yml`. GoReleaser honors that by uploading the build assets to an **unpublished draft** release and stopping there. Nothing in `release.yml` (or any other workflow/script) un-drafts it — `release.yml` only triggers `on: push: tags` and has no publish step.

The npm publish steps run regardless, so npm always showed the correct `latest` version. That masked the broken half: **every GitHub release since #212 has been left as a draft** and required a manual `gh release edit --draft=false` to go public. Most recently, v5.2.6 landed as a draft for exactly this reason.

### Evidence

- `git show 1b1b8ab` (#212) — the diff that added `draft: true`; there was no draft line before it.
- GoReleaser logs for both v5.2.5 and v5.2.6 print identical `publishing` / `release succeeded` lines — "succeeded" means *assets uploaded to the draft*, not *published*.
- `v5.2.1` is still sitting as `draft=true` in the releases API — an un-drafted one that was never manually published.

## Fix

Set `draft: false` so a `v*` tag push fully publishes the GitHub release with no manual step — restoring the pre-#212 behavior. Single-line change (plus an explanatory comment).

## Scope / risk

- Does **not** touch the already-published v5.2.6.
- Affects only future releases: the next tag push will publish its GitHub release directly.
- npm publishing is unchanged.

## Alternative considered

If a pre-publish review gate on release notes was *intended*, the fix would instead be to add an automated `gh release edit "v${VERSION}" --draft=false --latest` step to `release.yml`. Going with `draft: false` per the "it's all supposed to be automatic" intent — easy to switch approaches if you'd rather keep the gate.