### PR TITLE
test: backfill safety/logic coverage (safepath, keychain, cmd)

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -27,6 +28,27 @@ func TestHomeDir_FallsBackToUserProfile(t *testing.T) {
 	}
 	if got != "/tmp/userprofile" {
 		t.Errorf("homeDir() = %q, want USERPROFILE value", got)
+	}
+}
+
+// TestHomeDir_FallsBackToUserHomeDir covers the branch where neither HOME nor
+// USERPROFILE is set: homeDir falls through to os.UserHomeDir(). On both
+// platforms os.UserHomeDir() consults the same now-empty variable ($HOME /
+// %USERPROFILE%), so it returns an error — exercising the error branch. Either
+// a non-empty path or a descriptive error is acceptable; a silent empty string
+// is not.
+func TestHomeDir_FallsBackToUserHomeDir(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	got, err := homeDir()
+	if err != nil {
+		if !strings.Contains(err.Error(), "could not determine home directory") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+		return
+	}
+	if got == "" {
+		t.Error("homeDir() returned empty path and no error")
 	}
 }
 

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -177,6 +177,47 @@ func TestUninstall_ConfirmAbort(t *testing.T) {
 	}
 }
 
+// TestUninstall_EOFAborts verifies that closing stdin without input (e.g. Ctrl+D
+// or a closed pipe) is treated as a decline: the uninstall aborts and the block
+// survives. Covers the scanner.Scan()==false EOF branch of confirmUninstallAborted.
+func TestUninstall_EOFAborts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	var out string
+	withStdin(t, "", func() { // empty input -> EOF on first Scan
+		out = captureStdout(t, func() {
+			if err := ExecuteArgs([]string{"uninstall"}); err != nil {
+				t.Fatalf("uninstall error: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(out, "Aborted") {
+		t.Errorf("EOF on the prompt should abort, got:\n%s", out)
+	}
+	if strings.Contains(out, "Uninstall complete") {
+		t.Errorf("EOF-aborted uninstall must not complete, got:\n%s", out)
+	}
+
+	data := readSettingsJSON(t, home)
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parsing settings.json: %v", err)
+	}
+	if _, ok := settings["juggernaut"]; !ok {
+		t.Error("EOF-aborted uninstall should preserve the juggernaut block")
+	}
+}
+
 // TestUninstall_NothingInstalled is a clean no-op: uninstall on a fresh home
 // should succeed and still print completion without errors.
 func TestUninstall_NothingInstalled(t *testing.T) {

--- a/internal/keychain/boundary_test.go
+++ b/internal/keychain/boundary_test.go
@@ -1,0 +1,57 @@
+package keychain
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestIsTooBigForKeychain_ExactBoundary covers the threshold arithmetic at the
+// exact MaxWindowsKeychainSize limit. On non-Windows the function short-circuits
+// to false, so the boundary logic is Windows-only.
+func TestIsTooBigForKeychain_ExactBoundary(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("threshold branch is Windows-only")
+	}
+	atLimit := strings.Repeat("a", MaxWindowsKeychainSize)
+	overLimit := strings.Repeat("a", MaxWindowsKeychainSize+1)
+	underLimit := strings.Repeat("a", MaxWindowsKeychainSize-1)
+
+	if IsTooBigForKeychain(atLimit) {
+		t.Errorf("a token of exactly %d bytes must fit (got too-big)", MaxWindowsKeychainSize)
+	}
+	if IsTooBigForKeychain(underLimit) {
+		t.Errorf("a token of %d bytes must fit", MaxWindowsKeychainSize-1)
+	}
+	if !IsTooBigForKeychain(overLimit) {
+		t.Errorf("a token of %d bytes must be rejected", MaxWindowsKeychainSize+1)
+	}
+}
+
+// TestExtractToken_LegacyV1 covers the v1 (plaintext) credential path: the
+// prefix is stripped and the raw token returned.
+func TestExtractToken_LegacyV1(t *testing.T) {
+	got := extractTokenFromVersionedCredential([]byte(credentialVersionPrefix + "my-token"))
+	if got != "my-token" {
+		t.Errorf("v1 extract = %q, want %q", got, "my-token")
+	}
+}
+
+// TestExtractToken_UnprefixedIsReturnedRaw covers the fallback branch: data with
+// no known version prefix is returned as-is (legacy bare token).
+func TestExtractToken_UnprefixedIsReturnedRaw(t *testing.T) {
+	got := extractTokenFromVersionedCredential([]byte("bare-token"))
+	if got != "bare-token" {
+		t.Errorf("unprefixed extract = %q, want %q", got, "bare-token")
+	}
+}
+
+// TestExtractToken_V2InvalidBase64FailsClosed covers the v2 branch where the
+// body is not valid base64: the function must yield "" (no usable credential)
+// rather than leaking ciphertext.
+func TestExtractToken_V2InvalidBase64FailsClosed(t *testing.T) {
+	got := extractTokenFromVersionedCredential([]byte(credentialVersionPrefixV2 + "!!!not-base64!!!"))
+	if got != "" {
+		t.Errorf("v2 with invalid base64 must fail closed, got %q", got)
+	}
+}

--- a/internal/safepath/safepath_test.go
+++ b/internal/safepath/safepath_test.go
@@ -46,6 +46,26 @@ func TestReadWriteFileWithinBase(t *testing.T) {
 	}
 }
 
+// TestJoinUnder_RejectsImmediateParent covers the exact rel == ".." branch of
+// withinBase (going up exactly one level to the immediate parent), distinct from
+// the "../"-prefixed multi-level escape.
+func TestJoinUnder_RejectsImmediateParent(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "child")
+	if _, err := safepath.JoinUnder(base, ".."); err == nil {
+		t.Fatal("expected immediate-parent escape to be rejected")
+	}
+}
+
+// TestReadFile_RejectsAbsoluteOutsideBase covers withinBase rejecting an
+// absolute target that lives entirely outside base.
+func TestWriteFile_RejectsOutsideBase(t *testing.T) {
+	base := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "evil.txt")
+	if err := safepath.WriteFile(base, outside, []byte("x")); err == nil {
+		t.Fatal("expected write outside base to fail")
+	}
+}
+
 func TestReadFile_RejectsOutsideBase(t *testing.T) {
 	base := t.TempDir()
 	outside := filepath.Join(t.TempDir(), "outside.txt")


### PR DESCRIPTION
## What & why

A data-driven coverage sweep: I mapped every function below 100% across all packages, then (via parallel analysis) kept **only** pure-logic and safety-critical branches — deliberately skipping OS-error-injection and real-backend paths that can't be tested meaningfully without mocking the OS. No production code changes; tests only.

## Tests added

**safepath (security — path containment):**
- `withinBase` exact `rel == ".."` immediate-parent escape (distinct from the existing `../`-prefix multi-level case).
- `WriteFile` rejection of a target outside base.
- Coverage 85.7% → **90.5%**.

**keychain (safety):**
- `IsTooBigForKeychain` exact `MaxWindowsKeychainSize` boundary (2559/2560/2561) — this threshold *is* the Windows-keychain size bug; the existing test only used "short"/3000.
- `extractTokenFromVersionedCredential`: v1 plaintext, unprefixed legacy, and **fail-closed** v2-with-invalid-base64.
- **Honest note:** these are correctness assertions; the statements were already incidentally covered, so the package % is unchanged (83.2%). Kept anyway because they lock down the exact threshold + fail-closed behavior a refactor could silently break.

**cmd:**
- `homeDir` fallback when both `HOME` and `USERPROFILE` are empty (exercises the `os.UserHomeDir()` error branch; assertion is cross-platform via the wrapper's error prefix).
- `uninstall` abort on stdin **EOF** (Ctrl+D / closed pipe) — block must survive.
- Coverage 77.1% → **78.3%**.

**Total: 80.7% → 81.1%.**

## Note

While writing the `homeDir` test I hit a real platform subtlety: on Windows, empty `%USERPROFILE%` makes `os.UserHomeDir()` error rather than return a path. The test now asserts the correct cross-platform behavior (path *or* descriptive error, never silent empty) — caught because I ran it and watched it fail first.

Full suite green; `gofmt`/`go vet` clean.
