### PR TITLE
feat: OpenCode CLI on Bedrock (--cli=opencode)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -235,7 +235,7 @@ func printApplyDryRun(home string, block *schema.Block, prov provider.Provider) 
 	if err != nil {
 		return err
 	}
-	title := strings.Title(prov.Name()) //nolint:staticcheck // ASCII CLI names
+	title := providerDisplayName(prov.Name())
 	fmt.Printf("Would write juggernaut config to %s\n", path)
 	fmt.Printf("Would install Juggernaut %s activation blocks in shell profiles\n", title)
 	// Legacy v4.2.6 launcher-artifact recovery is Claude-specific.
@@ -282,6 +282,11 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 	installActivation(home, prov)
 	reportLegacyRecovery(home)
 	fmt.Println("Configuration written successfully.")
+	// Surface any provider-emitted heads-ups (e.g. an unverified/passthrough
+	// model, or a model not confirmed in the chosen region).
+	for _, w := range plan.Warnings {
+		fmt.Printf("⚠ %s\n", w)
+	}
 	// Auto-mode and the Mantle prompt-caching tradeoff are Claude-specific
 	// concerns; gate their warnings on provider capability so other CLIs don't
 	// print nonsensical Claude guidance.
@@ -356,12 +361,27 @@ func installActivation(home string, prov provider.Provider) {
 		fmt.Fprintf(os.Stderr, "Warning: could not install shell activation: %v\n", err)
 		return
 	}
-	title := strings.Title(prov.Name()) //nolint:staticcheck // ASCII CLI names; strings.Title is fine here
+	title := providerDisplayName(prov.Name())
 	if len(paths) == 0 {
 		fmt.Printf("  ✓ %s shell activation already up to date\n", title)
 		return
 	}
 	fmt.Printf("  ✓ Installed %s activation in %d shell profile(s)\n", title, len(paths))
+}
+
+// providerDisplayName returns a human-facing CLI name for messages. Falls back
+// to strings.Title for unknown providers.
+func providerDisplayName(name string) string {
+	switch name {
+	case "claude":
+		return "Claude"
+	case "codex":
+		return "Codex"
+	case "opencode":
+		return "OpenCode"
+	default:
+		return strings.Title(name) //nolint:staticcheck // ASCII CLI name fallback
+	}
 }
 
 func reportLegacyRecovery(home string) {

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -74,6 +74,55 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 	}
 }
 
