### PR TITLE
fix(grok): skip sign-in via [auth] auth_provider_command + juggernaut auth-token

### DIFF
--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -13,6 +13,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// longTermRefreshSecs bounds how long Grok caches a long-term (no-embedded-
+// expiry) Bedrock key before re-running auth-token. Short enough to pick up a
+// same-day key rotation, long enough that the re-run overhead is negligible.
+const longTermRefreshSecs = 6 * 60 * 60 // 6 hours
+
 // authTokenCmd is a hidden command invoked by the Grok CLI's
 // `auth_provider_command` (see internal/provider/grok.go). Grok runs it via
 // `sh -c`, reads a token from stdout, stores it in ~/.grok/auth.json, and
@@ -54,7 +59,9 @@ func runAuthToken(_ *cobra.Command, _ []string) error {
 // {"access_token":"<token>"} plus an optional "expires_in" (seconds until the
 // key's embedded expiry) so Grok can refresh proactively. Short-term Bedrock
 // keys carry an expiry; long-term keys don't, in which case expires_in is
-// omitted and Grok assumes a long lifetime (refreshing on a 401).
+// bounded (longTermRefreshSecs) so Grok periodically re-runs the command and
+// picks up a rotated key from the keychain instead of caching the old token for
+// ~30 days (Grok's default) and only refreshing on a 401.
 func buildAuthTokenJSON(token string, now time.Time) string {
 	payload := map[string]any{"access_token": token}
 	if exp, ok := bedrock.ParseAPIKeyExpiry(token); ok {
@@ -62,6 +69,12 @@ func buildAuthTokenJSON(token string, now time.Time) string {
 		if secs > 0 {
 			payload["expires_in"] = secs
 		}
+	} else {
+		// No embedded expiry (long-term key). Emit a bounded lifetime so Grok
+		// re-runs auth-token periodically and picks up a key rotated via
+		// `apply --cli=grok --bedrock-key <new>` — otherwise Grok caches the old
+		// token for ~30 days and keeps sending it until a 401.
+		payload["expires_in"] = longTermRefreshSecs
 	}
 	b, err := json.Marshal(payload)
 	if err != nil {

--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"time"
 
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
 	"github.com/spf13/cobra"
@@ -40,7 +42,8 @@ func runAuthToken(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("reading Bedrock API key from keychain: %w", err)
 	}
 	if token == "" {
-		return fmt.Errorf("no Bedrock API key found; run `juggernaut apply --cli=grok --auth=bedrock-api-key`")
+		return errors.New("no Bedrock bearer token stored in the keychain — " +
+			"run juggernaut apply --cli=grok with --auth=" + authmode.BedrockAPIKey + " to store one")
 	}
 	out := buildAuthTokenJSON(token, time.Now().UTC())
 	fmt.Println(out)

--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
+	"github.com/spf13/cobra"
+)
+
+// authTokenCmd is a hidden command invoked by the Grok CLI's
+// `auth_provider_command` (see internal/provider/grok.go). Grok runs it via
+// `sh -c`, reads a token from stdout, stores it in ~/.grok/auth.json, and
+// re-runs it to refresh. Its stdout MUST contain ONLY the token JSON — any other
+// text breaks Grok's parsing — so all diagnostics go to stderr.
+var authTokenCmd = &cobra.Command{
+	Use:          "auth-token",
+	Short:        "Print the Bedrock bearer token as JSON (used by the Grok CLI auth provider)",
+	Hidden:       true,
+	SilenceUsage: true,
+	RunE:         runAuthToken,
+}
+
+func init() {
+	rootCmd.AddCommand(authTokenCmd)
+}
+
+func runAuthToken(_ *cobra.Command, _ []string) error {
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
+	token, err := keychain.Default().GetWithFallback(home)
+	if err != nil {
+		// Diagnostics go to stderr; stdout stays clean so Grok never mis-parses
+		// an error message as a token.
+		return fmt.Errorf("reading Bedrock API key from keychain: %w", err)
+	}
+	if token == "" {
+		return fmt.Errorf("no Bedrock API key found; run `juggernaut apply --cli=grok --auth=bedrock-api-key`")
+	}
+	out := buildAuthTokenJSON(token, time.Now().UTC())
+	fmt.Println(out)
+	return nil
+}
+
+// buildAuthTokenJSON renders the token in Grok's expected stdout shape:
+// {"access_token":"<token>"} plus an optional "expires_in" (seconds until the
+// key's embedded expiry) so Grok can refresh proactively. Short-term Bedrock
+// keys carry an expiry; long-term keys don't, in which case expires_in is
+// omitted and Grok assumes a long lifetime (refreshing on a 401).
+func buildAuthTokenJSON(token string, now time.Time) string {
+	payload := map[string]any{"access_token": token}
+	if exp, ok := bedrock.ParseAPIKeyExpiry(token); ok {
+		secs := int64(math.Floor(exp.Sub(now).Seconds()))
+		if secs > 0 {
+			payload["expires_in"] = secs
+		}
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		// A map[string]any of strings/ints cannot fail to marshal; fall back to
+		// the bare-token form rather than emit nothing.
+		return fmt.Sprintf(`{"access_token":%q}`, token)
+	}
+	return string(b)
+}

--- a/cmd/auth_token_test.go
+++ b/cmd/auth_token_test.go
@@ -19,8 +19,9 @@ func makeShortTermKey(issued time.Time, expiresSecs int) string {
 	return "bedrock-api-key-" + base64.StdEncoding.EncodeToString([]byte(url))
 }
 
-// TestBuildAuthTokenJSON_BareToken: a token with no parseable expiry yields just
-// access_token (Grok then assumes a long lifetime).
+// TestBuildAuthTokenJSON_BareToken: a token with no parseable expiry (long-term
+// key) emits a BOUNDED expires_in so Grok re-runs the command periodically and
+// picks up a rotated key, rather than caching the old token for ~30 days.
 func TestBuildAuthTokenJSON_BareToken(t *testing.T) {
 	out := buildAuthTokenJSON("plain-token-value", time.Now().UTC())
 	var m map[string]any
@@ -30,8 +31,12 @@ func TestBuildAuthTokenJSON_BareToken(t *testing.T) {
 	if m["access_token"] != "plain-token-value" {
 		t.Errorf("access_token = %v, want plain-token-value", m["access_token"])
 	}
-	if _, ok := m["expires_in"]; ok {
-		t.Errorf("expires_in must be omitted for a key with no expiry, got %v", m["expires_in"])
+	exp, ok := m["expires_in"].(float64)
+	if !ok {
+		t.Fatalf("expires_in must be present (bounded) for a long-term key, got %v", m["expires_in"])
+	}
+	if int(exp) != longTermRefreshSecs {
+		t.Errorf("expires_in = %d, want bounded %d for a no-expiry key", int(exp), longTermRefreshSecs)
 	}
 }
 

--- a/cmd/auth_token_test.go
+++ b/cmd/auth_token_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// makeShortTermKey builds a bedrock-api-key-<b64(presigned url)> whose embedded
+// X-Amz-Date/X-Amz-Expires encode a known expiry, so ParseAPIKeyExpiry has
+// something real to parse (mirrors the format apikey.go decodes).
+func makeShortTermKey(issued time.Time, expiresSecs int) string {
+	url := "bedrock.amazonaws.com/?Action=CallWithBearerToken" +
+		"&X-Amz-Date=" + issued.UTC().Format("20060102T150405Z") +
+		"&X-Amz-Expires=" + strconv.Itoa(expiresSecs)
+	return "bedrock-api-key-" + base64.StdEncoding.EncodeToString([]byte(url))
+}
+
+// TestBuildAuthTokenJSON_BareToken: a token with no parseable expiry yields just
+// access_token (Grok then assumes a long lifetime).
+func TestBuildAuthTokenJSON_BareToken(t *testing.T) {
+	out := buildAuthTokenJSON("plain-token-value", time.Now().UTC())
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, out)
+	}
+	if m["access_token"] != "plain-token-value" {
+		t.Errorf("access_token = %v, want plain-token-value", m["access_token"])
+	}
+	if _, ok := m["expires_in"]; ok {
+		t.Errorf("expires_in must be omitted for a key with no expiry, got %v", m["expires_in"])
+	}
+}
+
+// TestBuildAuthTokenJSON_WithExpiry: a short-term key emits expires_in as the
+// seconds remaining until its embedded expiry.
+func TestBuildAuthTokenJSON_WithExpiry(t *testing.T) {
+	now := time.Date(2026, 7, 4, 20, 0, 0, 0, time.UTC)
+	key := makeShortTermKey(now, 43200) // 12h lifetime, issued "now"
+	out := buildAuthTokenJSON(key, now)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, out)
+	}
+	if m["access_token"] != key {
+		t.Errorf("access_token mismatch")
+	}
+	exp, ok := m["expires_in"].(float64)
+	if !ok {
+		t.Fatalf("expires_in missing/wrong type for a short-term key: %v", m["expires_in"])
+	}
+	if int(exp) != 43200 {
+		t.Errorf("expires_in = %d, want 43200", int(exp))
+	}
+}
+
+// TestBuildAuthTokenJSON_StdoutIsCleanJSON: the output is a single JSON object
+// and nothing else — Grok reads stdout verbatim, so stray text would break it.
+func TestBuildAuthTokenJSON_StdoutIsCleanJSON(t *testing.T) {
+	out := buildAuthTokenJSON("tok", time.Now().UTC())
+	if !strings.HasPrefix(out, "{") || !strings.HasSuffix(strings.TrimSpace(out), "}") {
+		t.Errorf("output must be a bare JSON object, got %q", out)
+	}
+	if strings.Count(out, "{") != 1 {
+		t.Errorf("output must be a single JSON object, got %q", out)
+	}
+}
+
+// TestAuthToken_Command_EmitsKeychainToken drives the real command: store a
+// token in an isolated keychain, run `auth-token`, and confirm stdout is the
+// JSON carrying that token.
+func TestAuthToken_Command_EmitsKeychainToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	store := setupIsolatedKeychain(t) // skips if backend unavailable/hangs
+	if err := store.SetWithFallback("kc-token-123", home); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	t.Cleanup(func() { _ = store.DeleteWithFallback(home) })
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"auth-token"}); err != nil {
+			t.Fatalf("auth-token: %v", err)
+		}
+	})
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &m); err != nil {
+		t.Fatalf("auth-token stdout not valid JSON: %v (%q)", err, out)
+	}
+	if m["access_token"] != "kc-token-123" {
+		t.Errorf("access_token = %v, want kc-token-123", m["access_token"])
+	}
+}
+
+// TestAuthToken_Command_ErrorsWhenNoToken: with no stored token, the command
+// errors (non-zero) and prints nothing parseable as a token to stdout, so Grok
+// falls through to its normal login.
+func TestAuthToken_Command_ErrorsWhenNoToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	setupIsolatedKeychain(t) // isolated empty store
+
+	var err error
+	out := captureStdout(t, func() {
+		err = ExecuteArgs([]string{"auth-token"})
+	})
+	if err == nil {
+		t.Fatal("expected an error when no token is stored")
+	}
+	if strings.Contains(out, "access_token") {
+		t.Errorf("stdout must stay clean on error, got %q", out)
+	}
+}

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -9,16 +9,31 @@ import (
 )
 
 // grok is the OFFICIAL xAI Grok CLI provider (grok / grok.exe, config TOML at
