### PR TITLE
fix: refuse silent data-loss on type-mismatched deep-merge keys

### DIFF
--- a/internal/config/deep_merge_test.go
+++ b/internal/config/deep_merge_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -127,6 +128,48 @@ func TestMergeConfigPlanDeep_NonMapValueFallsBackToReplace(t *testing.T) {
 	got, _ := m.Read()
 	if got["model"] != "new-string" {
 		t.Errorf("non-map deep value should replace, got %v", got["model"])
+	}
+}
+
+// TestMergeConfigPlanDeep_ScalarUnderTableKeyErrors: if a deep-merge key is
+// already present holding a NON-table value while we're merging a table into it,
+// the config is corrupt/foreign for a key Juggernaut owns as a table. Rather
+// than silently discard the user's value, merge must refuse with an actionable
+// error and leave the file untouched.
+func TestMergeConfigPlanDeep_ScalarUnderTableKeyErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	_ = m.Write(map[string]any{"model": "legacy-scalar"})
+	// Incoming is a TABLE (our bedrock-grok block) but existing "model" is a scalar.
+	err := m.MergeConfigPlanDeep(map[string]any{
+		"model": map[string]any{"bedrock-grok": map[string]any{"model": "xai.grok-4.3"}},
+	}, []string{"model"})
+	if err == nil {
+		t.Fatal("expected an error merging a table onto an existing scalar, got nil")
+	}
+	if !strings.Contains(err.Error(), "expected a table") {
+		t.Errorf("error should explain the type mismatch, got: %v", err)
+	}
+	// The user's scalar must survive untouched — we refused before writing.
+	got, _ := m.Read()
+	if got["model"] != "legacy-scalar" {
+		t.Errorf("user's value must be preserved on refusal, got %v", got["model"])
+	}
+}
+
+// TestRemoveManagedKeysDeep_ScalarUnderTableKeyErrors: uninstall must not
+// silently no-op when a deep key holds a non-table value; it surfaces the
+// corruption instead of leaving managed sub-keys unremoved.
+func TestRemoveManagedKeysDeep_ScalarUnderTableKeyErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	_ = m.Write(map[string]any{"model": "legacy-scalar"})
+	err := m.RemoveManagedKeysDeep([]string{"model"}, map[string][]string{"model": {"bedrock-grok"}})
+	if err == nil {
+		t.Fatal("expected an error removing sub-keys from a scalar, got nil")
+	}
+	if !strings.Contains(err.Error(), "expected a table") {
+		t.Errorf("error should explain the type mismatch, got: %v", err)
 	}
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -217,7 +217,9 @@ func (m *Manager) MergeConfigPlanDeep(keys map[string]any, deepKeys []string) er
 			continue
 		}
 		if deep[k] {
-			mergeNested(existing, k, v)
+			if err := mergeNested(existing, k, v, m.path); err != nil {
+				return err
+			}
 			continue
 		}
 		if err := applyManagedKey(existing, k, v); err != nil {
@@ -230,20 +232,34 @@ func (m *Manager) MergeConfigPlanDeep(keys map[string]any, deepKeys []string) er
 // mergeNested merges the sub-keys of a nested-table value into existing[k],
 // preserving the user's other sub-keys. Juggernaut's leaves overwrite matching
 // ones. If the incoming value isn't a map, it falls back to whole replace.
-func mergeNested(existing map[string]any, k string, v any) {
+//
+// If existing[k] is already present but holds a NON-table value (a scalar or
+// array), the config is corrupt/foreign for a key Juggernaut deep-merges (these
+// are always tables in a valid config). Rather than silently discard the user's
+// value, refuse and tell them what to fix — losing data quietly is worse than
+// stopping.
+func mergeNested(existing map[string]any, k string, v any, path string) error {
 	incoming, ok := v.(map[string]any)
 	if !ok {
 		existing[k] = v
-		return
+		return nil
 	}
-	dst, ok := existing[k].(map[string]any)
-	if !ok || dst == nil {
-		dst = map[string]any{}
+	dst := map[string]any{}
+	if raw, present := existing[k]; present {
+		m, isMap := raw.(map[string]any)
+		if !isMap {
+			return fmt.Errorf("cannot merge into %q in %s: expected a table but found %T — "+
+				"remove or fix that key in the file, then re-run", k, path, raw)
+		}
+		if m != nil {
+			dst = m
+		}
 	}
 	for sk, sv := range incoming {
 		dst[sk] = sv
 	}
 	existing[k] = dst
+	return nil
 }
 
 // mergePermissions sets or removes only the permissions.defaultMode sub-key,
@@ -305,7 +321,9 @@ func (m *Manager) RemoveManagedKeysDeep(keys []string, ownedSubKeys map[string][
 			continue
 		}
 		if subs, deep := ownedSubKeys[k]; deep {
-			removeOwnedSubKeys(existing, k, subs)
+			if err := removeOwnedSubKeys(existing, k, subs, m.path); err != nil {
+				return err
+			}
 			continue
 		}
 		delete(existing, k)
@@ -318,11 +336,19 @@ func (m *Manager) RemoveManagedKeysDeep(keys []string, ownedSubKeys map[string][
 
 // removeOwnedSubKeys deletes only the named sub-keys from existing[k]'s nested
 // table, preserving the user's other entries. Drops the table entirely if it
-// becomes empty.
-func removeOwnedSubKeys(existing map[string]any, k string, subs []string) {
-	tbl, ok := existing[k].(map[string]any)
+// becomes empty. If the key is absent there is nothing to remove (a clean
+// no-op); but if it is PRESENT holding a non-table value, the config is
+// corrupt/foreign for a key Juggernaut owns as a table — surface that instead
+// of silently leaving our sub-keys unremoved.
+func removeOwnedSubKeys(existing map[string]any, k string, subs []string, path string) error {
+	raw, present := existing[k]
+	if !present {
+		return nil
+	}
+	tbl, ok := raw.(map[string]any)
 	if !ok {
-		return
+		return fmt.Errorf("cannot remove managed sub-keys from %q in %s: expected a table but found %T — "+
+			"remove or fix that key in the file, then re-run", k, path, raw)
 	}
 	for _, sk := range subs {
 		delete(tbl, sk)
@@ -332,6 +358,7 @@ func removeOwnedSubKeys(existing map[string]any, k string, subs []string) {
 	} else {
 		existing[k] = tbl
 	}
+	return nil
 }
 
 // HasManagedKeys reports whether the config contains the juggernaut block or any

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -53,7 +53,11 @@ func (grok) DeepMergeKeys() []string { return []string{"model", "models"} }
 
 // OwnedSubKeys: uninstall removes only our bedrock-grok model profile and the
 // models.default pointer we set — preserving the user's other model profiles
-// and settings.
+// and settings. Note: apply sets models.default = bedrock-grok (that IS the
+// point — route Grok through Bedrock), and uninstall deletes that pointer
+// rather than restoring whatever default the user had before, since Juggernaut
+// does not persist the prior value. Grok then falls back to its built-in
+// default; the user's own model profiles are untouched.
 func (grok) OwnedSubKeys() map[string][]string {
 	return map[string][]string{
 		"model":  {grokModelName},


### PR DESCRIPTION
## What

Post-preview hardening from the multi-CLI bug-hunt (follow-ups 1–3 of the final sweep).

`mergeNested` and `removeOwnedSubKeys` silently discarded / skipped a user's value when a deep-merge key held a **scalar instead of a table**. Deep-merge keys — Grok `[model.*]`, Codex `[model_providers.*]`, OpenCode `provider.*` — are always tables in a valid config, so a non-table there means the config is corrupt or hand-edited into an incompatible shape. The old code:

- **apply**: `mergeNested` fell through to whole-value replace → user's value gone, no warning.
- **uninstall**: `removeOwnedSubKeys` `return`ed early → our managed sub-keys left unremoved, no error.

Both now **return an actionable error** naming the file and key, leaving the config untouched — losing data quietly is worse than stopping.

## Why this isn't the earlier "wiped my profile" bug

It isn't. The bug-hunt confirmed the deep-merge happy path is safe: BurntSushi/toml decodes nested tables to `map[string]any`, sibling keys survive apply+uninstall (verified with live TOML round-trips). These are the *robustness* gaps the audit surfaced on already-invalid input — not a wipe on valid input.

## Also

- Documented that Grok `uninstall` drops `models.default` rather than restoring the user's prior default (Juggernaut doesn't persist it); the user's own model profiles are untouched.

## Tests

- `TestMergeConfigPlanDeep_ScalarUnderTableKeyErrors` — apply refuses + preserves the user's value.
- `TestRemoveManagedKeysDeep_ScalarUnderTableKeyErrors` — uninstall surfaces the mismatch.
- Existing `TestMergeConfigPlanDeep_NonMapValueFallsBackToReplace` still passes (incoming scalar → whole replace unchanged).

Full suite green; gosec 0 issues.