### PR TITLE
fix(apply): preserve externally-set permission mode on re-apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -318,6 +318,17 @@ func resolveApplyInputs(home string, bCfg *bedrock.Config) (authMode, region str
 					}
 				}
 			}
+			// Also adopt a permission mode set outside Juggernaut (e.g. Claude
+			// Code's Shift+Tab writes native permissions.defaultMode without
+			// touching our meta block). Without this, a re-apply with no --mode
+			// would wipe the user's externally-chosen mode.
+			if applyFlags.mode == "" {
+				if perms, ok := existing["permissions"].(map[string]any); ok {
+					if dmode, ok := perms["defaultMode"].(string); ok && dmode != "" {
+						applyFlags.mode = dmode
+					}
+				}
+			}
 		}
 		if authMode == "" {
 			authMode = bCfg.Defaults.AuthMode

--- a/cmd/apply_permmode_test.go
+++ b/cmd/apply_permmode_test.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+)
+
+// setNativeDefaultMode rewrites settings.json setting permissions.defaultMode,
+// simulating an external editor (e.g. Claude Code's Shift+Tab) that touches the
+// native key without updating Juggernaut's meta block.
+func setNativeDefaultMode(t *testing.T, home, mode string) {
+	t.Helper()
+	var settings map[string]any
+	if err := json.Unmarshal(readSettingsJSON(t, home), &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	perms, ok := settings["permissions"].(map[string]any)
+	if !ok {
+		perms = map[string]any{}
+		settings["permissions"] = perms
+	}
+	perms["defaultMode"] = mode
+	b, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatalf("marshaling settings.json: %v", err)
+	}
+	if err := safepath.WriteFile(home, filepath.Join(home, ".claude", "settings.json"), b); err != nil {
+		t.Fatalf("writing settings.json: %v", err)
+	}
+}
+
+// readJuggernautPermissionMode returns the persisted meta.permissionMode from
+// the user-scope settings.json juggernaut block ("" if absent).
+func readJuggernautPermissionMode(t *testing.T, home string) string {
+	t.Helper()
+	var settings map[string]any
+	if err := json.Unmarshal(readSettingsJSON(t, home), &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	block, ok := settings["juggernaut"].(map[string]any)
+	if !ok {
+		t.Fatal("missing juggernaut block")
+	}
+	meta, ok := block["meta"].(map[string]any)
+	if !ok {
+		t.Fatal("missing meta in juggernaut block")
+	}
+	mode, _ := meta["permissionMode"].(string)
+	return mode
+}
+
+// readNativeDefaultMode returns the native permissions.defaultMode from
+// settings.json ("" if absent).
+func readNativeDefaultMode(t *testing.T, home string) string {
+	t.Helper()
+	var settings map[string]any
+	if err := json.Unmarshal(readSettingsJSON(t, home), &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	perms, ok := settings["permissions"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	mode, _ := perms["defaultMode"].(string)
+	return mode
+}
+
+// readNativeEnvValue returns settings.json env[key] ("" if absent).
+func readNativeEnvValue(t *testing.T, home, key string) string {
+	t.Helper()
+	var settings map[string]any
+	if err := json.Unmarshal(readSettingsJSON(t, home), &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	env, ok := settings["env"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := env[key].(string)
+	return v
+}
+
+// TestApply_ReapplyWithoutMode_PreservesAutoMode is the regression for #231:
+// applying with --mode=auto then re-applying WITHOUT --mode must preserve the
+// auto permission mode and its CLAUDE_CODE_ENABLE_AUTO_MODE env var.
+func TestApply_ReapplyWithoutMode_PreservesAutoMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	// First apply pins auto mode.
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--mode=auto", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("first apply error: %v", err)
+	}
+	if got := readJuggernautPermissionMode(t, home); got != "auto" {
+		t.Fatalf("after first apply, permissionMode = %q, want %q", got, "auto")
+	}
+	if got := readNativeDefaultMode(t, home); got != "auto" {
+		t.Fatalf("after first apply, defaultMode = %q, want %q", got, "auto")
+	}
+	if got := readNativeEnvValue(t, home, "CLAUDE_CODE_ENABLE_AUTO_MODE"); got != "1" {
+		t.Fatalf("after first apply, CLAUDE_CODE_ENABLE_AUTO_MODE = %q, want %q", got, "1")
+	}
+
+	// Re-apply WITHOUT --mode (e.g. a routine effort/model tweak).
+	if err := ExecuteArgs([]string{
+		"apply", "--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("re-apply error: %v", err)
+	}
+
+	if got := readJuggernautPermissionMode(t, home); got != "auto" {
+		t.Errorf("re-apply without --mode changed permissionMode to %q, want %q (preserved)", got, "auto")
+	}
+	if got := readNativeDefaultMode(t, home); got != "auto" {
+		t.Errorf("re-apply without --mode changed defaultMode to %q, want %q (preserved)", got, "auto")
+	}
+	if got := readNativeEnvValue(t, home, "CLAUDE_CODE_ENABLE_AUTO_MODE"); got != "1" {
+		t.Errorf("re-apply without --mode dropped CLAUDE_CODE_ENABLE_AUTO_MODE (got %q, want %q)", got, "1")
+	}
+}
+
+// TestApply_ReapplyPreservesExternallySetMode is the true regression for #231:
+// a mode set OUTSIDE Juggernaut (e.g. Claude Code's Shift+Tab writes the native
+// permissions.defaultMode but not Juggernaut's meta block) must survive a
+// routine re-apply that omits --mode. Previously mergePermissions deleted the
+// native defaultMode whenever Juggernaut had no --mode opinion.
+func TestApply_ReapplyPreservesExternallySetMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	// First apply with no permission mode (Juggernaut asserts nothing).
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("first apply error: %v", err)
+	}
+
+	// Simulate the user enabling auto via Claude Code Shift+Tab: it edits the
+	// native permissions.defaultMode directly and does not touch Juggernaut's
+	// meta block.
+	setNativeDefaultMode(t, home, "auto")
+
+	// Routine re-apply with no --mode (e.g. a region/effort tweak).
+	if err := ExecuteArgs([]string{
+		"apply", "--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("re-apply error: %v", err)
+	}
+
+	if got := readNativeDefaultMode(t, home); got != "auto" {
+		t.Errorf("re-apply wiped externally-set defaultMode: got %q, want %q", got, "auto")
+	}
+	if got := readNativeEnvValue(t, home, "CLAUDE_CODE_ENABLE_AUTO_MODE"); got != "1" {
+		t.Errorf("re-apply did not restore CLAUDE_CODE_ENABLE_AUTO_MODE for adopted auto mode (got %q)", got)
+	}
+}
+
+// TestApply_ExplicitModeOverridesExternalMode confirms preservation only kicks
+// in when --mode is omitted: an explicit --mode=default must still override an
+// externally-set auto mode (and clear its env var).
+func TestApply_ExplicitModeOverridesExternalMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("first apply error: %v", err)
+	}
+	setNativeDefaultMode(t, home, "auto")
+
+	// Explicit --mode=default must win over the externally-set auto.
+	if err := ExecuteArgs([]string{
+		"apply", "--region=us-west-2", "--mode=default", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("re-apply --mode=default error: %v", err)
+	}
+
+	if got := readNativeDefaultMode(t, home); got != "default" {
+		t.Errorf("explicit --mode=default did not override external auto: got %q, want %q", got, "default")
+	}
+	if got := readNativeEnvValue(t, home, "CLAUDE_CODE_ENABLE_AUTO_MODE"); got != "" {
+		t.Errorf("explicit --mode=default should clear CLAUDE_CODE_ENABLE_AUTO_MODE, got %q", got)
+	}
+}


### PR DESCRIPTION
## What & why

Auto mode was silently disappearing after a routine `juggernaut apply`. Investigation (TDD-first, documented in #231) showed the original premise was wrong and found the real root cause:

- **Not a bug:** re-applying without `--mode` already preserves a mode *Juggernaut itself* set — `resolveApplyInputs` reads `meta.permissionMode` back (shipped v4.1.0). Verified with a passing round-trip test.
- **The real bug:** Claude Code's **Shift+Tab** writes the *native* `permissions.defaultMode` directly and never touches Juggernaut's `meta` block. So on a re-apply with no `--mode`, `meta.permissionMode` is empty, the existing preservation finds nothing, and `mergePermissions` (config/manager.go) **deletes** the native `defaultMode` — taking `CLAUDE_CODE_ENABLE_AUTO_MODE` with it. That exactly matches the observed live state (`defaultMode: default`, no env var).

## The fix

In `resolveApplyInputs`, when `--mode` is omitted **and** Juggernaut's own `meta.permissionMode` is empty, adopt the existing native `permissions.defaultMode`. The adopted mode then flows through `schema.Build` (re-sets `CLAUDE_CODE_ENABLE_AUTO_MODE` for auto) and the merge (re-writes the native key). Mirrors the existing `--auth` preservation pattern. Fixing only the merge layer would leave auto half-broken on Bedrock (native key present, env var missing).

Explicit `--mode=X` still overrides; only omission preserves.

## Tests (TDD, RED verified first)

- **`TestApply_ReapplyPreservesExternallySetMode`** — the real regression: external Shift+Tab sets auto → re-apply with no `--mode` → mode preserved **and** env var restored. (Failed before the fix.)
- **`TestApply_ReapplyWithoutMode_PreservesAutoMode`** — Juggernaut-set auto still round-trips.
- **`TestApply_ExplicitModeOverridesExternalMode`** — explicit `--mode=default` still overrides a preserved mode and clears the env var.

Full suite green; `gofmt`/`go vet` clean. `cmd` coverage 76.6% → 76.8% (previously-untested preservation path now covered).

Fixes #231
