### PR TITLE
fix(ci): harden release pipeline against draft-only GoReleaser config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
             exit 1
           fi
           echo "Version sync OK: $FILE_VERSION"
+      - name: Verify GoReleaser auto-publishes releases
+        run: |
+          if grep -qE '^\s*draft:\s*true' .goreleaser.yml; then
+            echo "ERROR: .goreleaser.yml has draft: true; .github/workflows/release.yml does not un-draft releases"
+            exit 1
+          fi
+          echo "GoReleaser draft check OK"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee  # v9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify GitHub release is published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          DRAFT=$(gh release view "$TAG" --json isDraft -q .isDraft)
+          if [ "$DRAFT" != "false" ]; then
+            echo "ERROR: release $TAG is still a draft — aborting before npm publish"
+            exit 1
+          fi
+          ASSETS=$(gh release view "$TAG" --json assets -q '.assets | length')
+          if [ "$ASSETS" -lt 6 ]; then
+            echo "ERROR: release $TAG has $ASSETS assets, expected at least 6 (5 archives + checksums.txt)"
+            exit 1
+          fi
+          echo "GitHub release $TAG is published with $ASSETS assets"
+
       - name: Copy platform binaries into npm sub-packages
         run: bash scripts/copy-npm-binaries.sh
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,10 +48,6 @@ release:
     owner: jpvelasco
     name: juggernaut
   name_template: "v{{.Version}}"
-  # Publish the GitHub release immediately on tag push. With draft: true,
-  # GoReleaser uploads assets but leaves the release unpublished, and nothing
-  # in release.yml un-drafts it — so every release since #212 required a manual
-  # `gh release edit --draft=false`. The npm publish steps run regardless, which
-  # masked the broken GitHub-release half. Keep this false so a tag push fully
-  # publishes with no manual step.
+  # Must stay false: .github/workflows/release.yml has no un-draft step; draft:true
+  # left GitHub releases unpublished while npm still published (since #212).
   draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Juggernaut will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release pipeline hardening (follow-up to #226).** CI now fails if `.goreleaser.yml` sets `draft: true`, and `release.yml` verifies the GitHub release is published with assets before npm publish — so a draft-only GoReleaser config cannot silently ship npm while GitHub releases stay hidden.
+
 ## [5.2.6] - 2026-06-28
 
 **Patch release — clean npm install output: drop the redundant `preinstall` script.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Version must stay in sync across **three** locations: `VERSION`, `bedrock-config
 ## CI / Release
 
 - CI (`ci.yml`): lint + version sync check → `go test ./... -v` on ubuntu/macos/windows → race detector → coverage (52% threshold) → npm tests → shellcheck → gosec. Actions pinned to full commit SHAs. Go module cache is shared across jobs.
-- Release (`release.yml`): triggered on `v*` tags → GoReleaser builds binaries → npm OIDC publish to `juggernaut-bedrock`.
+- Release (`release.yml`): triggered on `v*` tags → GoReleaser builds and **publishes** the GitHub release (`draft: false` in `.goreleaser.yml`; CI fails on `draft: true`) → verifies the release is non-draft with assets before npm → npm OIDC publish to `juggernaut-bedrock`.
 - GoReleaser requires a clean git tree — never commit build artifacts (`bin/` is gitignored).
 - npm package is in `npm/` — optional platform sub-packages ship prebuilt binaries; `npm/index.js` resolves and execs the matching package.
 


### PR DESCRIPTION
## Summary

Follow-up to #226. That PR fixed the immediate bug (\draft: false\ in GoReleaser), but the pipeline still had no guardrails — a future \draft: true\ revert would silently ship npm while GitHub releases stayed hidden.

## Changes

- **CI lint** (\ci.yml\): fail if \.goreleaser.yml\ sets \draft: true\
- **Release verification** (\elease.yml\): after GoReleaser, assert the GitHub release is published (\isDraft == false\) with at least 6 assets before npm publish
- **Docs**: shortened \.goreleaser.yml\ comment, updated \CLAUDE.md\ release section, \CHANGELOG.md\ entry

## Housekeeping (done outside this diff)

Deleted two orphan draft releases left over from the #212 regression:
- \5.2.1 - PowerShell profile discovery fix\ (duplicate on tag \5.2.1\)
- \4.0.0\ (duplicate on tag \4.0.0\)

## Not included

- \goreleaser check\ in CI — blocked by pre-existing \rchives.format\ deprecation (would fail today)