### PR TITLE
feat: Grok CLI on Bedrock (--cli=grok) + fix nested-config data loss

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -275,7 +275,7 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 		return err
 	}
 	mgr := config.NewManagerWithFormat(path, format)
-	if err := mgr.MergeConfigPlan(plan.Keys); err != nil {
+	if err := mgr.MergeConfigPlanDeep(plan.Keys, prov.DeepMergeKeys()); err != nil {
 		return err
 	}
 
@@ -379,6 +379,8 @@ func providerDisplayName(name string) string {
 		return "Codex"
 	case "opencode":
 		return "OpenCode"
+	case "grok":
+		return "Grok"
 	default:
 		return strings.Title(name) //nolint:staticcheck // ASCII CLI name fallback
 	}

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1167,6 +1167,8 @@ func (s stubProvider) BuildConfig(*bedrock.Config, provider.Options) (provider.C
 }
 func (s stubProvider) LaunchSpec() provider.LaunchSpec   { return provider.LaunchSpec{} }
 func (s stubProvider) Supports(provider.Capability) bool { return false }
+func (s stubProvider) DeepMergeKeys() []string           { return nil }
+func (s stubProvider) OwnedSubKeys() map[string][]string { return nil }
 
 // TestResolveApplyInputs_BadConfigFormat_Errors covers the FormatByName error
 // branch: a provider reporting an unknown config format surfaces an error rather

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -126,7 +126,7 @@ func uninstallSettingsBlock(home, scope string, prov provider.Provider) {
 		fmt.Printf("Would remove juggernaut block from %s %s config\n", scope, prov.Name())
 		return
 	}
-	if err := mgr.RemoveManagedKeys(prov.NativeManagedKeys()); err != nil {
+	if err := mgr.RemoveManagedKeysDeep(prov.NativeManagedKeys(), prov.OwnedSubKeys()); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not remove %s block: %v\n", scope, err)
 		return
 	}

--- a/internal/config/deep_merge_test.go
+++ b/internal/config/deep_merge_test.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestMergeConfigPlan_DeepMergeKeys_PreservesSiblings is the data-loss
+// regression: writing a nested-table key (e.g. Grok's "model") must merge only
+// Juggernaut's own sub-key, preserving the user's other entries — NOT replace
+// the whole table. Recreates the real scenario that would have wiped a user's
+// batwing-coder / batmobile model profiles.
+func TestMergeConfigPlan_DeepMergeKeys_PreservesSiblings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+
+	// User's pre-existing config with their own model profiles + default.
+	if err := m.Write(map[string]any{
+		"model": map[string]any{
+			"batwing-coder":    map[string]any{"base_url": "http://192.168.0.131:8082/v1", "model": "qwen36"},
+			"batmobile-gemma4": map[string]any{"base_url": "http://192.168.0.112:1234/v1"},
+		},
+		"models": map[string]any{"default": "batwing-coder"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Juggernaut writes its bedrock-grok block. Deep-merge keys: model, models.
+	err := m.MergeConfigPlanDeep(map[string]any{
+		"model": map[string]any{
+			"bedrock-grok": map[string]any{"model": "xai.grok-4.3", "base_url": "https://mantle/openai/v1"},
+		},
+		"models": map[string]any{"default": "bedrock-grok"},
+	}, []string{"model", "models"})
+	if err != nil {
+		t.Fatalf("MergeConfigPlanDeep: %v", err)
+	}
+
+	got, _ := m.Read()
+	modelTbl, _ := got["model"].(map[string]any)
+	if modelTbl == nil {
+		t.Fatal("model table lost")
+	}
+	// Both the user's profiles AND ours must be present.
+	for _, want := range []string{"batwing-coder", "batmobile-gemma4", "bedrock-grok"} {
+		if _, ok := modelTbl[want]; !ok {
+			t.Errorf("model.%s missing after merge — data loss!", want)
+		}
+	}
+	// models.default: Juggernaut set it to bedrock-grok (a leaf override).
+	modelsTbl, _ := got["models"].(map[string]any)
+	if modelsTbl["default"] != "bedrock-grok" {
+		t.Errorf("models.default = %v, want bedrock-grok", modelsTbl["default"])
+	}
+}
+
+// TestRemoveManagedKeysDeep_PreservesSiblings is the uninstall-side data-loss
+// regression: removing our bedrock-grok block must NOT delete the user's other
+// model profiles or the whole table.
+func TestRemoveManagedKeysDeep_PreservesSiblings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	if err := m.Write(map[string]any{
+		"model": map[string]any{
+			"batwing-coder": map[string]any{"base_url": "http://x/v1"},
+			"bedrock-grok":  map[string]any{"model": "xai.grok-4.3"},
+		},
+		"models": map[string]any{"default": "bedrock-grok", "web_search": "batwing-coder"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := m.RemoveManagedKeysDeep([]string{"model", "models"}, map[string][]string{
+		"model":  {"bedrock-grok"},
+		"models": {"default"},
+	})
+	if err != nil {
+		t.Fatalf("RemoveManagedKeysDeep: %v", err)
+	}
+	got, _ := m.Read()
+	modelTbl, _ := got["model"].(map[string]any)
+	if modelTbl == nil {
+		t.Fatal("model table wrongly deleted — data loss!")
+	}
+	if _, ok := modelTbl["batwing-coder"]; !ok {
+		t.Error("user's batwing-coder profile lost on uninstall — data loss!")
+	}
+	if _, ok := modelTbl["bedrock-grok"]; ok {
+		t.Error("our bedrock-grok should be removed")
+	}
+	modelsTbl, _ := got["models"].(map[string]any)
+	if modelsTbl == nil {
+		t.Fatal("models table wrongly deleted")
+	}
+	if _, ok := modelsTbl["default"]; ok {
+		t.Error("our models.default should be removed")
+	}
+	if modelsTbl["web_search"] != "batwing-coder" {
+		t.Error("user's models.web_search setting lost — data loss!")
+	}
+}
+
+// TestRemoveManagedKeysDeep_EmptyTableCleaned: if removing our sub-key leaves the
+// nested table empty, the table itself is removed (no orphan empty table).
+func TestRemoveManagedKeysDeep_EmptyTableCleaned(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	_ = m.Write(map[string]any{
+		"model": map[string]any{"bedrock-grok": map[string]any{"model": "x"}},
+	})
+	_ = m.RemoveManagedKeysDeep([]string{"model"}, map[string][]string{"model": {"bedrock-grok"}})
+	got, _ := m.Read()
+	if _, ok := got["model"]; ok {
+		t.Error("empty model table should be removed after our only sub-key is gone")
+	}
+}
+
+// TestMergeConfigPlanDeep_NonDeepKeysStillReplace verifies keys NOT in the
+// deep-merge set keep whole-value replace semantics (back-compat for Claude's
+// env / modelOverrides etc.).
+func TestMergeConfigPlanDeep_NonDeepKeysStillReplace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	m := NewManager(path)
+	if err := m.Write(map[string]any{
+		"env": map[string]any{"OLD_KEY": "stale"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// env is NOT a deep-merge key → replaced wholesale.
+	err := m.MergeConfigPlanDeep(map[string]any{
+		"env": map[string]any{"AWS_REGION": "us-west-2"},
+	}, nil) // no deep keys
+	if err != nil {
+		t.Fatalf("MergeConfigPlanDeep: %v", err)
+	}
+	got, _ := m.Read()
+	env, _ := got["env"].(map[string]any)
+	if _, stale := env["OLD_KEY"]; stale {
+		t.Error("non-deep key should be replaced wholesale, stale OLD_KEY survived")
+	}
+	if env["AWS_REGION"] != "us-west-2" {
+		t.Errorf("env not replaced correctly: %v", env)
+	}
+}

--- a/internal/config/deep_merge_test.go
+++ b/internal/config/deep_merge_test.go
@@ -114,6 +114,36 @@ func TestRemoveManagedKeysDeep_EmptyTableCleaned(t *testing.T) {
 	}
 }
 
+// TestMergeConfigPlanDeep_NonMapValueFallsBackToReplace covers mergeNested's
+// fallback: if a "deep" key's incoming value isn't a map, it's set whole.
+func TestMergeConfigPlanDeep_NonMapValueFallsBackToReplace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	_ = m.Write(map[string]any{"model": "old-string-value"})
+	// "model" is declared deep but incoming value is a string → whole replace.
+	if err := m.MergeConfigPlanDeep(map[string]any{"model": "new-string"}, []string{"model"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := m.Read()
+	if got["model"] != "new-string" {
+		t.Errorf("non-map deep value should replace, got %v", got["model"])
+	}
+}
+
+// TestRemoveManagedKeysDeep_MissingTable is a no-op when the deep key is absent.
+func TestRemoveManagedKeysDeep_MissingTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	_ = m.Write(map[string]any{"unrelated": "x"})
+	if err := m.RemoveManagedKeysDeep([]string{"model"}, map[string][]string{"model": {"bedrock-grok"}}); err != nil {
+		t.Fatalf("should not error on missing table: %v", err)
+	}
+	got, _ := m.Read()
+	if got["unrelated"] != "x" {
+		t.Error("unrelated key must survive")
+	}
+}
+
 // TestMergeConfigPlanDeep_NonDeepKeysStillReplace verifies keys NOT in the
 // deep-merge set keep whole-value replace semantics (back-compat for Claude's
 // env / modelOverrides etc.).

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -193,13 +193,31 @@ func applyManagedKey(existing map[string]any, k string, v any) error {
 // "juggernaut" key (if present) is always set. This is the generic,
 // provider-driven entry point that supersedes MergeJuggernautBlock's fixed shape.
 func (m *Manager) MergeConfigPlan(keys map[string]any) error {
+	return m.MergeConfigPlanDeep(keys, nil)
+}
+
+// MergeConfigPlanDeep is like MergeConfigPlan but deep-merges the named keys
+// (nested tables where Juggernaut owns only its OWN sub-keys, e.g. Grok's
+// [model.<name>], Codex's [model_providers.<id>], OpenCode's provider.<id>):
+// their sub-keys are merged into the existing table rather than replacing it, so
+// a user's sibling entries survive. All other keys keep whole-value
+// set-or-delete semantics.
+func (m *Manager) MergeConfigPlanDeep(keys map[string]any, deepKeys []string) error {
 	existing, err := m.Read()
 	if err != nil {
 		return err
 	}
+	deep := make(map[string]bool, len(deepKeys))
+	for _, k := range deepKeys {
+		deep[k] = true
+	}
 	for k, v := range keys {
 		if k == "juggernaut" {
 			existing[k] = v // the managed block is always set verbatim
+			continue
+		}
+		if deep[k] {
+			mergeNested(existing, k, v)
 			continue
 		}
 		if err := applyManagedKey(existing, k, v); err != nil {
@@ -207,6 +225,25 @@ func (m *Manager) MergeConfigPlan(keys map[string]any) error {
 		}
 	}
 	return m.Write(existing)
+}
+
+// mergeNested merges the sub-keys of a nested-table value into existing[k],
+// preserving the user's other sub-keys. Juggernaut's leaves overwrite matching
+// ones. If the incoming value isn't a map, it falls back to whole replace.
+func mergeNested(existing map[string]any, k string, v any) {
+	incoming, ok := v.(map[string]any)
+	if !ok {
+		existing[k] = v
+		return
+	}
+	dst, ok := existing[k].(map[string]any)
+	if !ok || dst == nil {
+		dst = map[string]any{}
+	}
+	for sk, sv := range incoming {
+		dst[sk] = sv
+	}
+	existing[k] = dst
 }
 
 // mergePermissions sets or removes only the permissions.defaultMode sub-key,
@@ -248,6 +285,15 @@ func (m *Manager) RemoveJuggernautBlock() error {
 // (only defaultMode is stripped). This is the generic, provider-driven form of
 // RemoveJuggernautBlock.
 func (m *Manager) RemoveManagedKeys(keys []string) error {
+	return m.RemoveManagedKeysDeep(keys, nil)
+}
+
+// RemoveManagedKeysDeep removes the juggernaut block plus the given managed
+// top-level keys. For keys listed in ownedSubKeys (nested tables where a user
+// may have their own sibling entries), ONLY Juggernaut's own sub-keys are
+// removed — preserving the user's; if that empties the table, the table is
+// dropped. All other keys are removed whole-value.
+func (m *Manager) RemoveManagedKeysDeep(keys []string, ownedSubKeys map[string][]string) error {
 	existing, err := m.Read()
 	if err != nil {
 		return err
@@ -258,12 +304,34 @@ func (m *Manager) RemoveManagedKeys(keys []string) error {
 			mergePermissions(existing, nil)
 			continue
 		}
+		if subs, deep := ownedSubKeys[k]; deep {
+			removeOwnedSubKeys(existing, k, subs)
+			continue
+		}
 		delete(existing, k)
 	}
 	// Ensure the Juggernaut-managed permissions sub-key is stripped even if
 	// "permissions" was not in the key list (matches legacy behavior).
 	mergePermissions(existing, nil)
 	return m.Write(existing)
+}
+
+// removeOwnedSubKeys deletes only the named sub-keys from existing[k]'s nested
+// table, preserving the user's other entries. Drops the table entirely if it
+// becomes empty.
+func removeOwnedSubKeys(existing map[string]any, k string, subs []string) {
+	tbl, ok := existing[k].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, sk := range subs {
+		delete(tbl, sk)
+	}
+	if len(tbl) == 0 {
+		delete(existing, k)
+	} else {
+		existing[k] = tbl
+	}
 }
 
 // HasManagedKeys reports whether the config contains the juggernaut block or any

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -51,6 +51,13 @@ func (claude) OwnsConfig(data map[string]any) bool {
 	return meta["managedBy"] == "juggernaut"
 }
 
+// DeepMergeKeys: Claude's managed keys are all whole-value (Juggernaut fully
+// owns env/modelOverrides/etc.), so none are deep-merged.
+func (claude) DeepMergeKeys() []string { return nil }
+
+// OwnedSubKeys: none — Claude has no deep-merge keys.
+func (claude) OwnedSubKeys() map[string][]string { return nil }
+
 func (claude) NativeManagedKeys() []string {
 	return []string{
 		"env",

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -55,6 +55,16 @@ func (codex) NativeManagedKeys() []string {
 	}
 }
 
+// DeepMergeKeys: model_providers is a nested [model_providers.<id>] table where a
+// user may have their own providers; merge only our bedrock-mantle entry.
+func (codex) DeepMergeKeys() []string { return []string{"model_providers"} }
+
+// OwnedSubKeys: uninstall removes only our bedrock-mantle provider from the
+// model_providers table (model / model_provider leaves are removed whole).
+func (codex) OwnedSubKeys() map[string][]string {
+	return map[string][]string{"model_providers": {"bedrock-mantle"}}
+}
+
 func (codex) ActivationMarkers() (begin, end string) {
 	return "# BEGIN: Juggernaut Codex Activation", "# END: Juggernaut Codex Activation"
 }

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -1,0 +1,114 @@
+package provider
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+)
+
+// grok is the OFFICIAL xAI Grok CLI provider (grok / grok.exe, config TOML at
+// ~/.grok/config.toml). Grok is a BYOK-friendly harness: custom providers are
+// [model.<name>] tables with base_url + env_key, selected via [models].default.
+// Juggernaut routes to Grok 4.3 on Bedrock Mantle by writing such a block with
+// base_url → Mantle /openai/v1 and env_key → the injected bearer token (xAI's
+// own docs prefer env_key over inline api_key). Schema verified against a real
+// install + docs.x.ai/build/settings — see the grok-cli-config-schema memory.
+type grok struct{}
+
+// grokModelName is the [model.<name>] key + [models].default value we write.
+const grokModelName = "bedrock-grok"
+
+func (grok) Name() string { return "grok" }
+
+func (grok) BinaryNames() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"grok.exe", "grok.cmd", "grok.bat"}
+	}
+	return []string{"grok"}
+}
+
+func (grok) ConfigFormatName() string { return "toml" }
+
+// ConfigPath is ALWAYS ~/.grok/config.toml. Grok's project-scoped
+// .grok/config.toml only accepts mcp_servers/plugins/permission — model config
+// is user-scoped — so both scopes resolve to the user config.
+func (grok) ConfigPath(home, _ string) (string, error) {
+	return safepath.JoinUnder(home, ".grok", "config.toml")
+}
+
+// NativeManagedKeys are the top-level config.toml keys Juggernaut owns. Note the
+// whole [model] and [models] tables are managed here (Grok nests custom models
+// under [model.<name>]); on uninstall RemoveManagedKeys drops them wholesale,
+// which is acceptable for a Juggernaut-owned config.
+func (grok) NativeManagedKeys() []string {
+	return []string{"model", "models"}
+}
+
+// DeepMergeKeys: both [model.<name>] and [models] are nested tables holding a
+// user's own model profiles + settings; merge only our bedrock-grok block and
+// the default leaf, preserving their profiles.
+func (grok) DeepMergeKeys() []string { return []string{"model", "models"} }
+
+// OwnedSubKeys: uninstall removes only our bedrock-grok model profile and the
+// models.default pointer we set — preserving the user's other model profiles
+// and settings.
+func (grok) OwnedSubKeys() map[string][]string {
+	return map[string][]string{
+		"model":  {grokModelName},
+		"models": {"default"},
+	}
+}
+
+// OwnsConfig recognizes a config Juggernaut wrote by our named model block
+// [model.bedrock-grok] — NOT a user's own model profiles.
+func (grok) OwnsConfig(data map[string]any) bool {
+	models, ok := data["model"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = models[grokModelName]
+	return ok
+}
+
+func (grok) ActivationMarkers() (begin, end string) {
+	return "# BEGIN: Juggernaut Grok Activation", "# END: Juggernaut Grok Activation"
+}
+
+func (grok) LaunchSpec() LaunchSpec {
+	// Grok routes via config (env_key references the token env var); no static
+	// enable flag, but the bearer token is required (Mantle).
+	return LaunchSpec{
+		TokenEnvVar: bedrockAuthEnvName,
+		NeedsToken:  true,
+	}
+}
+
+func (grok) Supports(Capability) bool { return false }
+
+// BuildConfig writes a [model.bedrock-grok] block routing to Grok 4.3 on Mantle
+// plus [models].default. Grok 4.3 is the only xAI model on Mantle, so there's no
+// model table/passthrough — just the one verified target.
+func (grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1", opts.Region)
+	keys := map[string]any{
+		"model": map[string]any{
+			grokModelName: map[string]any{
+				"model":          "xai.grok-4.3",
+				"base_url":       baseURL,
+				"name":           "Grok 4.3 (Amazon Bedrock Mantle)",
+				"env_key":        bedrockAuthEnvName,
+				"api_backend":    "chat_completions",
+				"context_window": 1000000,
+			},
+		},
+		"models": map[string]any{
+			"default": grokModelName,
+		},
+	}
+	return ConfigPlan{
+		Keys:        keys,
+		ManagedKeys: grok{}.NativeManagedKeys(),
+	}, nil
+}

--- a/internal/provider/grok_test.go
+++ b/internal/provider/grok_test.go
@@ -1,0 +1,148 @@
+package provider
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGet_Grok(t *testing.T) {
+	p, err := Get("grok")
+	if err != nil {
+		t.Fatalf("Get(grok): %v", err)
+	}
+	if p.Name() != "grok" {
+		t.Errorf("Name() = %q, want grok", p.Name())
+	}
+}
+
+func TestGrok_ConfigFormatIsTOML(t *testing.T) {
+	p, _ := Get("grok")
+	if p.ConfigFormatName() != "toml" {
+		t.Errorf("format = %q, want toml", p.ConfigFormatName())
+	}
+}
+
+// TestGrok_ConfigPath: ~/.grok/config.toml. Grok's model config is USER-ONLY
+// (project .grok/config.toml accepts only mcp/plugins/permission), so BOTH
+// scopes resolve to the user config.
+func TestGrok_ConfigPath(t *testing.T) {
+	p, _ := Get("grok")
+	home := t.TempDir()
+	for _, scope := range []string{"user", "project"} {
+		got, err := p.ConfigPath(home, scope)
+		if err != nil {
+			t.Fatalf("scope %s: %v", scope, err)
+		}
+		if !strings.Contains(filepath.ToSlash(got), ".grok/config.toml") {
+			t.Errorf("scope %s path = %q, want ~/.grok/config.toml", scope, got)
+		}
+	}
+}
+
+func TestGrok_BinaryNames(t *testing.T) {
+	p, _ := Get("grok")
+	got := p.BinaryNames()
+	if len(got) == 0 || (got[0] != "grok" && got[0] != "grok.exe") {
+		t.Errorf("binary names = %v, want grok first", got)
+	}
+}
+
+func TestGrok_ActivationMarkers(t *testing.T) {
+	p, _ := Get("grok")
+	begin, end := p.ActivationMarkers()
+	if begin != "# BEGIN: Juggernaut Grok Activation" {
+		t.Errorf("begin = %q", begin)
+	}
+	if end != "# END: Juggernaut Grok Activation" {
+		t.Errorf("end = %q", end)
+	}
+	for _, other := range []Provider{claude{}, codex{}, opencode{}} {
+		ob, _ := other.ActivationMarkers()
+		if begin == ob {
+			t.Errorf("Grok markers must differ from %s", other.Name())
+		}
+	}
+}
+
+func TestGrok_LaunchSpec(t *testing.T) {
+	p, _ := Get("grok")
+	ls := p.LaunchSpec()
+	if len(ls.StaticEnv) != 0 {
+		t.Errorf("Grok should have no static enable flag, got %v", ls.StaticEnv)
+	}
+	if ls.TokenEnvVar != "AWS_BEARER_TOKEN_BEDROCK" {
+		t.Errorf("TokenEnvVar = %q", ls.TokenEnvVar)
+	}
+	if !ls.NeedsToken {
+		t.Error("Grok via Mantle needs a token")
+	}
+}
+
+func TestGrok_Supports_None(t *testing.T) {
+	p, _ := Get("grok")
+	for _, c := range []Capability{CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels} {
+		if p.Supports(c) {
+			t.Errorf("Grok should not claim capability %d", c)
+		}
+	}
+}
+
+// TestGrok_OwnsConfig: recognizes our named [model.bedrock-grok] block, not a
+// user's own grok model profiles.
+func TestGrok_OwnsConfig(t *testing.T) {
+	p, _ := Get("grok")
+	if !p.OwnsConfig(map[string]any{
+		"model": map[string]any{"bedrock-grok": map[string]any{"model": "xai.grok-4.3"}},
+	}) {
+		t.Error("should own a config containing [model.bedrock-grok]")
+	}
+	// A plain grok config with other model profiles → not ours.
+	if p.OwnsConfig(map[string]any{
+		"model": map[string]any{"my-local": map[string]any{"base_url": "http://localhost"}},
+	}) {
+		t.Error("must not claim a config without our bedrock-grok model")
+	}
+	if p.OwnsConfig(map[string]any{"models": map[string]any{"default": "grok-4.3"}}) {
+		t.Error("must not claim a plain config")
+	}
+}
+
+// TestGrok_BuildConfig writes the [model.bedrock-grok] block (base_url→Mantle
+// /openai/v1, env_key, model xai.grok-4.3) + [models].default.
+func TestGrok_BuildConfig(t *testing.T) {
+	p, _ := Get("grok")
+	opts := baseOpts()
+	opts.Region = "us-east-1"
+	plan, err := p.BuildConfig(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	modelSection, ok := plan.Keys["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("[model] table missing: %T", plan.Keys["model"])
+	}
+	bg, ok := modelSection["bedrock-grok"].(map[string]any)
+	if !ok {
+		t.Fatalf("[model.bedrock-grok] missing: %v", modelSection)
+	}
+	if bg["model"] != "xai.grok-4.3" {
+		t.Errorf("model = %v, want xai.grok-4.3", bg["model"])
+	}
+	if base, _ := bg["base_url"].(string); base != "https://bedrock-mantle.us-east-1.api.aws/openai/v1" {
+		t.Errorf("base_url = %q, want .../openai/v1", base)
+	}
+	if bg["env_key"] != "AWS_BEARER_TOKEN_BEDROCK" {
+		t.Errorf("env_key = %v, want AWS_BEARER_TOKEN_BEDROCK", bg["env_key"])
+	}
+	if bg["api_backend"] != "chat_completions" {
+		t.Errorf("api_backend = %v, want chat_completions", bg["api_backend"])
+	}
+	models, ok := plan.Keys["models"].(map[string]any)
+	if !ok || models["default"] != "bedrock-grok" {
+		t.Errorf("[models].default = %v, want bedrock-grok", plan.Keys["models"])
+	}
+	if err := plan.Validate(); err != nil {
+		t.Errorf("plan should validate: %v", err)
+	}
+}

--- a/internal/provider/grok_test.go
+++ b/internal/provider/grok_test.go
@@ -79,6 +79,33 @@ func TestGrok_LaunchSpec(t *testing.T) {
 	}
 }
 
+// TestDeepMergeContract pins each provider's deep-merge keys + owned sub-keys —
+// the contract the data-loss fix depends on.
+func TestDeepMergeContract(t *testing.T) {
+	cases := map[string]struct {
+		deep  []string
+		owned map[string][]string
+	}{
+		"claude":   {nil, nil},
+		"codex":    {[]string{"model_providers"}, map[string][]string{"model_providers": {"bedrock-mantle"}}},
+		"opencode": {[]string{"provider"}, map[string][]string{"provider": {"bedrock-mantle"}}},
+		"grok":     {[]string{"model", "models"}, map[string][]string{"model": {"bedrock-grok"}, "models": {"default"}}},
+	}
+	for name, want := range cases {
+		p, _ := Get(name)
+		got := p.DeepMergeKeys()
+		if len(got) != len(want.deep) {
+			t.Errorf("%s DeepMergeKeys = %v, want %v", name, got, want.deep)
+		}
+		os := p.OwnedSubKeys()
+		for k, subs := range want.owned {
+			if len(os[k]) != len(subs) || (len(subs) > 0 && os[k][0] != subs[0]) {
+				t.Errorf("%s OwnedSubKeys[%s] = %v, want %v", name, k, os[k], subs)
+			}
+		}
+	}
+}
+
 func TestGrok_Supports_None(t *testing.T) {
 	p, _ := Get("grok")
 	for _, c := range []Capability{CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels} {

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -52,6 +52,16 @@ func (opencode) NativeManagedKeys() []string {
 	return []string{"model", "provider"}
 }
 
+// DeepMergeKeys: "provider" is a nested map where a user may have their own
+// providers (anthropic, openai, …); merge only our bedrock-mantle entry.
+func (opencode) DeepMergeKeys() []string { return []string{"provider"} }
+
+// OwnedSubKeys: uninstall removes only our bedrock-mantle provider from the
+// provider map (the model leaf is removed whole).
+func (opencode) OwnedSubKeys() map[string][]string {
+	return map[string][]string{"provider": {mantleProviderID}}
+}
+
 // OwnsConfig recognizes a config Juggernaut wrote by our bedrock-mantle provider
 // under the "provider" map — NOT a plain user opencode.json that merely has a
 // "provider" block for other vendors or a "model" key.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,6 +38,19 @@ type Provider interface {
 	// (replaced on apply, removed on uninstall).
 	NativeManagedKeys() []string
 
+	// DeepMergeKeys lists the subset of NativeManagedKeys that are NESTED tables
+	// where Juggernaut owns only its OWN sub-key (e.g. Grok's [model.<name>],
+	// Codex's [model_providers.<id>], OpenCode's provider.<id>). On apply these
+	// are deep-merged so a user's sibling entries survive instead of the whole
+	// table being replaced. Providers whose keys are all whole-value return nil.
+	DeepMergeKeys() []string
+
+	// OwnedSubKeys maps each deep-merge key to the specific sub-keys Juggernaut
+	// writes into it, so uninstall removes ONLY those (preserving a user's
+	// sibling entries) instead of deleting the whole nested table. Keys not
+	// listed here are removed whole-value on uninstall.
+	OwnedSubKeys() map[string][]string
+
 	// OwnsConfig reports whether the given parsed config was written by
 	// Juggernaut for THIS provider (i.e. Bedrock is already configured). It must
 	// be stricter than "any managed key is present": a plain user config that
@@ -71,6 +84,7 @@ func init() {
 	register(claude{})
 	register(codex{})
 	register(opencode{})
+	register(grok{})
 }
 
 // Get resolves a provider by name. An empty name defaults to "claude" so every


### PR DESCRIPTION
## What

Adds the **official xAI Grok CLI** as the 4th provider — and fixes a **data-loss bug** that affected all nested-config CLIs (Grok, Codex, OpenCode).

## Grok provider

Official xAI Grok CLI (`grok`/`grok.exe`), TOML `~/.grok/config.toml`. Schema verified against a real install + `docs.x.ai/build/settings`. Writes a `[model.bedrock-grok]` block (`model=xai.grok-4.3`, `base_url`→Mantle `/openai/v1`, `env_key=AWS_BEARER_TOKEN_BEDROCK`, `api_backend=chat_completions`, 1M ctx) + `[models].default`. Grok's custom-model `env_key` pattern is xAI's own documented preference — so the token is injected at launch, never written to disk. Config is **user-scoped only** (Grok's project config can't hold model defs).

## 🔴 Data-loss fix (the important part)

`apply`/`uninstall` replaced/deleted **whole nested config tables** — which would **wipe a user's own entries**: a real Grok user's `[model.batwing-coder]` / `[model.batmobile-*]` profiles, or a user's own Codex `[model_providers.*]` / OpenCode `provider.*` blocks. Caught during E2E on a synthetic config.

Fix:
- Providers declare `DeepMergeKeys()` (nested tables) + `OwnedSubKeys()` (the exact sub-keys Juggernaut writes).
- **apply → `MergeConfigPlanDeep`**: merges only our sub-key into the table, keeping siblings.
- **uninstall → `RemoveManagedKeysDeep`**: removes only our sub-keys; drops the table only if empty.
- Claude unaffected (no deep keys; **golden byte-identical**). Also fixes the latent bug for Codex + OpenCode.

## Verified E2E (real binary)

With a config holding `batwing-coder` + `batmobile-gemma4` + a `web_search` setting:
- `apply --cli=grok` → adds `bedrock-grok`, switches `default`, **preserves both profiles + web_search**.
- `uninstall --cli=grok` → removes only `bedrock-grok` + our default pointer, **both user profiles + web_search survive**.

Plus: `grok()` wrapper installed; coexists with claude/codex/opencode. Regression tests for both merge and remove; provider coverage ~100%; full suite green; gofmt/vet/gosec clean.

Completes the multi-CLI set (Claude + Codex + OpenCode + Grok) for the v5.3.0-preview.