### PR TITLE
fix(region): route Mantle CLIs to a region that serves the model (Iron Fist)

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -197,6 +197,10 @@ func runApply(_ *cobra.Command, _ []string) error {
 	// not one of Claude's per-tier IDs. Thread the raw flag through so the
 	// provider selects the right model instead of silently defaulting.
 	provOpts.Model = applyFlags.model
+	// Whether the region was explicitly chosen (vs filled from the global
+	// default). Mantle providers auto-switch a model to a region that serves it
+	// only when the region was defaulted; an explicit --region is honored.
+	provOpts.RegionExplicit = applyFlags.region != ""
 	return commitApply(home, authMode, token, block, prov, bCfg, provOpts)
 }
 

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -154,9 +154,13 @@ func TestCodex_BuildConfig_MantleBlock(t *testing.T) {
 	if bm["wire_api"] != "responses" {
 		t.Errorf("wire_api = %v, want responses (gpt-5.5 default)", bm["wire_api"])
 	}
-	base, _ := bm["base_url"].(string)
-	if len(base) < len("/openai/v1") || base[len(base)-len("/openai/v1"):] != "/openai/v1" {
-		t.Errorf("base_url = %q, want .../openai/v1", base)
+	// baseOpts uses the default region us-west-2 (non-explicit). gpt-5.5 is only
+	// in us-east-1/2, so the region auto-switches to us-east-1.
+	if got := bm["base_url"].(string); got != "https://bedrock-mantle.us-east-1.api.aws/openai/v1" {
+		t.Errorf("base_url = %q, want us-east-1 /openai/v1 (auto-switched from default us-west-2)", got)
+	}
+	if len(plan.Warnings) == 0 {
+		t.Error("expected an auto-switch heads-up when the default region can't serve gpt-5.5")
 	}
 	if err := plan.Validate(); err != nil {
 		t.Errorf("Codex plan should validate: %v", err)
@@ -195,19 +199,27 @@ func TestCodex_BuildConfig_UnknownModel(t *testing.T) {
 	}
 }
 
-// TestCodex_BuildConfig_RegionWarning warns when the model isn't confirmed in
-// the requested region (gpt-5.5 is us-east-1/2 only).
-func TestCodex_BuildConfig_RegionWarning(t *testing.T) {
+// TestCodex_BuildConfig_RegionIronFist: gpt-5.5 is us-east-1/2 only, so ANY
+// non-serving region — even one the user passed explicitly — is overridden to a
+// known-good region and the base_url reflects the override. Juggernaut never
+// writes a config that can't reach the model.
+func TestCodex_BuildConfig_RegionIronFist(t *testing.T) {
 	p, _ := Get("codex")
 	opts := baseOpts()
 	opts.Model = "gpt-5.5"
 	opts.Region = "eu-west-1" // not in gpt-5.5's known regions
+	opts.RegionExplicit = true
 	plan, err := p.BuildConfig(testConfig(), opts)
 	if err != nil {
 		t.Fatalf("BuildConfig: %v", err)
 	}
+	mp := plan.Keys["model_providers"].(map[string]any)
+	bm := mp["bedrock-mantle"].(map[string]any)
+	if got := bm["base_url"].(string); got != "https://bedrock-mantle.us-east-1.api.aws/openai/v1" {
+		t.Errorf("base_url = %q, want us-east-1 (overridden from eu-west-1)", got)
+	}
 	if len(plan.Warnings) == 0 {
-		t.Error("expected a region-availability warning for gpt-5.5 in eu-west-1")
+		t.Error("expected a message noting the region override")
 	}
 }
 

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"slices"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
@@ -126,7 +125,12 @@ func (codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) 
 		return ConfigPlan{}, fmt.Errorf("unknown Codex model %q (supported: gpt-5.5, gpt-5.4)", key)
 	}
 
-	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws%s", opts.Region, m.BasePath)
+	// A model is only reachable in the regions where it's verified available; a
+	// user's default region may not serve it. Auto-switch when the region was
+	// defaulted, honor-and-warn when it was explicit.
+	region, regionMsg, _ := resolveMantleRegion(opts.Region, opts.RegionExplicit, m.Regions)
+
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws%s", region, m.BasePath)
 	provBlock := map[string]any{
 		"name":     "Amazon Bedrock (Mantle)",
 		"base_url": baseURL,
@@ -148,10 +152,8 @@ func (codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) 
 	}
 
 	var warnings []string
-	if len(m.Regions) > 0 && !regionAllowed(opts.Region, m.Regions) {
-		warnings = append(warnings, fmt.Sprintf(
-			"model %s is not confirmed available in %s (known: %v) — apply will still write config, but requests may fail",
-			m.ModelID, opts.Region, m.Regions))
+	if regionMsg != "" {
+		warnings = append(warnings, fmt.Sprintf("%s: %s", m.ModelID, regionMsg))
 	}
 
 	return ConfigPlan{
@@ -172,8 +174,4 @@ func (codex) LaunchSpec() LaunchSpec {
 
 func (codex) Supports(c Capability) bool {
 	return c == CapEffortLevels
-}
-
-func regionAllowed(region string, allowed []string) bool {
-	return slices.Contains(allowed, region)
 }

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -115,7 +115,11 @@ func (grok) Supports(Capability) bool { return false }
 // still falls through to interactive login. The [auth] block is the documented
 // way to replace login entirely.
 func (grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
-	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1", opts.Region)
+	// Iron Fist: route to a region that actually serves grok-4.3 rather than
+	// writing a config that can't reach it (see resolveMantleRegion).
+	region, regionMsg, _ := resolveMantleRegion(opts.Region, opts.RegionExplicit, grokRegions)
+
+	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/openai/v1", region)
 	keys := map[string]any{
 		"model": map[string]any{
 			grokModelName: map[string]any{
@@ -139,10 +143,8 @@ func (grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
 	}
 
 	var warnings []string
-	if !regionAllowed(opts.Region, grokRegions) {
-		warnings = append(warnings, fmt.Sprintf(
-			"model xai.grok-4.3 is not confirmed available in %s (known: %v) — apply will still write config, but requests may fail",
-			opts.Region, grokRegions))
+	if regionMsg != "" {
+		warnings = append(warnings, "xai.grok-4.3 "+regionMsg)
 	}
 
 	return ConfigPlan{

--- a/internal/provider/grok_test.go
+++ b/internal/provider/grok_test.go
@@ -208,22 +208,32 @@ func TestGrok_BuildConfig_AuthBlock(t *testing.T) {
 	}
 }
 
-// TestGrok_BuildConfig_RegionWarning: xai.grok-4.3 is verified in us-east-1/2 and
-// us-west-2; an unlisted region should warn (not fail).
-func TestGrok_BuildConfig_RegionWarning(t *testing.T) {
+// TestGrok_BuildConfig_RegionIronFist: xai.grok-4.3 is verified in us-east-1/2
+// and us-west-2. An unlisted region is OVERRIDDEN to a known-good one (base_url
+// reflects it) rather than written as-is; a known region is kept silently.
+func TestGrok_BuildConfig_RegionIronFist(t *testing.T) {
 	p, _ := Get("grok")
 	opts := baseOpts()
 	opts.Region = "eu-west-1"
+	opts.RegionExplicit = true
 	plan, err := p.BuildConfig(testConfig(), opts)
 	if err != nil {
 		t.Fatalf("BuildConfig should not fail on an unlisted region: %v", err)
 	}
-	if len(plan.Warnings) == 0 {
-		t.Error("expected a region-availability warning for grok-4.3 in eu-west-1")
+	bg := plan.Keys["model"].(map[string]any)[grokModelName].(map[string]any)
+	if base := bg["base_url"].(string); strings.Contains(base, "eu-west-1") {
+		t.Errorf("base_url must not use the non-serving region eu-west-1, got %q", base)
 	}
-	// A known region must NOT warn.
+	if len(plan.Warnings) == 0 {
+		t.Error("expected a region-override message for grok-4.3 in eu-west-1")
+	}
+	// us-west-2 IS a known grok-4.3 region → kept, silent.
 	opts.Region = "us-west-2"
 	plan, _ = p.BuildConfig(testConfig(), opts)
+	bg = plan.Keys["model"].(map[string]any)[grokModelName].(map[string]any)
+	if base := bg["base_url"].(string); !strings.Contains(base, "us-west-2") {
+		t.Errorf("us-west-2 serves grok-4.3 and must be kept, got %q", base)
+	}
 	if len(plan.Warnings) != 0 {
 		t.Errorf("us-west-2 is a known region and must not warn, got %v", plan.Warnings)
 	}

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -31,8 +31,13 @@ const bedrockAuthEnvName = "AWS_BEARER_TOKEN_BEDROCK"
 // provider package stays decoupled from Claude's schema — the mapping lives only
 // in claude.go.
 type Options struct {
-	AuthMode       string
-	Region         string
+	AuthMode string
+	Region   string
+	// RegionExplicit is true when the user passed --region, false when Region was
+	// filled from the global default. Mantle providers use this to decide whether
+	// they may auto-switch a model to a region that actually serves it (default)
+	// or must honor the user's explicit choice (and only warn).
+	RegionExplicit bool
 	Effort         string
 	Scope          string
 	Version        string

--- a/internal/provider/region.go
+++ b/internal/provider/region.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"fmt"
+	"slices"
+)
+
+// regionAllowed reports whether region is in the model's set of known-available
+// regions. An empty set means "no verified region data" — callers treat that as
+// unconstrained (see resolveMantleRegion).
+func regionAllowed(region string, known []string) bool {
+	return slices.Contains(known, region)
+}
+
+// resolveMantleRegion applies the shared Mantle region policy — the "Iron Fist":
+// a model is only reachable where it's verified available (known), and a user's
+// configured region cannot be assumed to serve it, so Juggernaut ALWAYS routes to
+// a region that actually works rather than writing a config that can't
+// authenticate. If the requested region serves the model it's kept; otherwise
+// Juggernaut overrides to the model's first known-good region — whether the
+// region was defaulted OR explicitly passed — and says what it did.
+//
+//   - known is empty         → no region data to enforce; keep requested, silent.
+//   - requested is in known  → keep it, silent.
+//   - requested NOT in known → override to known[0] (switched=true) with a
+//     message; the message wording notes whether the region was the user's
+//     explicit choice or the global default.
+//
+// (A future flag may let users force a non-serving region; for now the Iron Fist
+// guarantees a working config.)
+func resolveMantleRegion(requested string, explicit bool, known []string) (region, message string, switched bool) {
+	if len(known) == 0 || regionAllowed(requested, known) {
+		return requested, "", false
+	}
+	source := "default region"
+	if explicit {
+		source = "requested region"
+	}
+	return known[0], fmt.Sprintf(
+		"not available in %s %s; using %s instead (available: %v)",
+		source, requested, known[0], known), true
+}

--- a/internal/provider/region_test.go
+++ b/internal/provider/region_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import "testing"
+
+// TestResolveMantleRegion covers the shared region-resolution policy used by
+// Mantle providers: a model is only reachable in the regions where it's verified
+// available. When the user did NOT explicitly choose a region and the resolved
+// (defaulted) region can't serve the model, auto-switch to the model's first
+// known-good region. When the user DID choose the region, honor it but warn.
+func TestResolveMantleRegion(t *testing.T) {
+	known := []string{"us-east-1", "us-east-2"}
+
+	t.Run("defaulted region not serving model auto-switches", func(t *testing.T) {
+		region, warn, switched := resolveMantleRegion("us-west-2", false, known)
+		if region != "us-east-1" {
+			t.Errorf("region = %q, want us-east-1 (first known)", region)
+		}
+		if !switched {
+			t.Error("switched should be true")
+		}
+		if warn == "" {
+			t.Error("expected a heads-up message on auto-switch")
+		}
+	})
+
+	t.Run("defaulted region already serving model is kept", func(t *testing.T) {
+		region, warn, switched := resolveMantleRegion("us-east-2", false, known)
+		if region != "us-east-2" {
+			t.Errorf("region = %q, want us-east-2 (already valid)", region)
+		}
+		if switched || warn != "" {
+			t.Errorf("no switch/warn expected, got switched=%v warn=%q", switched, warn)
+		}
+	})
+
+	t.Run("explicit region not serving model is OVERRIDDEN (Iron Fist)", func(t *testing.T) {
+		region, warn, switched := resolveMantleRegion("us-west-2", true, known)
+		if region != "us-east-1" {
+			t.Errorf("region = %q, want us-east-1 (Iron Fist overrides even an explicit region)", region)
+		}
+		if !switched {
+			t.Error("switched should be true — Juggernaut never writes a non-serving region")
+		}
+		if warn == "" {
+			t.Error("expected a message noting the override")
+		}
+	})
+
+	t.Run("explicit region serving model is silent", func(t *testing.T) {
+		region, warn, switched := resolveMantleRegion("us-east-1", true, known)
+		if region != "us-east-1" || switched || warn != "" {
+			t.Errorf("valid explicit region should be silent, got region=%q warn=%q switched=%v", region, warn, switched)
+		}
+	})
+
+	t.Run("empty known set is a no-op (no region data to enforce)", func(t *testing.T) {
+		region, warn, switched := resolveMantleRegion("eu-west-1", false, nil)
+		if region != "eu-west-1" || switched || warn != "" {
+			t.Errorf("no known regions => keep as-is, got region=%q warn=%q switched=%v", region, warn, switched)
+		}
+	})
+}


### PR DESCRIPTION
## What

`apply --cli=codex` with no `--region` defaulted to `us-west-2`, but `gpt-5.5` is only served in `us-east-1`/`us-east-2` — so Juggernaut wrote a `config.toml` Codex **couldn't authenticate against**. JP hit exactly this: our own warning fired (`gpt-5.5 is not confirmed available in us-west-2`), then Codex choked at request time. Grok worked only because its model (grok-4.3) happens to be served in `us-west-2`.

The principle: **a user's configured region cannot be assumed to serve a given model** — but we *do* have verified data on where each model is available.

## Fix — the "Iron Fist"

New shared `resolveMantleRegion` policy (`internal/provider/region.go`): a model is only reachable where it's verified available. If the resolved region doesn't serve it, Juggernaut **overrides** to the model's first known-good region and says so — whether the region was the global **default** or passed **explicitly**. Juggernaut never writes a config that can't reach the model. If the region already serves the model, it's kept silently. Empty known-region data ⇒ no enforcement (we don't fabricate).

- `provider.Options` gains `RegionExplicit` (cmd sets it from `applyFlags.region != ""`).
- Codex + Grok `BuildConfig` resolve the region first and build `base_url` from it. `regionAllowed` moved to `region.go` (shared).
- **OpenCode intentionally NOT wired**: we have verified region data for only some of its curated models (grok-4.3, gpt-oss), not GLM/Kimi/DeepSeek/Qwen. Fabricating region lists would violate the no-guessing rule, so it's left as-is (documented in the commit).

## Tests (TDD)

- `resolveMantleRegion`: defaulted-not-serving → override; already-serving → keep silent; explicit-not-serving → **override** (Iron Fist); empty known set → no-op.
- Codex: `baseOpts()` (default us-west-2, gpt-5.5) now yields a **us-east-1** base_url + heads-up; explicit `eu-west-1` is also overridden to us-east-1.
- Grok: `eu-west-1` overridden (base_url doesn't contain it); `us-west-2` kept silently (valid for grok-4.3).
- **E2E verified**: reproduced JP's exact `apply --cli=codex` (no --region) → now writes `us-east-1` base_url with a message; grok keeps `us-west-2`. Full suite + gosec + Claude golden clean.

Follow-up to the v5.3.1 Codex/Grok auth fixes.