-// ~/.grok/config.toml). Grok is a BYOK-friendly harness: custom providers are
-// [model.<name>] tables with base_url + env_key, selected via [models].default.
-// Juggernaut routes to Grok 4.3 on Bedrock Mantle by writing such a block with
-// base_url → Mantle /openai/v1 and env_key → the injected bearer token (xAI's
-// own docs prefer env_key over inline api_key). Schema verified against a real
-// install + docs.x.ai/build/settings — see the grok-cli-config-schema memory.
+// ~/.grok/config.toml). Juggernaut routes to Grok 4.3 on Bedrock Mantle by
+// writing a [model.bedrock-grok] block (base_url → Mantle /openai/v1) selected
+// via [models].default, PLUS an [auth] block whose auth_provider_command runs
+// `juggernaut auth-token` to supply the keychain bearer token.
+//
+// Why the [auth] block (not env_key): Grok's per-model credential order is
+// api_key → env_key → XAI_API_KEY, but a custom [model.*] block does NOT satisfy
+// Grok's SESSION auth — with only env_key set, Grok still runs its interactive
+// browser/OIDC login and prompts the user. The documented mechanism that
+// REPLACES login is [auth] auth_provider_command: Grok runs it, reads a token
+// from stdout, stores it in ~/.grok/auth.json, and auto-refreshes. Verified
+// against the official xAI Grok CLI docs (README "External Auth Provider").
 type grok struct{}
 
 // grokModelName is the [model.<name>] key + [models].default value we write.
 const grokModelName = "bedrock-grok"
