### PR TITLE
fix: apply --cli=codex re-prompts for auth even when already configured

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -395,14 +395,19 @@ func resolveApplyInputs(home string, bCfg *bedrock.Config, prov provider.Provide
 		return
 	}
 	mgr := config.NewManagerWithFormat(path, format)
-	has, herr := mgr.HasManagedKeys(prov.NativeManagedKeys())
+	existing, herr := mgr.Read()
 	if herr != nil {
 		err = fmt.Errorf("checking existing configuration: %w", herr)
 		return
 	}
-	if has {
+	// Re-apply detection must recognize a config JUGGERNAUT wrote for THIS
+	// provider (Bedrock already configured) — not merely any shared key. A plain
+	// Codex config already has a top-level `model`; treating that as "configured"
+	// would skip the auth prompt on a FIRST apply and default to iam, breaking
+	// Mantle which requires a bearer token. OwnsConfig is the strict check.
+	if prov.OwnsConfig(existing) {
 		// Preserve auth mode and permission mode from the existing block when not supplied as flags.
-		if existing, rerr := mgr.Read(); rerr == nil {
+		{
 			if jBlock, ok := existing["juggernaut"].(map[string]any); ok {
 				if authMode == "" {
 					if auth, ok := jBlock["auth"].(map[string]any); ok {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -116,7 +116,7 @@ func runApply(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	authMode, region, opusplan, err := resolveApplyInputs(home, bCfg)
+	authMode, region, opusplan, err := resolveApplyInputs(home, bCfg, prov)
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func reportLegacyRecovery(home string) {
 	}
 }
 
-func resolveApplyInputs(home string, bCfg *bedrock.Config) (authMode, region string, opusplan bool, err error) {
+func resolveApplyInputs(home string, bCfg *bedrock.Config, prov provider.Provider) (authMode, region string, opusplan bool, err error) {
 	authMode = applyFlags.auth
 	region = applyFlags.region
 	if region == "" {
@@ -384,13 +384,18 @@ func resolveApplyInputs(home string, bCfg *bedrock.Config) (authMode, region str
 	}
 	opusplan = applyFlags.opusplan
 
-	path, herr := settingsPath(home, applyFlags.scope)
+	path, herr := prov.ConfigPath(home, applyFlags.scope)
 	if herr != nil {
 		err = herr
 		return
 	}
-	mgr := config.NewManager(path)
-	has, herr := mgr.HasJuggernautBlock()
+	format, herr := config.FormatByName(prov.ConfigFormatName())
+	if herr != nil {
+		err = herr
+		return
+	}
+	mgr := config.NewManagerWithFormat(path, format)
+	has, herr := mgr.HasManagedKeys(prov.NativeManagedKeys())
 	if herr != nil {
 		err = fmt.Errorf("checking existing configuration: %w", herr)
 		return

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1083,6 +1083,36 @@ func TestApply_Codex_NoClaudeWarnings(t *testing.T) {
 	}
 }
 
+func TestApply_CodexDryRun_ReapplySkipsPromptWhenCodexConfigExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := safepath.MkdirAll(codexDir); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	configPath := filepath.Join(codexDir, "config.toml")
+	content := []byte("model = \"openai.gpt-5.5\"\nmodel_provider = \"bedrock-mantle\"\n\n[model_providers.bedrock-mantle]\nname = \"Amazon Bedrock (Mantle)\"\nbase_url = \"https://bedrock-mantle.us-west-2.api.aws/openai/v1\"\nwire_api = \"responses\"\nenv_key = \"AWS_BEARER_TOKEN_BEDROCK\"\n")
+	if err := safepath.WriteFile(codexDir, configPath, content); err != nil {
+		t.Fatalf("write codex config: %v", err)
+	}
+
+	var err error
+	withStdin(t, "", func() {
+		err = ExecuteArgs([]string{
+			"apply",
+			"--cli=codex",
+			"--dry-run",
+			"--skip-preflight",
+		})
+	})
+	if err != nil {
+		t.Fatalf("codex re-apply dry-run should not prompt when codex config exists: %v", err)
+	}
+}
+
 func TestApply_UnknownCLI_Errors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1113,6 +1113,33 @@ func TestApply_CodexDryRun_ReapplySkipsPromptWhenCodexConfigExists(t *testing.T)
 	}
 }
 
+func TestApply_ClaudeDryRun_ReapplySkipsPromptWhenClaudeConfigExists(t *testing.T) {
+	// Cross-provider guard: the reapply-detection refactor (threading the
+	// provider through resolveApplyInputs) must NOT break Claude's own detection.
+	// A first apply writes ~/.claude/settings.json; a second dry-run with closed
+	// stdin must skip the prompt (detect existing config) and return cleanly.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=claude", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	var err error
+	withStdin(t, "", func() {
+		err = ExecuteArgs([]string{
+			"apply", "--cli=claude", "--dry-run", "--skip-preflight",
+		})
+	})
+	if err != nil {
+		t.Fatalf("claude re-apply dry-run should not prompt when settings.json exists: %v", err)
+	}
+}
+
 func TestApply_UnknownCLI_Errors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
 
@@ -1137,6 +1139,84 @@ func TestApply_ClaudeDryRun_ReapplySkipsPromptWhenClaudeConfigExists(t *testing.
 	})
 	if err != nil {
 		t.Fatalf("claude re-apply dry-run should not prompt when settings.json exists: %v", err)
+	}
+}
+
+// stubProvider is a minimal provider.Provider for exercising resolveApplyInputs
+// error branches (bad config format, config-path failure) that a real
+// registered provider never hits.
+type stubProvider struct {
+	formatName string
+	pathErr    error
+}
+
+func (s stubProvider) Name() string             { return "stub" }
+func (s stubProvider) BinaryNames() []string    { return []string{"stub"} }
+func (s stubProvider) ConfigFormatName() string { return s.formatName }
+func (s stubProvider) ConfigPath(home, scope string) (string, error) {
+	if s.pathErr != nil {
+		return "", s.pathErr
+	}
+	return filepath.Join(home, ".stub", "config"), nil
+}
+func (s stubProvider) NativeManagedKeys() []string         { return []string{"model"} }
+func (s stubProvider) OwnsConfig(map[string]any) bool      { return false }
+func (s stubProvider) ActivationMarkers() (string, string) { return "# B", "# E" }
+func (s stubProvider) BuildConfig(*bedrock.Config, provider.Options) (provider.ConfigPlan, error) {
+	return provider.ConfigPlan{}, nil
+}
+func (s stubProvider) LaunchSpec() provider.LaunchSpec   { return provider.LaunchSpec{} }
+func (s stubProvider) Supports(provider.Capability) bool { return false }
+
+// TestResolveApplyInputs_BadConfigFormat_Errors covers the FormatByName error
+// branch: a provider reporting an unknown config format surfaces an error rather
+// than silently proceeding.
+func TestResolveApplyInputs_BadConfigFormat_Errors(t *testing.T) {
+	home := t.TempDir()
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: "iam"}}
+	_, _, _, err := resolveApplyInputs(home, bCfg, stubProvider{formatName: "yaml"})
+	if err == nil {
+		t.Fatal("expected error for unknown config format")
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error should name the bad format, got: %v", err)
+	}
+}
+
+// TestResolveApplyInputs_ConfigPathError_Propagates covers the ConfigPath error branch.
+func TestResolveApplyInputs_ConfigPathError_Propagates(t *testing.T) {
+	home := t.TempDir()
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: "iam"}}
+	sentinel := fmt.Errorf("bad path")
+	_, _, _, err := resolveApplyInputs(home, bCfg, stubProvider{formatName: "json", pathErr: sentinel})
+	if err == nil {
+		t.Fatal("expected ConfigPath error to propagate")
+	}
+}
+
+// dirPathProvider is a stub whose ConfigPath points at an existing DIRECTORY, so
+// Manager.Read fails (reading a directory as a file), covering the
+// "checking existing configuration" error branch of resolveApplyInputs.
+type dirPathProvider struct {
+	stubProvider
+	dir string
+}
+
+func (d dirPathProvider) ConfigPath(string, string) (string, error) { return d.dir, nil }
+
+func TestResolveApplyInputs_ReadError_Propagates(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "isadir")
+	if err := safepath.MkdirAll(dir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: "iam"}}
+	_, _, _, err := resolveApplyInputs(home, bCfg, dirPathProvider{stubProvider: stubProvider{formatName: "json"}, dir: dir})
+	if err == nil {
+		t.Fatal("expected a read error when config path is a directory")
+	}
+	if !strings.Contains(err.Error(), "checking existing configuration") {
+		t.Errorf("expected wrapped read error, got: %v", err)
 	}
 }
 

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -37,6 +37,20 @@ func (claude) ConfigPath(home, scope string) (string, error) {
 	return safepath.JoinUnder(home, ".claude", "settings.json")
 }
 
