### PR TITLE
fix: harden provider seam per PR #243 review

### DIFF
--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1058,6 +1058,9 @@ func TestApply_UnknownCLI_Errors(t *testing.T) {
 	if !strings.Contains(err.Error(), "nonesuch") {
 		t.Errorf("error should name the bad CLI, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should list supported CLI names to guide the user, got: %v", err)
+	}
 }
 
 func TestApply_DefaultCLI_IsClaude_StillWrites(t *testing.T) {

--- a/internal/config/format_test.go
+++ b/internal/config/format_test.go
@@ -47,6 +47,23 @@ func TestJSONFormat_Name(t *testing.T) {
 	}
 }
 
+// TestNewManagerWithFormat_NilFormatPanics verifies a nil ConfigFormat is
+// rejected at construction with a clear message, rather than deferring to an
+// opaque nil-pointer panic inside Read/Write. NewManagerWithFormat is exported
+// and future CLIs (TOML) will call it, so guard the invariant at the boundary.
+func TestNewManagerWithFormat_NilFormatPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for nil format")
+		}
+		if s, ok := r.(string); !ok || !strings.Contains(s, "format") {
+			t.Errorf("panic should mention nil format, got: %v", r)
+		}
+	}()
+	NewManagerWithFormat(t.TempDir()+"/settings.json", nil)
+}
+
 // TestNewManager_DefaultsToJSON verifies existing callers get JSON behavior unchanged.
 func TestNewManager_DefaultsToJSON(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -27,8 +27,13 @@ func NewManager(path string) *Manager {
 }
 
 // NewManagerWithFormat creates a Manager that reads/writes using the given
-// on-disk format (JSON for Claude Code/OpenCode/Grok, TOML for Codex).
+// on-disk format (JSON for Claude Code/OpenCode/Grok, TOML for Codex). A nil
+// format is a programming error: Read/Write would otherwise nil-panic deep in
+// the I/O path, so fail loudly at the boundary instead.
 func NewManagerWithFormat(path string, format ConfigFormat) *Manager {
+	if format == nil {
+		panic("config.NewManagerWithFormat: format must not be nil")
+	}
 	clean := filepath.Clean(path)
 	return &Manager{path: clean, base: filepath.Dir(clean), format: format}
 }

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -2,11 +2,12 @@ package provider
 
 import "runtime"
 
-// claude is the Claude Code provider. Every value here is transcribed verbatim
-// from the pre-abstraction hardcoded sites (internal/config/manager.go's
-// nativeManagedKeys, internal/activation/activation.go's markers and binary
-// names, and the CLAUDE_CODE_USE_BEDROCK launch env var) so behavior is
-// byte-identical. The provider_test.go pins guard against drift.
+// claude is the Claude Code provider. Every value here is transcribed from the
+// pre-abstraction sources so behavior is byte-identical: NativeManagedKeys from
+// internal/config/manager.go's nativeManagedKeys slice, the markers and binary
+// names from internal/activation/activation.go, and the Bedrock env var
+// (CLAUDE_CODE_USE_BEDROCK=1) from the literal set inside activation.Launch.
+// The provider_test.go pins guard against drift.
 type claude struct{}
 
 func (claude) Name() string { return "claude" }


### PR DESCRIPTION
## What

Follow-up to #243, addressing the actionable findings from the multi-agent PR review. Three small, safe changes — no behavior change for existing callers.

## Changes

1. **Nil `ConfigFormat` guard** (`internal/config/manager.go`) — `NewManagerWithFormat` now panics with a clear message on a nil format, instead of deferring to an opaque nil-pointer panic deep inside `Read`/`Write`. The constructor is exported and the upcoming TOML-based CLIs will call it, so the invariant is guarded at the boundary. *(silent-failure-hunter, verified reachable-in-future)*
2. **Unknown-CLI error assertion** (`cmd/apply_test.go`) — `provider.Get` already lists supported names in its error; the test now pins that so the user-guidance can't silently regress. *(pr-test-analyzer)*
3. **Comment clarity** (`internal/provider/claude.go`) — the Bedrock env var is a string literal inside `activation.Launch`, not a named constant; comment now says so. *(comment-analyzer)*

## Deliberately NOT changed (review items triaged out)

- **Marshal/Unmarshal self-wrapping** — errors are already wrapped at the `Manager` level (`parsing %s` / `encoding settings.json`), byte-identical to pre-refactor. Style preference; revisit in the Codex PR if warranted.
- **Registry dup-validation, `ConfigFormatName`-as-string, `ActivationMarkers` struct, `BuildEnv` migration** — flagged by the type/test reviewers as *foundation guidance for the Codex PR*, not defects in what merged. Deferred with intent.
- **Byte-identical idempotency test as proposed** — would fail on the `meta.appliedAt` timestamp; the byte-identical property is already covered by the encoding-pin + provider legacy-value tests.

## Verification

- New nil-guard test written failing first, then green. Unknown-CLI assertion added.
- Full `go test ./...` green; `go vet` + `gofmt` clean.

## Review outcome

Five specialized reviewers (code, tests, errors, types, comments) found **zero real bugs** in #243 — the byte-identical safety property was independently confirmed. These three are hardening/clarity only.