### PR TITLE
fix(codex): skip ChatGPT login, reject IAM for Mantle-only CLIs, drop gpt-oss

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -121,6 +121,16 @@ func runApply(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Mantle-only CLIs (Codex, OpenCode, Grok) authenticate solely via a bearer
+	// token; IAM/SSO (SigV4) does not reach Mantle. Reject a non-bearer auth mode
+	// for them so we never write a config that can't authenticate — the symptom
+	// is the CLI silently falling back to its own sign-in at launch.
+	if !prov.Supports(provider.CapNativeAuth) && !authmode.IsBedrockAPIKey(authMode) {
+		return fmt.Errorf("%s routes through Bedrock Mantle, which requires a Bedrock API key — "+
+			"re-run with --auth=%s (IAM/SSO is not supported for this CLI)",
+			providerDisplayName(prov.Name()), authmode.BedrockAPIKey)
+	}
+
 	// Skip credential resolution in dry-run mode: it can prompt interactively
 	// for a Bedrock API key, and a dry-run must have no side effects. The token
 	// is only consumed by commitApply, which dry-run never reaches.
@@ -400,6 +410,13 @@ func reportLegacyRecovery(home string) {
 
 func resolveApplyInputs(home string, bCfg *bedrock.Config, prov provider.Provider) (authMode, region string, opusplan bool, err error) {
 	authMode = applyFlags.auth
+	// Mantle-only CLIs (Codex, OpenCode, Grok) have exactly one valid auth mode:
+	// the Bedrock API key. Pin it up front so neither the interactive prompt, a
+	// re-apply of an existing config (which stores no auth mode), nor the global
+	// default (iam) can steer them to a tokenless mode the launch can't satisfy.
+	if authMode == "" && !prov.Supports(provider.CapNativeAuth) {
+		authMode = authmode.BedrockAPIKey
+	}
 	region = applyFlags.region
 	if region == "" {
 		region = bCfg.Defaults.Region
@@ -464,6 +481,8 @@ func resolveApplyInputs(home string, bCfg *bedrock.Config, prov provider.Provide
 		return
 	}
 
+	// authMode is already pinned for Mantle-only CLIs (top of this function), so
+	// this point is reached only by CLIs that support IAM (Claude) with no --auth.
 	if authMode != "" {
 		return
 	}

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1073,7 +1073,7 @@ func TestApply_Codex_NoClaudeWarnings(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
-			"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value",
+			"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value",
 			"--region=us-east-1", "--mode=auto", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1073,7 +1073,7 @@ func TestApply_Codex_NoClaudeWarnings(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
-			"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy",
+			"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value",
 			"--region=us-east-1", "--mode=auto", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1070,6 +1070,7 @@ func TestApply_Codex_NoClaudeWarnings(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1073,8 +1073,8 @@ func TestApply_Codex_NoClaudeWarnings(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
-			"apply", "--cli=codex", "--auth=iam", "--region=us-east-1",
-			"--mode=auto", "--skip-preflight",
+			"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy",
+			"--region=us-east-1", "--mode=auto", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -26,6 +26,32 @@ func containsStr(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
 }
 
+// TestApply_MantleOnlyCLI_RejectsIAM: Codex/OpenCode/Grok route only through
+// Mantle (bearer token required), so an explicit --auth=iam must be rejected with
+// an actionable error rather than writing a config that can never authenticate.
+func TestApply_MantleOnlyCLI_RejectsIAM(t *testing.T) {
+	for _, cli := range []string{"codex", "opencode", "grok"} {
+		t.Run(cli, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			setupMockPSRunner(t, home)
+
+			err := ExecuteArgs([]string{
+				"apply", "--cli=" + cli, "--auth=iam",
+				"--region=us-east-1", "--skip-preflight",
+			})
+			if err == nil {
+				t.Fatalf("%s: expected --auth=iam to be rejected (Mantle needs a bearer token)", cli)
+			}
+			msg := strings.ToLower(err.Error())
+			if !strings.Contains(msg, "iam") && !strings.Contains(msg, "bedrock api key") {
+				t.Errorf("%s: error should explain IAM is unsupported, got: %v", cli, err)
+			}
+		})
+	}
+}
+
 // TestApply_Codex_WritesTOMLConfig drives a full codex apply and asserts the
 // TOML config lands at ~/.codex/config.toml with the Mantle provider block.
 func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
@@ -35,7 +61,7 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=iam", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply --cli=codex: %v", err)
 	}
@@ -47,9 +73,11 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	}
 }
 
-// TestApply_Codex_ModelFlag_Respected: --model=gpt-oss-120b must produce a
-// gpt-oss config (chat/v1), not the GPT-5.5 default. Regression for the P2 bug
-// where --model never reached provider.Options.Model.
+// TestApply_Codex_ModelFlag_Respected: --model=gpt-5.4 must produce a gpt-5.4
+// config, not the GPT-5.5 default. Regression for the P2 bug where --model never
+// reached provider.Options.Model. (Uses gpt-5.4 rather than gpt-oss because
+// current Codex is Responses-only and gpt-oss — Chat-only on Mantle — is no
+// longer a valid Codex model.)
 func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -57,20 +85,21 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--model=gpt-oss-120b",
-		"--auth=iam", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--model=gpt-5.4",
+		"--auth=bedrock-api-key", "--bedrock-key=dummy",
+		"--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 	data := readFileForTest(t, filepath.Join(home, ".codex", "config.toml"))
-	if !containsStr(data, "openai.gpt-oss-120b") {
-		t.Errorf("expected gpt-oss-120b model, got:\n%s", data)
+	if !containsStr(data, "openai.gpt-5.4") {
+		t.Errorf("expected gpt-5.4 model, got:\n%s", data)
 	}
 	if containsStr(data, "openai.gpt-5.5") {
 		t.Errorf("must not fall back to gpt-5.5 when --model given:\n%s", data)
 	}
-	if !containsStr(data, `wire_api = "chat"`) {
-		t.Errorf("gpt-oss should use wire_api=chat, got:\n%s", data)
+	if !containsStr(data, `wire_api = "responses"`) {
+		t.Errorf("gpt-5.4 should use wire_api=responses, got:\n%s", data)
 	}
 }
 
@@ -88,7 +117,7 @@ func TestApply_OpenCode_PassthroughModel_PrintsWarning(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--cli=opencode", "--model=some.exotic-v9",
-			"--auth=iam", "--region=us-west-2", "--skip-preflight",
+			"--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-west-2", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -109,7 +138,7 @@ func TestApply_OpenCode_CuratedModel_NoWarning(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--cli=opencode", "--model=glm-4.7",
-			"--auth=iam", "--region=us-west-2", "--skip-preflight",
+			"--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-west-2", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -131,7 +160,7 @@ func TestUninstall_Codex_DryRun(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=iam", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
@@ -157,7 +186,7 @@ func TestUninstall_Codex_ActuallyRemoves(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=iam", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
@@ -61,7 +62,7 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply --cli=codex: %v", err)
 	}
@@ -86,7 +87,7 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 
 	if err := ExecuteArgs([]string{
 		"apply", "--cli=codex", "--model=gpt-5.4",
-		"--auth=bedrock-api-key", "--bedrock-key=test-key-value",
+		"--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value",
 		"--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
@@ -117,7 +118,7 @@ func TestApply_OpenCode_PassthroughModel_PrintsWarning(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--cli=opencode", "--model=some.exotic-v9",
-			"--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
+			"--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -138,7 +139,7 @@ func TestApply_OpenCode_CuratedModel_NoWarning(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--cli=opencode", "--model=glm-4.7",
-			"--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
+			"--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -160,7 +161,7 @@ func TestUninstall_Codex_DryRun(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
@@ -186,7 +187,7 @@ func TestUninstall_Codex_ActuallyRemoves(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -61,7 +61,7 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply --cli=codex: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 
 	if err := ExecuteArgs([]string{
 		"apply", "--cli=codex", "--model=gpt-5.4",
-		"--auth=bedrock-api-key", "--bedrock-key=dummy",
+		"--auth=bedrock-api-key", "--bedrock-key=test-key-value",
 		"--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
@@ -117,7 +117,7 @@ func TestApply_OpenCode_PassthroughModel_PrintsWarning(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--cli=opencode", "--model=some.exotic-v9",
-			"--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-west-2", "--skip-preflight",
+			"--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -138,7 +138,7 @@ func TestApply_OpenCode_CuratedModel_NoWarning(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--cli=opencode", "--model=glm-4.7",
-			"--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-west-2", "--skip-preflight",
+			"--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestUninstall_Codex_DryRun(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestUninstall_Codex_ActuallyRemoves(t *testing.T) {
 	setupMockPSRunner(t, home)
 
 	if err := ExecuteArgs([]string{
-		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=dummy", "--region=us-east-1", "--skip-preflight",
+		"apply", "--cli=codex", "--auth=bedrock-api-key", "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -60,6 +60,7 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	if err := ExecuteArgs([]string{
 		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
@@ -84,6 +85,7 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	if err := ExecuteArgs([]string{
 		"apply", "--cli=codex", "--model=gpt-5.4",
@@ -114,6 +116,7 @@ func TestApply_OpenCode_PassthroughModel_PrintsWarning(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
@@ -135,6 +138,7 @@ func TestApply_OpenCode_CuratedModel_NoWarning(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
@@ -159,6 +163,7 @@ func TestUninstall_Codex_DryRun(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	if err := ExecuteArgs([]string{
 		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
@@ -185,6 +190,7 @@ func TestUninstall_Codex_ActuallyRemoves(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	setupMockPSRunner(t, home)
+	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
 
 	if err := ExecuteArgs([]string{
 		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -83,9 +83,21 @@ func TestClaude_LaunchSpec(t *testing.T) {
 // TestClaude_Supports covers the Claude-only capabilities.
 func TestClaude_Supports(t *testing.T) {
 	p, _ := Get("claude")
-	for _, c := range []Capability{CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels} {
+	for _, c := range []Capability{CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels, CapNativeAuth} {
 		if !p.Supports(c) {
 			t.Errorf("Claude should support capability %d", c)
+		}
+	}
+}
+
+// TestMantleOnlyCLIs_NoNativeAuth: Codex/OpenCode/Grok route only through Mantle,
+// which requires a bearer token, so none may claim CapNativeAuth (IAM/SSO). apply
+// relies on this to reject --auth=iam for them.
+func TestMantleOnlyCLIs_NoNativeAuth(t *testing.T) {
+	for _, name := range []string{"codex", "opencode", "grok"} {
+		p, _ := Get(name)
+		if p.Supports(CapNativeAuth) {
+			t.Errorf("%s is Mantle-only and must NOT support CapNativeAuth", name)
 		}
 	}
 }
@@ -151,6 +163,28 @@ func TestCodex_BuildConfig_MantleBlock(t *testing.T) {
 	}
 }
 
+// TestCodex_BuildConfig_SkipsOpenAILogin verifies the Mantle provider block sets
+// requires_openai_auth = false. Without it, the Codex CLI shows its ChatGPT
+// login screen on launch even with a valid custom provider + env_key token
+// (verified in openai/codex tui/src/lib.rs should_show_login_screen: login is
+// skipped ONLY when the active provider's requires_openai_auth is false).
+func TestCodex_BuildConfig_SkipsOpenAILogin(t *testing.T) {
+	p, _ := Get("codex")
+	plan, err := p.BuildConfig(testConfig(), baseOpts())
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	mp := plan.Keys["model_providers"].(map[string]any)
+	bm := mp["bedrock-mantle"].(map[string]any)
+	got, ok := bm["requires_openai_auth"]
+	if !ok {
+		t.Fatal("bedrock-mantle block must set requires_openai_auth to skip the ChatGPT login screen")
+	}
+	if got != false {
+		t.Errorf("requires_openai_auth = %v, want false", got)
+	}
+}
+
 // TestCodex_BuildConfig_UnknownModel errors on an unlisted model.
 func TestCodex_BuildConfig_UnknownModel(t *testing.T) {
 	p, _ := Get("codex")
@@ -177,19 +211,15 @@ func TestCodex_BuildConfig_RegionWarning(t *testing.T) {
 	}
 }
 
-// TestCodex_BuildConfig_ExplicitGptOss selects the /v1 + chat path.
-func TestCodex_BuildConfig_ExplicitGptOss(t *testing.T) {
+// TestCodex_BuildConfig_GptOssRejected: gpt-oss is no longer a valid Codex model
+// (Codex is Responses-only; gpt-oss on Mantle is Chat-only), so BuildConfig must
+// error rather than emit a config Codex would reject at load.
+func TestCodex_BuildConfig_GptOssRejected(t *testing.T) {
 	p, _ := Get("codex")
 	opts := baseOpts()
 	opts.Model = "gpt-oss-120b"
-	plan, _ := p.BuildConfig(testConfig(), opts)
-	mp := plan.Keys["model_providers"].(map[string]any)
-	bm := mp["bedrock-mantle"].(map[string]any)
-	if bm["wire_api"] != "chat" {
-		t.Errorf("gpt-oss wire_api = %v, want chat", bm["wire_api"])
-	}
-	if got := bm["base_url"].(string); got != "https://bedrock-mantle.us-west-2.api.aws/v1" {
-		t.Errorf("gpt-oss base_url = %q, want .../v1", got)
+	if _, err := p.BuildConfig(testConfig(), opts); err == nil {
+		t.Error("expected gpt-oss-120b to be rejected for Codex (Responses-only)")
 	}
 }
 

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -128,7 +128,7 @@ func (claude) LaunchSpec() LaunchSpec {
 
 func (claude) Supports(c Capability) bool {
 	switch c {
-	case CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels:
+	case CapAutoMode, Cap1MContext, CapOpusplan, CapThinking, CapServiceTiers, CapEffortLevels, CapNativeAuth:
 		return true
 	default:
 		return false

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
+	"slices"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
@@ -70,13 +71,13 @@ func (codex) ActivationMarkers() (begin, end string) {
 }
 
 // codexMantleModel describes one OpenAI-family model reachable through Bedrock
-// Mantle from Codex. Base path AND wire_api are PER-MODEL — this is the core
-// finding, live-verified 2026-07-03: gpt-5.x use /openai/v1 + Responses, gpt-oss
-// use /v1 + Chat, and gpt-5.5 hard-rejects chat/completions.
+// Mantle from Codex. Current Codex is Responses-API-only (it rejects
+// `wire_api = "chat"` at config load), so every entry here uses /openai/v1 +
+// Responses. gpt-5.5 hard-rejects chat/completions, live-verified 2026-07-03.
 type codexMantleModel struct {
 	ModelID  string   // Bedrock Mantle model ID, e.g. "openai.gpt-5.5"
-	BasePath string   // endpoint path suffix: "/openai/v1" or "/v1"
-	WireAPI  string   // Codex wire_api: "responses" or "chat"
+	BasePath string   // endpoint path suffix (always "/openai/v1" for Codex)
+	WireAPI  string   // Codex wire_api (always "responses")
 	Regions  []string // regions where live-servable (informational)
 }
 
@@ -95,18 +96,11 @@ var codexModels = map[string]codexMantleModel{
 		WireAPI:  "responses",
 		Regions:  []string{"us-east-1", "us-west-2"},
 	},
-	"gpt-oss-120b": {
-		ModelID:  "openai.gpt-oss-120b",
-		BasePath: "/v1",
-		WireAPI:  "chat",
-		Regions:  []string{"us-east-1", "us-east-2", "us-west-2"},
-	},
-	"gpt-oss-20b": {
-		ModelID:  "openai.gpt-oss-20b",
-		BasePath: "/v1",
-		WireAPI:  "chat",
-		Regions:  []string{"us-east-1", "us-east-2", "us-west-2"},
-	},
+	// NOTE: gpt-oss is intentionally absent. Current Codex is Responses-API-only
+	// (it rejects `wire_api = "chat"` at config load — openai/codex
+	// CHAT_WIRE_API_REMOVED_ERROR), but gpt-oss on Mantle serves only Chat
+	// Completions on /v1 and has no Responses endpoint, so Codex cannot reach it.
+	// gpt-oss remains available via OpenCode (which speaks Chat Completions).
 }
 
 func codexModel(key string) (codexMantleModel, bool) {
@@ -129,7 +123,7 @@ func (codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) 
 	}
 	m, ok := codexModel(key)
 	if !ok {
-		return ConfigPlan{}, fmt.Errorf("unknown Codex model %q (supported: gpt-5.5, gpt-5.4, gpt-oss-120b, gpt-oss-20b)", key)
+		return ConfigPlan{}, fmt.Errorf("unknown Codex model %q (supported: gpt-5.5, gpt-5.4)", key)
 	}
 
 	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws%s", opts.Region, m.BasePath)
@@ -138,6 +132,11 @@ func (codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) 
 		"base_url": baseURL,
 		"wire_api": m.WireAPI,
 		"env_key":  bedrockAuthEnvName,
+		// Skip the ChatGPT/OpenAI login screen. Codex prompts for OpenAI auth only
+		// when the active provider's requires_openai_auth is true (verified in
+		// openai/codex tui should_show_login_screen); our credential is the bearer
+		// token in env_key, so declare no OpenAI auth is required.
+		"requires_openai_auth": false,
 	}
 
 	keys := map[string]any{
@@ -176,10 +175,5 @@ func (codex) Supports(c Capability) bool {
 }
 
 func regionAllowed(region string, allowed []string) bool {
-	for _, r := range allowed {
-		if r == region {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, region)
 }

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -75,20 +75,17 @@ func TestCodexModel_GPT55(t *testing.T) {
 	}
 }
 
-// TestCodexModel_GPTOSS pins gpt-oss-120b: Chat on the /v1 base path.
-func TestCodexModel_GPTOSS(t *testing.T) {
-	m, ok := codexModel("gpt-oss-120b")
-	if !ok {
-		t.Fatal("gpt-oss-120b not in Codex model table")
-	}
-	if m.ModelID != "openai.gpt-oss-120b" {
-		t.Errorf("ModelID = %q, want openai.gpt-oss-120b", m.ModelID)
-	}
-	if m.BasePath != "/v1" {
-		t.Errorf("BasePath = %q, want /v1", m.BasePath)
-	}
-	if m.WireAPI != "chat" {
-		t.Errorf("WireAPI = %q, want chat", m.WireAPI)
+// TestCodexModel_GPTOSSExcluded: gpt-oss is NOT selectable for Codex. Current
+// Codex is Responses-API-only (it rejects `wire_api = "chat"` at config load,
+// see openai/codex CHAT_WIRE_API_REMOVED_ERROR), but gpt-oss on Mantle speaks
+// only Chat Completions on /v1 — it has no Responses endpoint. So Codex cannot
+// reach gpt-oss at all; offering it would write a config that fails to load.
+// (OpenCode, which does speak Chat, still curates gpt-oss — that's unaffected.)
+func TestCodexModel_GPTOSSExcluded(t *testing.T) {
+	for _, key := range []string{"gpt-oss-120b", "gpt-oss-20b"} {
+		if _, ok := codexModel(key); ok {
+			t.Errorf("%s must NOT be a Codex model (Codex is Responses-only; gpt-oss is Chat-only)", key)
+		}
 	}
 }
 
@@ -99,23 +96,15 @@ func TestCodexModel_Unknown(t *testing.T) {
 	}
 }
 
-// TestCodexModel_PathsMatchVerifiedSplit guards the core finding that base path
-// is per-model: gpt-5.x on /openai/v1, gpt-oss on /v1.
-func TestCodexModel_PathsMatchVerifiedSplit(t *testing.T) {
-	cases := map[string]string{
-		"gpt-5.5":      "/openai/v1",
-		"gpt-5.4":      "/openai/v1",
-		"gpt-oss-120b": "/v1",
-		"gpt-oss-20b":  "/v1",
-	}
-	for key, wantPath := range cases {
-		m, ok := codexModel(key)
-		if !ok {
-			t.Errorf("%s missing from table", key)
-			continue
+// TestCodexModel_AllModelsAreResponsesOnly guards that every Codex model uses
+// the Responses wire API on /openai/v1 — the only shape current Codex accepts.
+func TestCodexModel_AllModelsAreResponsesOnly(t *testing.T) {
+	for key, m := range codexModels {
+		if m.WireAPI != "responses" {
+			t.Errorf("%s WireAPI = %q, want responses (Codex removed chat)", key, m.WireAPI)
 		}
-		if m.BasePath != wantPath {
-			t.Errorf("%s BasePath = %q, want %q", key, m.BasePath, wantPath)
+		if m.BasePath != "/openai/v1" {
+			t.Errorf("%s BasePath = %q, want /openai/v1", key, m.BasePath)
 		}
 	}
 }

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -71,6 +71,11 @@ const (
 	CapServiceTiers
 	// CapEffortLevels: reasoning-effort levels. Claude + Codex (gpt-5.x).
 	CapEffortLevels
+	// CapNativeAuth: the CLI can authenticate to Bedrock WITHOUT a bearer token
+	// (IAM/SSO via SigV4 on the native bedrock-runtime path). Claude supports this;
+	// the Mantle-only CLIs (Codex, OpenCode, Grok) do NOT — Mantle requires a
+	// bearer token, so apply must reject --auth=iam for them.
+	CapNativeAuth
 )
 
 // ConfigPlan is what a Provider persists to its config file at apply time.


### PR DESCRIPTION
## What

Three launch-auth fixes for a real report: `apply --cli=codex` succeeded, but launching `codex` **ignored the config and asked to sign in**. Root-caused against the actual `openai/codex` source (not guesses).

### 1. Codex skipped ChatGPT login (the reported bug)
The `[model_providers.bedrock-mantle]` block now sets **`requires_openai_auth = false`**. Verified in `openai/codex` `tui/src/lib.rs` `should_show_login_screen`: the login screen shows only when the active provider's `requires_openai_auth` is true. Our custom provider uses `env_key` (not the native `aws` sub-table or an `auth` command), so the field's conflict-lists don't apply. Without this key, Codex ignored the routing/token and prompted to sign in.

### 2. IAM rejected for Mantle-only CLIs
Codex/OpenCode/Grok route **only** through Bedrock Mantle, which requires a bearer token — IAM/SSO (SigV4) can't reach it. New provider capability **`CapNativeAuth`** (Claude has it; the three Mantle CLIs don't):
- `apply --cli=codex|opencode|grok --auth=iam` is now **rejected** with an actionable error.
- The auth mode is **pinned to the Bedrock API key** for the prompt / re-apply / default paths, so a user can't end up with a tokenless config the launch can't satisfy (the "picked IAM → no token → CLI falls back to sign-in" path).

### 3. gpt-oss removed from Codex's model table
Current Codex is **Responses-API-only** (rejects `wire_api = "chat"` at config load — `CHAT_WIRE_API_REMOVED_ERROR`), but gpt-oss on Mantle serves only Chat Completions and has no Responses endpoint, so Codex can't reach it. Removed from Codex; **still available via OpenCode** (which speaks Chat).

## Tests (TDD, red→green)
- `requires_openai_auth = false` present in the Codex block.
- Every Codex model is `responses` on `/openai/v1`; gpt-oss rejected with a clear error.
- All three Mantle CLIs reject `--auth=iam`.
- `--model` still threads through (now uses `gpt-5.4`, since gpt-oss is gone).
- Claude golden byte-identical; full suite + gosec clean.

## Not included
**Grok sign-in** is still open — research couldn't verify whether the official xAI Grok CLI has an equivalent "skip login" field, and I won't ship a guessed key. Fixes #2/#3 already help Grok (the IAM guard forces a token to exist). The definitive fix needs a diff against a known-working `~/.grok/config.toml`; tracked separately.