+
+// grokAuthCommand is the auth_provider_command Grok runs (via sh -c) to fetch
+// the bearer token. It maps to cmd/auth_token.go, which prints the keychain
+// token as {"access_token":...,"expires_in":...}.
+const grokAuthCommand = "juggernaut auth-token"
+
+// grokRegions are the regions where xai.grok-4.3 is verified available on Mantle
+// (live-checked 2026-07-03). apply warns—does not fail—outside this set.
+var grokRegions = []string{"us-east-1", "us-east-2", "us-west-2"}
 
 func (grok) Name() string { return "grok" }
 
@@ -38,30 +53,28 @@ func (grok) ConfigPath(home, _ string) (string, error) {
 	return safepath.JoinUnder(home, ".grok", "config.toml")
 }
 
-// NativeManagedKeys are the top-level config.toml keys Juggernaut owns. Note the
-// whole [model] and [models] tables are managed here (Grok nests custom models
-// under [model.<name>]); on uninstall RemoveManagedKeys drops them wholesale,
-// which is acceptable for a Juggernaut-owned config.
+// NativeManagedKeys are the top-level config.toml keys Juggernaut owns: the
+// [model] and [models] tables (nested), plus the [auth] table.
 func (grok) NativeManagedKeys() []string {
-	return []string{"model", "models"}
+	return []string{"model", "models", "auth"}
 }
 