+// TestApply_OpenCode_PassthroughModel_PrintsWarning locks in that provider
+// ConfigPlan.Warnings are surfaced to the user. An unverified (passthrough)
+// OpenCode model must print the "not in the curated set" heads-up — the warning
+// is the whole point of the honest-passthrough design and was previously
+// computed but never printed.
+func TestApply_OpenCode_PassthroughModel_PrintsWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--cli=opencode", "--model=some.exotic-v9",
+			"--auth=iam", "--region=us-west-2", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	})
+	if !strings.Contains(out, "curated set") {
+		t.Errorf("expected passthrough (unverified) model warning, got:\n%s", out)
+	}
+}
+
+// TestApply_OpenCode_CuratedModel_NoWarning: a curated model writes cleanly with
+// no passthrough warning.
+func TestApply_OpenCode_CuratedModel_NoWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupMockPSRunner(t, home)
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--cli=opencode", "--model=glm-4.7",
+			"--auth=iam", "--region=us-west-2", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	})
+	if strings.Contains(out, "curated set") {
+		t.Errorf("curated model must not warn, got:\n%s", out)
+	}
+	data := readFileForTest(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
+	if !containsStr(data, "zai.glm-4.7") {
+		t.Errorf("expected glm-4.7 in config, got:\n%s", data)
+	}
+}
+
 // TestUninstall_Codex_DryRun exercises the codex uninstall path without writing.
 func TestUninstall_Codex_DryRun(t *testing.T) {
 	home := t.TempDir()

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -143,7 +143,7 @@ func removeKeychainToken(home string) {
 
 func uninstallActivationFull(home string, prov provider.Provider) {
 	begin, end := prov.ActivationMarkers()
-	title := strings.Title(prov.Name()) //nolint:staticcheck // ASCII CLI names
+	title := providerDisplayName(prov.Name())
 	if uninstallFlags.dryRun {
 		fmt.Printf("Would remove Juggernaut %s activation blocks from shell profiles\n", title)
 		if prov.Name() == "claude" {

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+)
+
+// opencode is the OpenCode CLI provider (sst/anomalyco, config JSON at
+// ~/.config/opencode/opencode.json). OpenCode is model-agnostic, so it routes to
+// Bedrock via a custom OpenAI-compatible provider block
+// (npm "@ai-sdk/openai-compatible", options.baseURL → Mantle, apiKey via
+// {env:VAR}). Unlike Codex it has no "use bedrock" env var — routing lives in the
+// config; the bearer token is injected via the apiKey env interpolation.
+//
+// Because OpenCode targets ANY compatible model, it uses a curated tier of
+// live-/table-verified Mantle models plus a --model passthrough for any other
+// Mantle id (with an "unverified" warning). The curated coding models all speak
+// Chat Completions on /v1 (verified in models-api-compatibility.html), so the
+// provider block is uniform; the OpenAI Responses-only gpt-5.x family is
+// intentionally NOT in the curated set (it needs a different npm package).
+type opencode struct{}
+
+// mantleProviderID is the provider key written into opencode.json.
+const mantleProviderID = "bedrock-mantle"
+
+func (opencode) Name() string { return "opencode" }
+
+func (opencode) BinaryNames() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"opencode.exe", "opencode.cmd", "opencode.bat"}
+	}
+	return []string{"opencode"}
+}
+
+func (opencode) ConfigFormatName() string { return "json" }
+
+// ConfigPath is ~/.config/opencode/opencode.json (user) or ./opencode.json
+// (project).
+func (opencode) ConfigPath(home, scope string) (string, error) {
+	if scope == "project" {
+		return filepath.Join(".", "opencode.json"), nil
+	}
+	return safepath.JoinUnder(home, ".config", "opencode", "opencode.json")
+}
+
+// NativeManagedKeys are the top-level opencode.json keys Juggernaut owns.
+func (opencode) NativeManagedKeys() []string {
+	return []string{"model", "provider"}
+}
+
+// OwnsConfig recognizes a config Juggernaut wrote by our bedrock-mantle provider
+// under the "provider" map — NOT a plain user opencode.json that merely has a
+// "provider" block for other vendors or a "model" key.
+func (opencode) OwnsConfig(data map[string]any) bool {
+	prov, ok := data["provider"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = prov[mantleProviderID]
+	return ok
+}
+
+func (opencode) ActivationMarkers() (begin, end string) {
+	return "# BEGIN: Juggernaut OpenCode Activation", "# END: Juggernaut OpenCode Activation"
+}
+
+func (opencode) LaunchSpec() LaunchSpec {
+	// OpenCode routes via config; the bearer token is injected through the
+	// apiKey {env:...} interpolation, so no static enable flag — but the token
+	// is still required (Mantle).
+	return LaunchSpec{
+		TokenEnvVar: bedrockAuthEnvName,
+		NeedsToken:  true,
+	}
+}
+
+func (opencode) Supports(Capability) bool { return false }
+
+// opencodeCuratedModels maps a friendly key to a verified Mantle model ID. All
+// are Chat Completions on /v1 (see models-api-compatibility.html + mantle-model-
+// matrix). Popular coding models across vendors, reflecting OpenCode's
+// model-agnostic design.
+var opencodeCuratedModels = map[string]string{
+	"gpt-oss-120b":  "openai.gpt-oss-120b",
+	"gpt-oss-20b":   "openai.gpt-oss-20b",
+	"glm-4.7":       "zai.glm-4.7",
+	"glm-5":         "zai.glm-5",
+	"kimi-k2.5":     "moonshotai.kimi-k2.5",
+	"deepseek-v3.2": "deepseek.v3.2",
+	"qwen3-coder":   "qwen.qwen3-coder-480b-a35b-instruct",
+	"grok-4.3":      "xai.grok-4.3",
+}
+
+func opencodeDefaultModel() string { return "gpt-oss-120b" }
+
+// BuildConfig writes OpenCode's config: a custom OpenAI-compatible provider block
+// pointing at Mantle /v1, plus a top-level default model "provider_id/model_id".
+// A curated key resolves to its verified Mantle model ID; any other value is
+// passed through verbatim (BYO) with an "unverified" warning.
+func (opencode) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
+	key := opts.Model
+	if key == "" {
+		key = opencodeDefaultModel()
+	}
+
+	var warnings []string
+	modelID, curated := opencodeCuratedModels[key]
+	if !curated {
+		// Passthrough: treat the given value as a raw Mantle model ID. Honest
+		// about the risk — we haven't verified its API/path.
+		modelID = key
+		warnings = append(warnings, fmt.Sprintf(
+			"model %q is not in the curated set — writing it verbatim as a Mantle model. "+
+				"It may use a different API/path than Chat Completions and fail at runtime; "+
+				"verify against the model card if it doesn't work.", key))
+	}
+
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/v1", opts.Region)
+	keys := map[string]any{
+		"model": mantleProviderID + "/" + modelID,
+		"provider": map[string]any{
+			mantleProviderID: map[string]any{
+				"npm":  "@ai-sdk/openai-compatible",
+				"name": "Amazon Bedrock (Mantle)",
+				"options": map[string]any{
+					"baseURL": baseURL,
+					"apiKey":  "{env:" + bedrockAuthEnvName + "}",
+				},
+				"models": map[string]any{
+					modelID: map[string]any{"name": modelID},
+				},
+			},
+		},
+	}
+
+	return ConfigPlan{
+		Keys:        keys,
+		ManagedKeys: opencode{}.NativeManagedKeys(),
+		Warnings:    warnings,
+	}, nil
+}

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -1,0 +1,191 @@
+package provider
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGet_OpenCode(t *testing.T) {
+	p, err := Get("opencode")
+	if err != nil {
+		t.Fatalf("Get(opencode): %v", err)
+	}
+	if p.Name() != "opencode" {
+		t.Errorf("Name() = %q, want opencode", p.Name())
+	}
+}
+
+func TestOpenCode_ConfigFormatIsJSON(t *testing.T) {
+	p, _ := Get("opencode")
+	if p.ConfigFormatName() != "json" {
+		t.Errorf("format = %q, want json", p.ConfigFormatName())
+	}
+}
+
+func TestOpenCode_ConfigPath(t *testing.T) {
+	p, _ := Get("opencode")
+	home := t.TempDir()
+	user, err := p.ConfigPath(home, "user")
+	if err != nil {
+		t.Fatalf("user: %v", err)
+	}
+	// Global config lives at ~/.config/opencode/opencode.json
+	if !strings.Contains(filepath.ToSlash(user), ".config/opencode/opencode.json") {
+		t.Errorf("user path = %q, want ~/.config/opencode/opencode.json", user)
+	}
+	proj, err := p.ConfigPath(home, "project")
+	if err != nil {
+		t.Fatalf("project: %v", err)
+	}
+	if filepath.Base(proj) != "opencode.json" {
+		t.Errorf("project path = %q, want ./opencode.json", proj)
+	}
+}
+
+func TestOpenCode_BinaryNames(t *testing.T) {
+	p, _ := Get("opencode")
+	got := p.BinaryNames()
+	if len(got) == 0 || (got[0] != "opencode" && got[0] != "opencode.exe") {
+		t.Errorf("binary names = %v, want opencode first", got)
+	}
+}
+
+func TestOpenCode_ActivationMarkers(t *testing.T) {
+	p, _ := Get("opencode")
+	begin, end := p.ActivationMarkers()
+	if begin != "# BEGIN: Juggernaut OpenCode Activation" {
+		t.Errorf("begin = %q", begin)
+	}
+	if end != "# END: Juggernaut OpenCode Activation" {
+		t.Errorf("end = %q", end)
+	}
+	cb, _ := (claude{}).ActivationMarkers()
+	xb, _ := (codex{}).ActivationMarkers()
+	if begin == cb || begin == xb {
+		t.Error("OpenCode markers must be distinct from claude/codex")
+	}
+}
+
+func TestOpenCode_LaunchSpec(t *testing.T) {
+	p, _ := Get("opencode")
+	ls := p.LaunchSpec()
+	// OpenCode routes via config; token supplied through {env:VAR}. No static
+	// enable flag, but the bearer token is still needed (Mantle).
+	if len(ls.StaticEnv) != 0 {
+		t.Errorf("OpenCode should have no static enable flag, got %v", ls.StaticEnv)
+	}
+	if ls.TokenEnvVar != "AWS_BEARER_TOKEN_BEDROCK" {
+		t.Errorf("TokenEnvVar = %q", ls.TokenEnvVar)
+	}
+	if !ls.NeedsToken {
+		t.Error("OpenCode via Mantle needs a token")
+	}
+}
+
+func TestOpenCode_Supports_None(t *testing.T) {
+	p, _ := Get("opencode")
+	for _, c := range []Capability{CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels} {
+		if p.Supports(c) {
+			t.Errorf("OpenCode should not claim Claude/Codex capability %d", c)
+		}
+	}
+}
+
+// TestOpenCode_OwnsConfig: recognizes a config we wrote by our provider id under
+// the "provider" map, not a plain user opencode.json.
+func TestOpenCode_OwnsConfig(t *testing.T) {
+	p, _ := Get("opencode")
+	if !p.OwnsConfig(map[string]any{
+		"provider": map[string]any{"bedrock-mantle": map[string]any{"npm": "@ai-sdk/openai-compatible"}},
+	}) {
+		t.Error("should own a config containing our bedrock-mantle provider")
+	}
+	// Plain user config with other providers → not ours.
+	if p.OwnsConfig(map[string]any{"provider": map[string]any{"anthropic": map[string]any{}}}) {
+		t.Error("must not claim a config without our bedrock-mantle provider")
+	}
+	if p.OwnsConfig(map[string]any{"model": "anthropic/claude"}) {
+		t.Error("must not claim a plain config")
+	}
+}
+
+// TestOpenCode_BuildConfig_Curated: default (gpt-oss) writes a custom
+// openai-compatible provider block pointing at Mantle /v1, plus top-level model.
+func TestOpenCode_BuildConfig_Curated(t *testing.T) {
+	p, _ := Get("opencode")
+	opts := baseOpts()
+	opts.Region = "us-west-2"
+	plan, err := p.BuildConfig(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	prov, ok := plan.Keys["provider"].(map[string]any)
+	if !ok {
+		t.Fatalf("provider block missing: %T", plan.Keys["provider"])
+	}
+	bm, ok := prov["bedrock-mantle"].(map[string]any)
+	if !ok {
+		t.Fatalf("bedrock-mantle provider missing: %v", prov)
+	}
+	if bm["npm"] != "@ai-sdk/openai-compatible" {
+		t.Errorf("npm = %v, want @ai-sdk/openai-compatible", bm["npm"])
+	}
+	optsMap, _ := bm["options"].(map[string]any)
+	if base, _ := optsMap["baseURL"].(string); base != "https://bedrock-mantle.us-west-2.api.aws/v1" {
+		t.Errorf("baseURL = %q, want .../v1", base)
+	}
+	if api, _ := optsMap["apiKey"].(string); api != "{env:AWS_BEARER_TOKEN_BEDROCK}" {
+		t.Errorf("apiKey = %q, want {env:AWS_BEARER_TOKEN_BEDROCK}", api)
+	}
+	// top-level model must be provider_id/model_id
+	if m, _ := plan.Keys["model"].(string); m != "bedrock-mantle/openai.gpt-oss-120b" {
+		t.Errorf("model = %q, want bedrock-mantle/openai.gpt-oss-120b", m)
+	}
+	if err := plan.Validate(); err != nil {
+		t.Errorf("plan should validate: %v", err)
+	}
+}
+
+// TestOpenCode_BuildConfig_CuratedModels: GLM/Kimi/DeepSeek/Qwen are curated and
+// resolve to their Mantle model IDs (all Chat/v1).
+func TestOpenCode_BuildConfig_CuratedModels(t *testing.T) {
+	cases := map[string]string{
+		"glm-4.7":       "zai.glm-4.7",
+		"kimi-k2.5":     "moonshotai.kimi-k2.5",
+		"deepseek-v3.2": "deepseek.v3.2",
+		"qwen3-coder":   "qwen.qwen3-coder-480b-a35b-instruct",
+		"grok-4.3":      "xai.grok-4.3",
+	}
+	p, _ := Get("opencode")
+	for key, wantID := range cases {
+		opts := baseOpts()
+		opts.Model = key
+		plan, err := p.BuildConfig(testConfig(), opts)
+		if err != nil {
+			t.Errorf("%s: BuildConfig: %v", key, err)
+			continue
+		}
+		if m, _ := plan.Keys["model"].(string); m != "bedrock-mantle/"+wantID {
+			t.Errorf("%s: model = %q, want bedrock-mantle/%s", key, m, wantID)
+		}
+	}
+}
+
+// TestOpenCode_BuildConfig_Passthrough: an unknown model id is accepted verbatim
+// (BYO) and surfaces an "unverified" warning.
+func TestOpenCode_BuildConfig_Passthrough(t *testing.T) {
+	p, _ := Get("opencode")
+	opts := baseOpts()
+	opts.Model = "some.exotic-model-v9"
+	plan, err := p.BuildConfig(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("passthrough should not error: %v", err)
+	}
+	if m, _ := plan.Keys["model"].(string); m != "bedrock-mantle/some.exotic-model-v9" {
+		t.Errorf("passthrough model = %q, want verbatim id", m)
+	}
+	if len(plan.Warnings) == 0 {
+		t.Error("passthrough (unverified) model should emit a warning")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -70,6 +70,7 @@ func register(p Provider) { registry[p.Name()] = p }
 func init() {
 	register(claude{})
 	register(codex{})
+	register(opencode{})
 }
 
 // Get resolves a provider by name. An empty name defaults to "claude" so every


### PR DESCRIPTION
## What

Third harness behind the `Provider` abstraction (after Claude + Codex): **OpenCode** (`sst`/`anomalyco`, ~181k★). `apply/launch/uninstall --cli=opencode` all work — with **zero `cmd/` per-CLI changes**, since the apply/launch/uninstall flows are already fully provider-driven. That's the abstraction paying off.

## Design: curated + passthrough (model-agnostic)

OpenCode is deliberately model-agnostic ("bring any compatible model"), and Bedrock/Mantle hosts 45+ models across many vendors. So rather than a fixed OpenAI-only list *or* a landmine dropdown that lists models it can't actually serve:

- **Curated tier** — dev-favorite coding models whose Chat-Completions support is **verified in `models-api-compatibility.html`**: `gpt-oss-120b/20b`, `zai.glm-4.7`/`glm-5`, `moonshotai.kimi-k2.5`, `deepseek.v3.2`, `qwen3-coder-480b`, `xai.grok-4.3`. All uniformly Chat/`/v1`/`@ai-sdk/openai-compatible`, so the provider block is clean.
- **Passthrough** — any other `--model <id>` is written verbatim as a Mantle model with an explicit **"unverified — may use a different API/path"** warning. Honors "any compatible model" honestly.

Writes `~/.config/opencode/opencode.json`: `provider.bedrock-mantle { npm:@ai-sdk/openai-compatible, options.baseURL→Mantle /v1, apiKey:{env:AWS_BEARER_TOKEN_BEDROCK} }` + top-level `model: "bedrock-mantle/<id>"`.

## Also fixes (pre-existing, surfaced by OpenCode)

- **`ConfigPlan.Warnings` was never printed.** Both Codex (region warning) and OpenCode (passthrough) computed warnings that silently vanished — `commitApply` now surfaces them. Regression-tested.
- **`providerDisplayName()`** — messages read "OpenCode"/"Codex"/"Claude" instead of `strings.Title`'s mangled "Opencode".

## Verified (real binary)

- `apply --cli=opencode` writes correct `opencode.json` + `opencode()` wrapper.
- Curated `--model=glm-4.7` → `zai.glm-4.7`; passthrough warns.
- `uninstall --cli=opencode --full` removes its config + wrapper; **Claude preserved**; 3-way coexistence (claude+codex+opencode) in one profile.
- `opencode.go` ~100% covered; Claude golden byte-identical; full suite green; gofmt/vet/gosec clean.

Part of the multi-CLI effort; targets the v5.3.0-preview batch.