### PR TITLE
feat: Provider and ConfigFormat abstractions (multi-CLI groundwork)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ var applyCmd = &cobra.Command{
 }
 
 var applyFlags struct {
+	cli            string
 	auth           string
 	bedrockKey     string
 	preserveKey    bool
@@ -55,6 +57,7 @@ var applyFlags struct {
 
 func init() {
 	f := applyCmd.Flags()
+	f.StringVar(&applyFlags.cli, "cli", "claude", "coding CLI to configure: claude")
 	f.StringVar(&applyFlags.auth, "auth", "", "authentication mode: iam or "+authmode.BedrockAPIKey)
 	f.StringVar(&applyFlags.bedrockKey, "bedrock-key", "", "Bedrock API key")
 	f.BoolVar(&applyFlags.preserveKey, "preserve-key", false, "reuse existing key from keychain/env")
@@ -93,6 +96,13 @@ func init() {
 func runApply(_ *cobra.Command, _ []string) error {
 	home, err := homeDir()
 	if err != nil {
+		return err
+	}
+
+	// Resolve and validate the target CLI. Defaults to Claude Code, so callers
+	// that pass no --cli are unaffected. An unknown name errors here before any
+	// work is done.
+	if _, err := provider.Get(applyFlags.cli); err != nil {
 		return err
 	}
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1043,6 +1043,56 @@ func TestApply_NoMantleDryRun_NoMantleWarning(t *testing.T) {
 	}
 }
 
+func TestApply_UnknownCLI_Errors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--cli=nonesuch", "--skip-preflight",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown --cli")
+	}
+	if !strings.Contains(err.Error(), "nonesuch") {
+		t.Errorf("error should name the bad CLI, got: %v", err)
+	}
+}
+
+func TestApply_DefaultCLI_IsClaude_StillWrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	// No --cli flag: must behave exactly as before (Claude), writing settings.json.
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err != nil {
+		t.Errorf("expected settings.json written for default (claude) CLI: %v", err)
+	}
+}
+
+func TestApply_ExplicitClaudeCLI_Works(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--cli=claude", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply --cli=claude error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err != nil {
+		t.Errorf("expected settings.json written for --cli=claude: %v", err)
+	}
+}
+
 func TestApply_NoMantle_NoMantleWarning(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/format.go
+++ b/internal/config/format.go
@@ -1,0 +1,34 @@
+package config
+
+import "encoding/json"
+
+// ConfigFormat abstracts the on-disk encoding of a settings file so the Manager
+// can read/write JSON (Claude Code, OpenCode, Grok) or TOML (Codex) without
+// caring which. Implementations must round-trip: Unmarshal(Marshal(x)) == x.
+type ConfigFormat interface {
+	// Name identifies the format ("json", "toml").
+	Name() string
+	// Unmarshal decodes bytes into a generic map.
+	Unmarshal(data []byte) (map[string]any, error)
+	// Marshal encodes a generic map to bytes.
+	Marshal(data map[string]any) ([]byte, error)
+}
+
+// jsonFormat is the default ConfigFormat. Its Marshal reproduces the exact
+// two-space-indented encoding the Manager used before the format seam existed,
+// so existing settings.json output is byte-identical.
+type jsonFormat struct{}
+
+func (jsonFormat) Name() string { return "json" }
+
+func (jsonFormat) Unmarshal(data []byte) (map[string]any, error) {
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (jsonFormat) Marshal(data map[string]any) ([]byte, error) {
+	return json.MarshalIndent(data, "", "  ")
+}

--- a/internal/config/format_test.go
+++ b/internal/config/format_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestJSONFormat_RoundTrip verifies the JSON ConfigFormat reads back what it writes.
+func TestJSONFormat_RoundTrip(t *testing.T) {
+	f := jsonFormat{}
+	in := map[string]any{
+		"juggernaut": map[string]any{"meta": map[string]any{"managedBy": "juggernaut"}},
+		"model":      "opusplan",
+	}
+	encoded, err := f.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out, err := f.Unmarshal(encoded)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out["model"] != "opusplan" {
+		t.Errorf("round-trip lost model key: got %v", out["model"])
+	}
+}
+
+// TestJSONFormat_MatchesLegacyEncoding pins the exact two-space-indented encoding
+// so the ConfigFormat seam produces byte-identical output to the old hardcoded
+// json.MarshalIndent(data, "", "  ") call in Manager.Write.
+func TestJSONFormat_MatchesLegacyEncoding(t *testing.T) {
+	f := jsonFormat{}
+	encoded, err := f.Marshal(map[string]any{"a": "b"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := "{\n  \"a\": \"b\"\n}"
+	if string(encoded) != want {
+		t.Errorf("encoding drift:\n got: %q\nwant: %q", string(encoded), want)
+	}
+}
+
+// TestJSONFormat_Name identifies the format.
+func TestJSONFormat_Name(t *testing.T) {
+	if got := (jsonFormat{}).Name(); got != "json" {
+		t.Errorf("Name() = %q, want json", got)
+	}
+}
+
+// TestNewManager_DefaultsToJSON verifies existing callers get JSON behavior unchanged.
+func TestNewManager_DefaultsToJSON(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir + "/settings.json")
+	if m.format == nil {
+		t.Fatal("NewManager left format nil; existing callers would panic")
+	}
+	if m.format.Name() != "json" {
+		t.Errorf("default format = %q, want json", m.format.Name())
+	}
+}
+
+// TestManager_WriteUsesFormat verifies Write produces the format's encoding.
+func TestManager_WriteUsesFormat(t *testing.T) {
+	dir := t.TempDir()
+	m := NewManager(dir + "/settings.json")
+	if err := m.Write(map[string]any{"model": "sonnet"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := m.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got["model"] != "sonnet" {
+		t.Errorf("Read after Write lost data: %v", got)
+	}
+	// Confirm two-space indent landed on disk (legacy contract).
+	raw, err := m.format.Marshal(map[string]any{"model": "sonnet"})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), "\n  \"model\"") {
+		t.Errorf("expected two-space indent, got %q", string(raw))
+	}
+}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -2,7 +2,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,16 +14,23 @@ import (
 
 const backupRetain = 5
 
-// Manager handles atomic read/merge/write of a settings.json file.
+// Manager handles atomic read/merge/write of a settings file.
 type Manager struct {
-	path string
-	base string
+	path   string
+	base   string
+	format ConfigFormat
 }
 
-// NewManager creates a Manager for the settings.json at the given path.
+// NewManager creates a Manager for the JSON settings file at the given path.
 func NewManager(path string) *Manager {
+	return NewManagerWithFormat(path, jsonFormat{})
+}
+
+// NewManagerWithFormat creates a Manager that reads/writes using the given
+// on-disk format (JSON for Claude Code/OpenCode/Grok, TOML for Codex).
+func NewManagerWithFormat(path string, format ConfigFormat) *Manager {
 	clean := filepath.Clean(path)
-	return &Manager{path: clean, base: filepath.Dir(clean)}
+	return &Manager{path: clean, base: filepath.Dir(clean), format: format}
 }
 
 func (m *Manager) Read() (map[string]any, error) {
@@ -39,8 +45,8 @@ func (m *Manager) Read() (map[string]any, error) {
 		return map[string]any{}, nil
 	}
 	data = stripUTF8BOM(data)
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
+	result, err := m.format.Unmarshal(data)
+	if err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", m.path, err)
 	}
 	return result, nil
@@ -68,7 +74,7 @@ func (m *Manager) Write(data map[string]any) error {
 		}
 	}
 
-	encoded, err := json.MarshalIndent(data, "", "  ")
+	encoded, err := m.format.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("encoding settings.json: %w", err)
 	}

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -1,0 +1,41 @@
+package provider
+
+import "runtime"
+
+// claude is the Claude Code provider. Every value here is transcribed verbatim
+// from the pre-abstraction hardcoded sites (internal/config/manager.go's
+// nativeManagedKeys, internal/activation/activation.go's markers and binary
+// names, and the CLAUDE_CODE_USE_BEDROCK launch env var) so behavior is
+// byte-identical. The provider_test.go pins guard against drift.
+type claude struct{}
+
+func (claude) Name() string { return "claude" }
+
+func (claude) BinaryNames() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"claude.exe", "claude.cmd", "claude.bat"}
+	}
+	return []string{"claude"}
+}
+
+func (claude) ConfigFormatName() string { return "json" }
+
+func (claude) NativeManagedKeys() []string {
+	return []string{
+		"env",
+		"model",
+		"modelOverrides",
+		"fallbackModel",
+		"effortLevel",
+		"alwaysThinkingEnabled",
+		"skipWebFetchPreflight",
+	}
+}
+
+func (claude) ActivationMarkers() (begin, end string) {
+	return "# BEGIN: Juggernaut Claude Activation", "# END: Juggernaut Claude Activation"
+}
+
+func (claude) BedrockEnvVar() (key, value string) {
+	return "CLAUDE_CODE_USE_BEDROCK", "1"
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,82 @@
+// Package provider abstracts the CLI-specific surface Juggernaut configures for
+// Bedrock. Claude Code is the first (and, before the multi-CLI PRs, only)
+// implementation; Codex, OpenCode, and Grok are added behind this interface so
+// schema/config/activation stop being hardcoded to Claude Code.
+//
+// PR 1 scope: this interface centralizes the STRUCTURAL Claude-specific surface a
+// second CLI genuinely needs — identity, binary names, config location/format,
+// native managed keys, activation markers, and the launch-time Bedrock env var.
+// The env-var *emission* (schema.Build) is intentionally NOT moved here yet; it
+// migrates to a BuildEnv method in the Codex PR, when a real second CLI forces
+// the interface shape rather than a guessed one.
+package provider
+
+import "fmt"
+
+// Provider describes one coding CLI that Juggernaut can configure for Bedrock.
+type Provider interface {
+	// Name is the canonical --cli identifier ("claude", "codex", ...).
+	Name() string
+
+	// BinaryNames lists the real executable names to resolve on PATH when the
+	// launch wrapper execs the underlying CLI, most-preferred first.
+	BinaryNames() []string
+
+	// ConfigFormatName reports the on-disk config encoding ("json", "toml").
+	ConfigFormatName() string
+
+	// NativeManagedKeys lists the top-level config keys Juggernaut fully owns
+	// (replaced on apply, removed on uninstall).
+	NativeManagedKeys() []string
+
+	// ActivationMarkers returns the begin/end comment markers delimiting this
+	// CLI's managed shell-activation block.
+	ActivationMarkers() (begin, end string)
+
+	// BedrockEnvVar is the env var (key,value) the launcher sets to route this
+	// CLI through Bedrock.
+	BedrockEnvVar() (key, value string)
+}
+
+// registry holds every known provider by name.
+var registry = map[string]Provider{}
+
+func register(p Provider) { registry[p.Name()] = p }
+
+func init() {
+	register(claude{})
+}
+
+// Get resolves a provider by name. An empty name defaults to "claude" so every
+// existing caller (which passes no --cli) keeps getting Claude Code behavior.
+func Get(name string) (Provider, error) {
+	if name == "" {
+		name = "claude"
+	}
+	p, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown CLI %q — supported: %s", name, supportedNames())
+	}
+	return p, nil
+}
+
+func supportedNames() string {
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	// Deterministic order for the error message.
+	for i := 1; i < len(names); i++ {
+		for j := i; j > 0 && names[j] < names[j-1]; j-- {
+			names[j], names[j-1] = names[j-1], names[j]
+		}
+	}
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += n
+	}
+	return out
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestGet_Claude confirms the registry resolves the default Claude provider.
+func TestGet_Claude(t *testing.T) {
+	p, err := Get("claude")
+	if err != nil {
+		t.Fatalf("Get(claude): %v", err)
+	}
+	if p.Name() != "claude" {
+		t.Errorf("Name() = %q, want claude", p.Name())
+	}
+}
+
+// TestGet_Default confirms an empty name resolves to Claude (back-compat: every
+// existing caller passes no --cli and must keep getting Claude behavior).
+func TestGet_Default(t *testing.T) {
+	p, err := Get("")
+	if err != nil {
+		t.Fatalf("Get(\"\"): %v", err)
+	}
+	if p.Name() != "claude" {
+		t.Errorf("default provider = %q, want claude", p.Name())
+	}
+}
+
+// TestGet_Unknown rejects an unregistered CLI with an actionable error.
+func TestGet_Unknown(t *testing.T) {
+	_, err := Get("nonesuch")
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+// TestClaude_ManagedKeysMatchLegacy pins the exact native managed-key set the
+// config package hardcoded before the provider seam, so uninstall/merge behavior
+// is unchanged.
+func TestClaude_ManagedKeysMatchLegacy(t *testing.T) {
+	p, _ := Get("claude")
+	want := []string{
+		"env", "model", "modelOverrides", "fallbackModel",
+		"effortLevel", "alwaysThinkingEnabled", "skipWebFetchPreflight",
+	}
+	got := p.NativeManagedKeys()
+	if len(got) != len(want) {
+		t.Fatalf("managed keys = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("managed key[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestClaude_ActivationMarkers pins the exact marker strings activation.go used,
+// so shell-profile block detection/removal is unchanged.
+func TestClaude_ActivationMarkers(t *testing.T) {
+	p, _ := Get("claude")
+	begin, end := p.ActivationMarkers()
+	if begin != "# BEGIN: Juggernaut Claude Activation" {
+		t.Errorf("begin marker = %q", begin)
+	}
+	if end != "# END: Juggernaut Claude Activation" {
+		t.Errorf("end marker = %q", end)
+	}
+}
+
+// TestClaude_BinaryNames pins the platform-specific binary names activation.go
+// searched for when resolving the real Claude Code executable.
+func TestClaude_BinaryNames(t *testing.T) {
+	p, _ := Get("claude")
+	got := p.BinaryNames()
+	if runtime.GOOS == "windows" {
+		want := []string{"claude.exe", "claude.cmd", "claude.bat"}
+		if len(got) != len(want) || got[0] != want[0] {
+			t.Errorf("windows binary names = %v, want %v", got, want)
+		}
+	} else if len(got) != 1 || got[0] != "claude" {
+		t.Errorf("unix binary names = %v, want [claude]", got)
+	}
+}
+
+// TestClaude_BedrockEnvVar pins the launch-time Bedrock activation env var.
+func TestClaude_BedrockEnvVar(t *testing.T) {
+	p, _ := Get("claude")
+	k, v := p.BedrockEnvVar()
+	if k != "CLAUDE_CODE_USE_BEDROCK" || v != "1" {
+		t.Errorf("BedrockEnvVar() = (%q,%q), want (CLAUDE_CODE_USE_BEDROCK,1)", k, v)
+	}
+}
+
+// TestClaude_ConfigFormatIsJSON confirms Claude writes JSON.
+func TestClaude_ConfigFormatIsJSON(t *testing.T) {
+	p, _ := Get("claude")
+	if p.ConfigFormatName() != "json" {
+		t.Errorf("config format = %q, want json", p.ConfigFormatName())
+	}
+}


### PR DESCRIPTION
## What

First PR of the multi-harness effort (see `.research/multi-harness-bedrock-research.md`). Extracts the two seams that hardcode Juggernaut to Claude Code — **behind interfaces, with zero behavior change**. Claude Code stays the default; its `settings.json` output is byte-identical.

This is deliberately **ruthlessly small** (per the approved plan): abstraction + Claude port only. **No new CLIs, no TOML dependency.** Codex/OpenCode/Grok come in follow-up PRs once this seam is proven.

## Changes

- **`internal/config` — `ConfigFormat` interface** (`Unmarshal`/`Marshal`) + a JSON impl that reproduces the exact two-space-indented encoding. `Manager` holds a format; `NewManager` still defaults to JSON (via new `NewManagerWithFormat`). Lets a TOML-based CLI slot in later without touching merge/lock/backup logic.
- **`internal/provider` — new package.** `Provider` interface + registry + Claude implementation. Centralizes the structural Claude-specific surface a second CLI needs: binary names, config format, native managed keys, activation markers, launch-time Bedrock env var. Every value is **pinned to its legacy constant by tests** to guard against drift.
- **`cmd/apply` — `--cli` flag** (default `claude`). Resolves + validates the provider up front; an unknown CLI errors before any work is done.

## Explicitly deferred (not in this PR)

- **Env-var emission** (`schema.Build`'s `CLAUDE_CODE_*`/`ANTHROPIC_*` block) is **not** moved into the provider yet. Moving it on spec is the highest-risk drift source; it migrates in the Codex PR when a real second CLI forces the interface shape. Keeping `schema.go` untouched is what makes the byte-identical guarantee easy to hold.
- Rewiring `activation.go` markers/binary-resolution to read from the provider — deferred to the Codex PR (values are already pinned identical).

## Verification

- New tests (TDD, written failing first): `ConfigFormat` round-trip + exact-encoding pin; provider registry (`Get`/default/unknown) + legacy-value pins (managed keys, markers, binary names, bedrock env var); `apply --cli` unknown-errors / default-is-claude / explicit-claude-works.
- **Byte-identical check:** real `apply` writes settings.json with unchanged top-level keys, `managedBy`/version, and two-space indent.
- Full `go test ./...` green; `gofmt`/`go vet`/`go mod tidy` clean. (Local golangci-lint is older than the repo's Go toolchain — relying on the CI lint job.)

## Next

PR 2 (Codex) adds the TOML `ConfigFormat`, migrates `BuildEnv` into providers, and wires `activation` per-provider — gated on confirming this seam in CI.