-// DeepMergeKeys: both [model.<name>] and [models] are nested tables holding a
-// user's own model profiles + settings; merge only our bedrock-grok block and
-// the default leaf, preserving their profiles.
-func (grok) DeepMergeKeys() []string { return []string{"model", "models"} }
+// DeepMergeKeys: [model.<name>], [models], and [auth] are nested tables that may
+// hold a user's own entries (model profiles, default selection, or their own
+// OIDC/auth-provider config); merge only our own sub-keys, preserving theirs.
+func (grok) DeepMergeKeys() []string { return []string{"model", "models", "auth"} }
 
-// OwnedSubKeys: uninstall removes only our bedrock-grok model profile and the
-// models.default pointer we set — preserving the user's other model profiles
-// and settings. Note: apply sets models.default = bedrock-grok (that IS the
-// point — route Grok through Bedrock), and uninstall deletes that pointer
-// rather than restoring whatever default the user had before, since Juggernaut
-// does not persist the prior value. Grok then falls back to its built-in
-// default; the user's own model profiles are untouched.
+// OwnedSubKeys: uninstall removes ONLY our sub-keys — the bedrock-grok model
+// profile, the models.default pointer, and the two [auth] keys we set —
+// preserving a user's other model profiles and any auth settings of their own.
+// Note: apply sets models.default = bedrock-grok (that IS the point) and
+// uninstall deletes that pointer rather than restoring the prior value (not
+// persisted); Grok then falls back to its built-in default.
 func (grok) OwnedSubKeys() map[string][]string {
 	return map[string][]string{
 		"model":  {grokModelName},
 		"models": {"default"},
+		"auth":   {"auth_provider_command", "auth_provider_label"},
 	}
 }
 
