### PR TITLE
fix(apply): make dead flags honest (--no-opusplan guard, --skip-preflight no-op)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -48,7 +48,6 @@ var applyFlags struct {
 	mantleURL      string
 	scope          string
 	dryRun         bool
-	skipPreflight  bool
 	mode           string
 	alwaysThinking bool
 	serviceTier    string
@@ -79,7 +78,11 @@ func init() {
 	f.StringVar(&applyFlags.mantleURL, "mantle-url", "", "custom Mantle base URL")
 	f.StringVar(&applyFlags.scope, "scope", "user", "settings scope: user or project")
 	f.BoolVar(&applyFlags.dryRun, "dry-run", false, "preview without writing")
-	f.BoolVar(&applyFlags.skipPreflight, "skip-preflight", false, "skip dependency checks")
+	// Deprecated: --skip-preflight never gated any check and is now a no-op.
+	// Kept hidden for script compatibility.
+	var deprecatedSkipPreflight bool
+	f.BoolVar(&deprecatedSkipPreflight, "skip-preflight", false, "")
+	_ = f.MarkHidden("skip-preflight")
 	f.StringVar(&applyFlags.mode, "mode", "", "permission mode: default|acceptEdits|plan|auto|dontAsk|bypassPermissions")
 	f.BoolVar(&applyFlags.alwaysThinking, "always-thinking", false, "enable extended thinking by default")
 	f.StringVar(&applyFlags.serviceTier, "service-tier", "", "Bedrock service tier: default|flex|priority")
@@ -95,6 +98,10 @@ func runApply(_ *cobra.Command, _ []string) error {
 
 	bCfg, err := loadBedrockConfig()
 	if err != nil {
+		return err
+	}
+
+	if err := resolveOpusplanConflict(); err != nil {
 		return err
 	}
 
@@ -165,6 +172,13 @@ func resolveMantle() (bool, error) {
 		return false, fmt.Errorf("--no-mantle cannot be combined with --mantle or --mantle-url")
 	}
 	return applyFlags.mantle || applyFlags.mantleURL != "", nil
+}
+
+func resolveOpusplanConflict() error {
+	if applyFlags.noOpusplan && applyFlags.opusplan {
+		return fmt.Errorf("--no-opusplan cannot be combined with --opusplan")
+	}
+	return nil
 }
 
 func printApplyDryRun(home string) error {

--- a/cmd/apply_flags_test.go
+++ b/cmd/apply_flags_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestApply_NoOpusplanConflict verifies --no-opusplan cannot be combined with
+// --opusplan (mirrors the --no-mantle conflict guard).
+func TestApply_NoOpusplanConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2",
+		"--opusplan", "--no-opusplan", "--skip-preflight",
+	})
+	if err == nil {
+		t.Fatal("expected error when combining --opusplan and --no-opusplan")
+	}
+	if !strings.Contains(err.Error(), "--no-opusplan cannot be combined") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestApply_NoOpusplanAloneIsNoop verifies --no-opusplan by itself is accepted
+// (opusplan defaults off, so disabling it is a harmless no-op).
+func TestApply_NoOpusplanAloneIsNoop(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2",
+		"--no-opusplan", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("--no-opusplan alone should succeed, got: %v", err)
+	}
+}
+
+// TestApply_SkipPreflightAccepted verifies --skip-preflight remains accepted as
+// a no-op so existing scripts/CI passing it do not break.
+func TestApply_SkipPreflightAccepted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("--skip-preflight should be accepted as a no-op, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What & why

Two `apply` flags were registered but never read — they accepted input and did nothing (found during the review that produced #229/#230).

- **`--no-opusplan`** claimed to "disable opusplan" but was ignored: `apply --opusplan --no-opusplan` silently kept opusplan on. The sibling `--no-mantle` has a conflict guard; opusplan had none.
- **`--skip-preflight`** claimed to "skip dependency checks" but no preflight check exists in `runApply`. Vestigial — ~40 tests pass it, implying a planned step that never landed.

## The fix

- **`--no-opusplan`**: added `resolveOpusplanConflict`, mirroring `resolveMantle` — errors on `--opusplan --no-opusplan`. Alone it stays a harmless no-op (opusplan defaults off), so it remains visible in help.
- **`--skip-preflight`**: converted to a **hidden no-op**, matching the existing `--1m-context` compat pattern. Removing it outright would break scripts/CI passing it (`unknown flag`); hidden-noop is non-breaking. Now hidden from `--help` but still accepted.

## Tests (TDD, RED verified first)

- `TestApply_NoOpusplanConflict` — `--opusplan --no-opusplan` errors. (Failed before the guard.)
- `TestApply_NoOpusplanAloneIsNoop` — `--no-opusplan` alone succeeds.
- `TestApply_SkipPreflightAccepted` — `--skip-preflight` remains accepted as a no-op.

Full suite green; `gofmt`/`go vet` clean. `cmd` coverage 76.6% → 76.9%. Verified `--help` no longer shows `--skip-preflight` while `apply --skip-preflight` still runs.

Fixes #233