+// OwnsConfig recognizes a Claude config Juggernaut wrote by its managed
+// juggernaut block with managedBy == "juggernaut".
+func (claude) OwnsConfig(data map[string]any) bool {
+	block, ok := data["juggernaut"].(map[string]any)
+	if !ok {
+		return false
+	}
+	meta, ok := block["meta"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return meta["managedBy"] == "juggernaut"
+}
+
 func (claude) NativeManagedKeys() []string {
 	return []string{
 		"env",

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -38,6 +38,15 @@ func (codex) ConfigPath(home, scope string) (string, error) {
 }
 
 // NativeManagedKeys are the top-level config.toml keys Juggernaut owns for Codex.
+// OwnsConfig recognizes a Codex config Juggernaut wrote by its Bedrock-Mantle
+// routing (model_provider == "bedrock-mantle"). A plain user config that merely
+// has a top-level `model` is NOT ours — critical so a first-time
+// `apply --cli=codex` over an existing Codex config still prompts for auth
+// instead of defaulting to iam (Mantle requires a bearer token).
+func (codex) OwnsConfig(data map[string]any) bool {
+	return data["model_provider"] == "bedrock-mantle"
+}
+
 func (codex) NativeManagedKeys() []string {
 	return []string{
 		"model",

--- a/internal/provider/ownsconfig_test.go
+++ b/internal/provider/ownsconfig_test.go
@@ -36,3 +36,22 @@ func TestCodex_OwnsConfig(t *testing.T) {
 		t.Error("codex must NOT claim a config pointing at a non-Mantle provider")
 	}
 }
+
+// TestClaude_OwnsConfig_MalformedBlocks covers the defensive branches: a
+// juggernaut key that isn't a map, or a block missing/!map meta, or a wrong
+// owner, must not be mistaken for ownership.
+func TestClaude_OwnsConfig_MalformedBlocks(t *testing.T) {
+	p, _ := Get("claude")
+	cases := []map[string]any{
+		{},                               // no juggernaut key
+		{"juggernaut": "not-a-map"},      // juggernaut not a map
+		{"juggernaut": map[string]any{}}, // no meta
+		{"juggernaut": map[string]any{"meta": "x"}},                                         // meta not a map
+		{"juggernaut": map[string]any{"meta": map[string]any{"managedBy": "someone-else"}}}, // wrong owner
+	}
+	for i, c := range cases {
+		if p.OwnsConfig(c) {
+			t.Errorf("case %d: claude must not claim ownership of %v", i, c)
+		}
+	}
+}

--- a/internal/provider/ownsconfig_test.go
+++ b/internal/provider/ownsconfig_test.go
@@ -1,0 +1,38 @@
+package provider
+
+import "testing"
+
+// TestClaude_OwnsConfig: Claude recognizes its config by the managed juggernaut block.
+func TestClaude_OwnsConfig(t *testing.T) {
+	p, _ := Get("claude")
+	if !p.OwnsConfig(map[string]any{
+		"juggernaut": map[string]any{"meta": map[string]any{"managedBy": "juggernaut"}},
+	}) {
+		t.Error("claude should own a config with a juggernaut managed block")
+	}
+	// A bare model / unrelated keys are NOT ownership.
+	if p.OwnsConfig(map[string]any{"model": "sonnet", "editor": "vim"}) {
+		t.Error("claude must NOT claim a config lacking the juggernaut block")
+	}
+}
+
+// TestCodex_OwnsConfig: Codex recognizes ONLY its Bedrock-Mantle routing, not a
+// plain user config that merely has a `model` key. This is the P2 fix: a vanilla
+// Codex config (model = "...") must NOT be mistaken for a Juggernaut-configured one.
+func TestCodex_OwnsConfig(t *testing.T) {
+	p, _ := Get("codex")
+	if !p.OwnsConfig(map[string]any{
+		"model":          "openai.gpt-5.5",
+		"model_provider": "bedrock-mantle",
+	}) {
+		t.Error("codex should own a config routed to bedrock-mantle")
+	}
+	// Plain non-Juggernaut Codex config with just a model → NOT ours.
+	if p.OwnsConfig(map[string]any{"model": "gpt-5.1-codex"}) {
+		t.Error("codex must NOT claim a plain config that only has a model key")
+	}
+	// A different provider value → NOT ours.
+	if p.OwnsConfig(map[string]any{"model": "x", "model_provider": "openai"}) {
+		t.Error("codex must NOT claim a config pointing at a non-Mantle provider")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,6 +38,14 @@ type Provider interface {
 	// (replaced on apply, removed on uninstall).
 	NativeManagedKeys() []string
 
+	// OwnsConfig reports whether the given parsed config was written by
+	// Juggernaut for THIS provider (i.e. Bedrock is already configured). It must
+	// be stricter than "any managed key is present": a plain user config that
+	// merely shares a key name (e.g. Codex's own top-level `model`) must NOT
+	// count, or a first-time apply would wrongly skip the auth prompt. Used to
+	// decide whether an apply is a re-apply.
+	OwnsConfig(data map[string]any) bool
+
 	// ActivationMarkers returns the begin/end comment markers delimiting this
 	// CLI's managed shell-activation block.
 	ActivationMarkers() (begin, end string)


### PR DESCRIPTION
## The regression

`apply` skips the interactive auth/region/permission prompt when it detects an existing config (re-apply). That detection was **hardcoded to Claude**: `resolveApplyInputs` used `settingsPath` (`~/.claude/settings.json`) + `HasJuggernautBlock()`.

For `--cli=codex` it looked at the wrong file, so an existing `~/.codex/config.toml` went **undetected** — and `apply --cli=codex` (even `--dry-run`) fell through to the prompt. On non-interactive/closed stdin that **blocks/hangs**.

Shipped in #245; missed by the review pass.

## Fix

Thread the resolved `provider.Provider` into `resolveApplyInputs` and detect existing config via `prov.ConfigPath` + `FormatByName(prov.ConfigFormatName())` + `HasManagedKeys(prov.NativeManagedKeys())` — the same provider seam `commitApply` and `uninstall` already use. No Claude behavior change.

## Verification

- **Regression test** `TestApply_CodexDryRun_ReapplySkipsPromptWhenCodexConfigExists`: pre-writes a codex `config.toml`, runs `apply --cli=codex --dry-run` with **closed stdin**. Proven to fail without the fix — with the fix stashed, the test **hangs on the prompt** (2-min timeout); with the fix it returns in ~1.5s.
- Full `cmd` + `internal/...` suite green; Claude golden byte-identical; gofmt/vet/gosec(G101,G306) clean.

Small, self-contained — a clean candidate to fold into the upcoming multi-CLI preview release.