### PR TITLE
fix: warn about Mantle tradeoffs on apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -238,6 +238,7 @@ func commitApply(home, authMode, token string, block *schema.Block) error {
 	reportLegacyRecovery(home)
 	fmt.Println("Configuration written successfully.")
 	warnAutoModeModel(block)
+	warnMantleTradeoffs(block)
 	return nil
 }
 
@@ -273,6 +274,25 @@ func warnAutoModeModel(block *schema.Block) {
 	fmt.Println("  not support for auto mode, so auto will not appear in the Shift+Tab cycle.")
 	fmt.Println("  Run Claude Code on Opus to unlock it — launch with `claude --model opus`")
 	fmt.Println("  or switch with `/model opus` inside a session (your opus alias is pinned to Opus 4.8).")
+}
+
+// warnMantleTradeoffs alerts the user that routing through Mantle disables
+// features that native bedrock-runtime provides. Verified against AWS docs:
+// prompt caching is unavailable on the Mantle endpoints (the caching page lists
+// only Converse/InvokeModel/Prompt Management/cross-region inference), and
+// Claude reaches Mantle solely via the Anthropic Messages API, which supports
+// current-generation models only (older Opus/Sonnet remain runtime-only).
+func warnMantleTradeoffs(block *schema.Block) {
+	if !block.Meta.UseMantle {
+		return
+	}
+	fmt.Println()
+	fmt.Println("⚠ Mantle routing is enabled. Compared with native Bedrock (bedrock-runtime):")
+	fmt.Println("  • prompt caching is unavailable on Mantle — repeated context is re-read")
+	fmt.Println("    every turn, which costs more and adds latency for large codebases.")
+	fmt.Println("  • only current-generation Claude models are reachable (Sonnet 5, Opus 4.7/4.8,")
+	fmt.Println("    Haiku 4.5, Fable 5); older models stay on bedrock-runtime.")
+	fmt.Println("  Leave Mantle off unless you specifically need it (e.g. non-Anthropic models).")
 }
 
 func installActivation(home string) {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -961,3 +961,61 @@ func TestApply_NonAutoMode_NoAutoModeWarning(t *testing.T) {
 		t.Errorf("did not expect auto-mode warning for --mode=plan, got:\n%s", out)
 	}
 }
+
+func TestApply_Mantle_WarnsAboutPromptCaching(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--mantle", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "prompt caching") {
+		t.Errorf("expected Mantle warning about prompt caching, got:\n%s", out)
+	}
+}
+
+func TestApply_MantleURL_WarnsAboutPromptCaching(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2",
+			"--mantle-url=https://example.test", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "prompt caching") {
+		t.Errorf("expected Mantle warning about prompt caching with --mantle-url, got:\n%s", out)
+	}
+}
+
+func TestApply_NoMantle_NoMantleWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "prompt caching") {
+		t.Errorf("did not expect Mantle warning when Mantle is off, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What

`juggernaut apply --mantle` (and `--mantle-url`) enabled Mantle routing **silently**. Add an actionable warning, mirroring the existing `warnAutoModeModel`, so users learn what they're giving up.

## Why

Routing through Mantle instead of native `bedrock-runtime` has two real costs, both verified against AWS docs:

- **Prompt caching is unavailable on Mantle.** The [prompt-caching page](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) lists its supported surfaces as Converse/ConverseStream, InvokeModel, Prompt Management, and cross-region inference — none of the Mantle APIs (Messages/Chat Completions/Responses). A coding agent then re-reads large repo context every turn: more money, more latency.
- **Current-generation Claude only.** Claude reaches Mantle solely via the Anthropic Messages API, which supports Sonnet 5, Opus 4.7/4.8, Haiku 4.5, Fable 5; older Opus/Sonnet stay on `bedrock-runtime` (per `models-api-compatibility.html`).

Nothing told the user this. Now `apply` prints a heads-up when Mantle is on.

## New output

\`\`\`
⚠ Mantle routing is enabled. Compared with native Bedrock (bedrock-runtime):
  • prompt caching is unavailable on Mantle — repeated context is re-read
    every turn, which costs more and adds latency for large codebases.
  • only current-generation Claude models are reachable (Sonnet 5, Opus 4.7/4.8,
    Haiku 4.5, Fable 5); older models stay on bedrock-runtime.
  Leave Mantle off unless you specifically need it (e.g. non-Anthropic models).
\`\`\`

## Tests (TDD)

Written before the implementation; confirmed failing against the old silent code, then passing:

- \`TestApply_Mantle_WarnsAboutPromptCaching\` — \`--mantle\` warns
- \`TestApply_MantleURL_WarnsAboutPromptCaching\` — \`--mantle-url\` warns
- \`TestApply_NoMantle_NoMantleWarning\` — default path stays quiet (guards against unconditional warning)

Full \`cmd\` suite + \`go vet\` pass locally.

## Notes / follow-ups

- The warning fires on real \`apply\`, **not** on \`apply --mantle --dry-run\` (dry-run returns before \`commitApply\`). Surfacing it in the dry-run preview too is a reasonable follow-up.
- No version bump included — left for a separate release cut.