@@ -81,8 +94,10 @@ func (grok) ActivationMarkers() (begin, end string) {
 }
 
 func (grok) LaunchSpec() LaunchSpec {
-	// Grok routes via config (env_key references the token env var); no static
-	// enable flag, but the bearer token is required (Mantle).
+	// Grok gets its token from the [auth] auth_provider_command (which reads the
+	// keychain directly), so the launch wrapper does not strictly need to inject
+	// the token. NeedsToken stays true: the shared token is still injected as an
+	// env var (harmless), and apply's Mantle-only IAM guard keys off NeedsToken.
 	return LaunchSpec{
 		TokenEnvVar: bedrockAuthEnvName,
 		NeedsToken:  true,
@@ -91,28 +106,48 @@ func (grok) LaunchSpec() LaunchSpec {
 
 func (grok) Supports(Capability) bool { return false }
 
-// BuildConfig writes a [model.bedrock-grok] block routing to Grok 4.3 on Mantle
-// plus [models].default. Grok 4.3 is the only xAI model on Mantle, so there's no
-// model table/passthrough — just the one verified target.
+// BuildConfig writes a [model.bedrock-grok] block routing to Grok 4.3 on Mantle,
+// [models].default, and an [auth] block whose auth_provider_command supplies the
+// keychain bearer token so Grok skips its interactive sign-in. Grok 4.3 is the
+// only xAI model on Mantle, so there's no model table/passthrough.
+//
+// Deliberately NO env_key on the model block: with env_key set, Grok's session
+// still falls through to interactive login. The [auth] block is the documented
+// way to replace login entirely.
 func (grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
 	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1", opts.Region)
 	keys := map[string]any{
 		"model": map[string]any{
 			grokModelName: map[string]any{
-				"model":          "xai.grok-4.3",
-				"base_url":       baseURL,
-				"name":           "Grok 4.3 (Amazon Bedrock Mantle)",
-				"env_key":        bedrockAuthEnvName,
-				"api_backend":    "chat_completions",
+				"model":       "xai.grok-4.3",
+				"base_url":    baseURL,
+				"name":        "Grok 4.3 (Amazon Bedrock Mantle)",
+				"api_backend": "responses",
+				// grok-4.3 on Mantle serves both Chat + Responses on /openai/v1
+				// (verified 2026-07-03); Responses is the richer surface (web
+				// search etc.), so we route through it.
 				"context_window": 1000000,
 			},
 		},
 		"models": map[string]any{
 			"default": grokModelName,
 		},
+		"auth": map[string]any{
+			"auth_provider_command": grokAuthCommand,
+			"auth_provider_label":   "Bedrock",
+		},
 	}
+
+	var warnings []string
+	if !regionAllowed(opts.Region, grokRegions) {
+		warnings = append(warnings, fmt.Sprintf(
+			"model xai.grok-4.3 is not confirmed available in %s (known: %v) — apply will still write config, but requests may fail",
+			opts.Region, grokRegions))
+	}
+
 	return ConfigPlan{
 		Keys:        keys,
 		ManagedKeys: grok{}.NativeManagedKeys(),
+		Warnings:    warnings,
 	}, nil
 }

--- a/internal/provider/grok_test.go
+++ b/internal/provider/grok_test.go
@@ -89,7 +89,7 @@ func TestDeepMergeContract(t *testing.T) {
 		"claude":   {nil, nil},
 		"codex":    {[]string{"model_providers"}, map[string][]string{"model_providers": {"bedrock-mantle"}}},
 		"opencode": {[]string{"provider"}, map[string][]string{"provider": {"bedrock-mantle"}}},
-		"grok":     {[]string{"model", "models"}, map[string][]string{"model": {"bedrock-grok"}, "models": {"default"}}},
+		"grok":     {[]string{"model", "models", "auth"}, map[string][]string{"model": {"bedrock-grok"}, "models": {"default"}, "auth": {"auth_provider_command", "auth_provider_label"}}},
 	}
 	for name, want := range cases {
 		p, _ := Get(name)
@@ -136,7 +136,10 @@ func TestGrok_OwnsConfig(t *testing.T) {
 }
 
 // TestGrok_BuildConfig writes the [model.bedrock-grok] block (base_url→Mantle
-// /openai/v1, env_key, model xai.grok-4.3) + [models].default.
+// /openai/v1, api_backend=responses, model xai.grok-4.3) + [models].default +
+// an [auth] block. Crucially it does NOT set env_key: with env_key, Grok's
+// credential order (api_key→env_key→XAI_API_KEY) still runs the interactive
+// login for the session. The [auth] auth_provider_command is what replaces login.
 func TestGrok_BuildConfig(t *testing.T) {
 	p, _ := Get("grok")
 	opts := baseOpts()
@@ -159,11 +162,11 @@ func TestGrok_BuildConfig(t *testing.T) {
 	if base, _ := bg["base_url"].(string); base != "https://bedrock-mantle.us-east-1.api.aws/openai/v1" {
 		t.Errorf("base_url = %q, want .../openai/v1", base)
 	}
-	if bg["env_key"] != "AWS_BEARER_TOKEN_BEDROCK" {
-		t.Errorf("env_key = %v, want AWS_BEARER_TOKEN_BEDROCK", bg["env_key"])
+	if _, hasEnvKey := bg["env_key"]; hasEnvKey {
+		t.Errorf("env_key must NOT be set (it keeps Grok's login flow alive); got %v", bg["env_key"])
 	}
-	if bg["api_backend"] != "chat_completions" {
-		t.Errorf("api_backend = %v, want chat_completions", bg["api_backend"])
+	if bg["api_backend"] != "responses" {
+		t.Errorf("api_backend = %v, want responses", bg["api_backend"])
 	}
 	models, ok := plan.Keys["models"].(map[string]any)
 	if !ok || models["default"] != "bedrock-grok" {
@@ -171,5 +174,57 @@ func TestGrok_BuildConfig(t *testing.T) {
 	}
 	if err := plan.Validate(); err != nil {
 		t.Errorf("plan should validate: %v", err)
+	}
+}
+
+// TestGrok_BuildConfig_AuthBlock: the [auth] block points auth_provider_command
+// at `juggernaut auth-token` with a Bedrock label — this is what makes Grok skip
+// its sign-in and use our keychain bearer token.
+func TestGrok_BuildConfig_AuthBlock(t *testing.T) {
+	p, _ := Get("grok")
+	plan, err := p.BuildConfig(testConfig(), baseOpts())
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	auth, ok := plan.Keys["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("[auth] block missing: %T", plan.Keys["auth"])
+	}
+	if cmd, _ := auth["auth_provider_command"].(string); !strings.Contains(cmd, "auth-token") {
+		t.Errorf("auth_provider_command = %v, want it to invoke `juggernaut auth-token`", auth["auth_provider_command"])
+	}
+	if auth["auth_provider_label"] != "Bedrock" {
+		t.Errorf("auth_provider_label = %v, want Bedrock", auth["auth_provider_label"])
+	}
+	// "auth" must be a managed key so uninstall removes it.
+	found := false
+	for _, k := range plan.ManagedKeys {
+		if k == "auth" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("auth must be in ManagedKeys")
+	}
+}
+
+// TestGrok_BuildConfig_RegionWarning: xai.grok-4.3 is verified in us-east-1/2 and
+// us-west-2; an unlisted region should warn (not fail).
+func TestGrok_BuildConfig_RegionWarning(t *testing.T) {
+	p, _ := Get("grok")
+	opts := baseOpts()
+	opts.Region = "eu-west-1"
+	plan, err := p.BuildConfig(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("BuildConfig should not fail on an unlisted region: %v", err)
+	}
+	if len(plan.Warnings) == 0 {
+		t.Error("expected a region-availability warning for grok-4.3 in eu-west-1")
+	}
+	// A known region must NOT warn.
+	opts.Region = "us-west-2"
+	plan, _ = p.BuildConfig(testConfig(), opts)
+	if len(plan.Warnings) != 0 {
+		t.Errorf("us-west-2 is a known region and must not warn, got %v", plan.Warnings)
 	}
 }


### PR DESCRIPTION
## What

`apply --cli=grok` wrote a valid `[model.bedrock-grok]` block, but launching `grok` **still prompted the user to sign in** — it never used the Bedrock routing.

**Root cause** (verified against the official xAI Grok CLI docs, read-only, on a real install): Grok's per-model credential order is `api_key → env_key → XAI_API_KEY`, but a custom `[model.*]` block does **not** satisfy Grok's *session* auth. With only `env_key` set (what we did), Grok still runs its interactive browser/OIDC login. The documented mechanism that **replaces** login is the `[auth]` block's `auth_provider_command`: Grok runs it via `sh -c`, reads a token from stdout, stores it in `~/.grok/auth.json`, and auto-refreshes (re-runs ~5 min before `expires_in`, or on 401).

## Changes

- **New hidden `juggernaut auth-token`** (`cmd/auth_token.go`): reads the shared keychain bearer token, prints `{"access_token":...}` to stdout, adds `"expires_in"` (seconds until the key's embedded expiry) for short-term keys so Grok refreshes proactively. Diagnostics go to **stderr** so stdout stays a clean token (Grok's contract); exits non-zero when no token is stored (Grok falls through to normal login, user sees why).
- **`grok.BuildConfig`**: drop `env_key`; add `[auth]` (`auth_provider_command="juggernaut auth-token"`, `auth_provider_label="Bedrock"`); set `api_backend="responses"` (grok-4.3 serves both Chat + Responses on `/openai/v1`, verified 2026-07-03; Responses is the richer surface — web search etc.). `"auth"` joins `NativeManagedKeys`/`DeepMergeKeys`/`OwnedSubKeys` so uninstall removes **only** our two auth keys and preserves a user's own `[auth]` (e.g. their OIDC config). Region-availability warning added (grok-4.3 known in us-east-1/2, us-west-2), mirroring Codex.

## Tests (TDD, red→green)

- `auth-token`: bare-token JSON, short-term-key `expires_in`, single-clean-JSON-object stdout, real command via isolated keychain, and non-zero + clean-stdout on empty.
- grok BuildConfig: `[auth]` block present, **no** `env_key`, `api_backend=responses`, region warning outside the known set; deep-merge contract includes `auth`.
- **E2E verified**: apply writes `[auth]`+`[model.bedrock-grok]`+`[models]`; a user's own model profile **and** their `oidc_issuer` survive both apply and uninstall (the deep-merge that prevents the earlier clobber). Full suite + gosec + Claude golden clean.

## Open item

`api_backend="responses"` matches our verified Mantle matrix + the value JP specified, but the final **live re-confirm on Mantle is pending a fresh Bedrock key** — the temp key used to test had a revoked STS session (structurally valid, but AWS rejected the underlying token). Backend is the only value gated on that; everything else is confirmed.