### PR TITLE
fix: show Mantle tradeoff warning on apply --dry-run

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -168,7 +168,7 @@ func runApply(_ *cobra.Command, _ []string) error {
 	}
 
 	if applyFlags.dryRun {
-		return printApplyDryRun(home)
+		return printApplyDryRun(home, block)
 	}
 	return commitApply(home, authMode, token, block)
 }
@@ -187,7 +187,7 @@ func resolveOpusplanConflict() error {
 	return nil
 }
 
-func printApplyDryRun(home string) error {
+func printApplyDryRun(home string, block *schema.Block) error {
 	fmt.Println("Dry run — no changes written.")
 	path, err := settingsPath(home, applyFlags.scope)
 	if err != nil {
@@ -196,6 +196,7 @@ func printApplyDryRun(home string) error {
 	fmt.Printf("Would write juggernaut block to %s\n", path)
 	fmt.Println("Would install Juggernaut Claude activation blocks in shell profiles")
 	fmt.Printf("Would recover known v4.2.6 launcher artifacts in %s\n", activation.DefaultBinDir(home))
+	warnMantleTradeoffs(block)
 	return nil
 }
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1001,6 +1001,48 @@ func TestApply_MantleURL_WarnsAboutPromptCaching(t *testing.T) {
 	}
 }
 
+func TestApply_MantleDryRun_WarnsAboutPromptCaching(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2",
+			"--mantle", "--dry-run", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Dry run — no changes written.") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "prompt caching") {
+		t.Errorf("expected Mantle warning on dry run, got:\n%s", out)
+	}
+}
+
+func TestApply_NoMantleDryRun_NoMantleWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--dry-run", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "prompt caching") {
+		t.Errorf("did not expect Mantle warning on dry run without Mantle, got:\n%s", out)
+	}
+}
+
 func TestApply_NoMantle_NoMantleWarning(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## What

Follow-up to #240. The Mantle tradeoff warning now also appears on `juggernaut apply --mantle --dry-run`.

## Why

In #240 the warning was only emitted from `commitApply` (the real-write path). `apply --dry-run` returns from `printApplyDryRun` *before* that — so the person carefully previewing an apply, exactly who'd want to know Mantle disables prompt caching before committing, saw nothing.

## Fix

Thread the built `*schema.Block` into `printApplyDryRun` and call the existing `warnMantleTradeoffs(block)` there too. No new message — reuses the same verified warning.

## Verified

Real binary, `--mantle --dry-run` now prints:

\`\`\`
Dry run — no changes written.
Would write juggernaut block to …/.claude/settings.json
Would install Juggernaut Claude activation blocks in shell profiles
Would recover known v4.2.6 launcher artifacts in …/.local/bin

⚠ Mantle routing is enabled. Compared with native Bedrock (bedrock-runtime):
  • prompt caching is unavailable on Mantle — …
  • only current-generation Claude models are reachable …
\`\`\`

Plain `--dry-run` stays quiet.

## Tests (TDD)

Written failing first, then passing:

- \`TestApply_MantleDryRun_WarnsAboutPromptCaching\` — `--mantle --dry-run` warns
- \`TestApply_NoMantleDryRun_NoMantleWarning\` — plain `--dry-run` stays quiet

Full \`cmd\` suite + \`go vet\` pass locally.