### PR TITLE
fix: dry-run credential prompt + us-gov. model prefix normalization

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -110,9 +110,15 @@ func runApply(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	token, err := resolveCredential(authMode, home)
-	if err != nil {
-		return err
+	// Skip credential resolution in dry-run mode: it can prompt interactively
+	// for a Bedrock API key, and a dry-run must have no side effects. The token
+	// is only consumed by commitApply, which dry-run never reaches.
+	var token string
+	if !applyFlags.dryRun {
+		token, err = resolveCredential(authMode, home)
+		if err != nil {
+			return err
+		}
 	}
 	useMantle, err := resolveMantle()
 	if err != nil {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -84,6 +84,36 @@ func TestApply_DryRun_BedrockAPIKey(t *testing.T) {
 	}
 }
 
+// TestApply_DryRun_BedrockAPIKey_NoPromptWithoutKey verifies dry-run is
+// non-interactive: with bedrock-api-key auth but NO --bedrock-key and no stored
+// credential, a dry-run must not trigger the interactive key prompt. We feed a
+// closed stdin (EOF); if the prompt fired it would error, and a dry-run must
+// never prompt at all. The command must succeed and write nothing.
+func TestApply_DryRun_BedrockAPIKey_NoPromptWithoutKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	var err error
+	withStdin(t, "", func() { // closed stdin: a prompt here would fail, not hang
+		err = ExecuteArgs([]string{
+			"apply",
+			"--auth=" + authmode.BedrockAPIKey,
+			"--region=us-west-2",
+			"--dry-run",
+			"--skip-preflight",
+		})
+	})
+	if err != nil {
+		t.Fatalf("dry-run must not prompt for a key; got error: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(home, ".claude", "settings.json")); !os.IsNotExist(statErr) {
+		t.Error("dry-run should not create settings.json")
+	}
+}
+
 func TestApply_WritesSettings_IAM(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -224,7 +224,7 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 // See https://code.claude.com/docs/en/permission-modes.
 func IsAutoModeCapableModel(modelID string) bool {
 	normalized := strings.TrimSuffix(modelID, "[1m]")
-	for _, prefix := range []string{"global.", "us.", "us-gov.", "eu.", "apac."} {
+	for _, prefix := range regionalInferencePrefixes {
 		normalized = strings.TrimPrefix(normalized, prefix)
 	}
 	return strings.Contains(normalized, "claude-opus-4-8") ||
@@ -240,10 +240,16 @@ func (b *Block) AutoModeUsable() bool {
 	return b.Meta.PermissionMode == "auto" && IsAutoModeCapableModel(b.Models.Sonnet)
 }
 
+// regionalInferencePrefixes are the Bedrock cross-region inference profile
+// prefixes stripped to recover the bare provider model ID. Keep this the single
+// source of truth so mantleModelID, supportsClaudeCode1M, and
+// IsAutoModeCapableModel all normalize identically.
+var regionalInferencePrefixes = []string{"global.", "us.", "us-gov.", "eu.", "apac."}
+
 func mantleModelID(model string) string {
-	for _, prefix := range []string{"global.", "us.", "eu.", "apac."} {
-		if strings.HasPrefix(model, prefix) {
-			return strings.TrimPrefix(model, prefix)
+	for _, prefix := range regionalInferencePrefixes {
+		if rest, ok := strings.CutPrefix(model, prefix); ok {
+			return rest
 		}
 	}
 	return model
@@ -258,7 +264,7 @@ func claudeCodeContextModelID(model string, use1M bool) string {
 
 func supportsClaudeCode1M(model string) bool {
 	normalized := strings.TrimSuffix(model, "[1m]")
-	for _, prefix := range []string{"global.", "us.", "eu.", "apac."} {
+	for _, prefix := range regionalInferencePrefixes {
 		normalized = strings.TrimPrefix(normalized, prefix)
 	}
 	return normalized == "opusplan" ||

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -522,6 +522,52 @@ func TestBuild_Mantle_StripsRegionalInferenceProfilePrefix(t *testing.T) {
 	}
 }
 
+// TestBuild_Mantle_StripsGovCloudPrefix covers the us-gov. regional inference
+// profile prefix, which must be stripped for Mantle routing just like us./eu./
+// apac. (previously only IsAutoModeCapableModel handled us-gov.).
+func TestBuild_Mantle_StripsGovCloudPrefix(t *testing.T) {
+	opts := schema.Options{
+		AuthMode:      "iam",
+		Region:        "us-west-2",
+		Effort:        "xhigh",
+		Scope:         "user",
+		Version:       "4.0.0",
+		AuthValidated: true,
+		UseMantle:     true,
+		SonnetModel:   "us-gov.anthropic.claude-sonnet-4-6",
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.Models.Sonnet != "anthropic.claude-sonnet-4-6" {
+		t.Errorf("expected sonnet without us-gov. prefix, got %s", block.Models.Sonnet)
+	}
+}
+
+// TestBuild_Use1M_RecognizesGovCloudOpus covers the us-gov. prefix in the 1M
+// context support check: a GovCloud Opus model must still be annotated [1m].
+func TestBuild_Use1M_RecognizesGovCloudOpus(t *testing.T) {
+	opts := schema.Options{
+		AuthMode:      "iam",
+		Region:        "us-west-2",
+		Effort:        "xhigh",
+		Scope:         "user",
+		Version:       "4.0.0",
+		AuthValidated: true,
+		Use1M:         true,
+		OpusModel:     "us-gov.anthropic.claude-opus-4-8",
+	}
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	got := block.Env["ANTHROPIC_DEFAULT_OPUS_MODEL"]
+	if got != "us-gov.anthropic.claude-opus-4-8[1m]" {
+		t.Errorf("expected GovCloud Opus annotated with [1m], got %q", got)
+	}
+}
+
 func TestBuild_NoMantle_KeepsGlobalPrefix(t *testing.T) {
 	opts := schema.Options{
 		AuthMode:      "iam",


### PR DESCRIPTION
## What & why

An adversarial multi-agent bug sweep over config/schema, activation, keychain/bedrock, and the cmd layer. Every candidate was verified by hand against the code before acting (one confidently-reported finding turned out to be a false positive — see below). Two real correctness bugs fixed, TDD.

## Bug 1 — `apply --dry-run` prompts for a Bedrock API key (Medium)

`runApply` called `resolveCredential` **before** the `--dry-run` check. So `juggernaut apply --auth=bedrock-api-key --dry-run` with no `--bedrock-key` and no stored key would pop an interactive `huh` key-entry form — during what is supposed to be a no-side-effects preview (it blocks waiting for input).

**Fix:** skip credential resolution under `--dry-run`. The token is only consumed by `commitApply`, which a dry-run never reaches.

**Test:** `TestApply_DryRun_BedrockAPIKey_NoPromptWithoutKey` runs with closed stdin — pre-fix it blocked on the prompt, post-fix it completes cleanly and writes nothing.

## Bug 2 — `us-gov.` model prefix not normalized (Low, latent)

`IsAutoModeCapableModel` stripped the `us-gov.` cross-region inference prefix, but `mantleModelID` and `supportsClaudeCode1M` did not. A GovCloud model override (`us-gov.anthropic.claude-opus-4-8`) would keep its prefix under Mantle routing and lose 1M-context detection. No current user hits it (default config is all `global.`), but it's a real inconsistency.

**Fix:** consolidated all three functions onto a single `regionalInferencePrefixes` list — one source of truth, so they can't drift again.

**Tests:** `TestBuild_Mantle_StripsGovCloudPrefix`, `TestBuild_Use1M_RecognizesGovCloudOpus`.

## What I did NOT ship (honesty)

- **Orphaned `.tmp` on `WriteFile` failure** (config manager): real but only reachable via disk-full-style faults that can't be exercised in a unit test. Shipping an untested production line would break the TDD discipline this branch follows — dropped rather than added blind.
- **PowerShell "dedup always appends"** (reported at confidence 95): **false positive.** The dedup checks `result.ActiveTargets`, which grows within the loop, so case-variant duplicates *are* caught. Verified by reading the loop; discarded.

Full suite green; `gofmt`/`go vet` clean. Also converted a `HasPrefix`+`TrimPrefix` to `CutPrefix` (lint) while consolidating.
