### PR TITLE
fix(codex): use command-backed auth so a direct codex run gets the token

### DIFF
--- a/cmd/auth_token.go
+++ b/cmd/auth_token.go
@@ -18,41 +18,64 @@ import (
 // same-day key rotation, long enough that the re-run overhead is negligible.
 const longTermRefreshSecs = 6 * 60 * 60 // 6 hours
 
-// authTokenCmd is a hidden command invoked by the Grok CLI's
-// `auth_provider_command` (see internal/provider/grok.go). Grok runs it via
-// `sh -c`, reads a token from stdout, stores it in ~/.grok/auth.json, and
-// re-runs it to refresh. Its stdout MUST contain ONLY the token JSON — any other
-// text breaks Grok's parsing — so all diagnostics go to stderr.
+// authTokenFormat selects the stdout shape (see runAuthToken). Reset by
+// resetFlags between ExecuteArgs calls.
+var authTokenFormat string
+
+// authTokenCmd is a hidden command invoked by a CLI's external auth provider to
+// fetch the Bedrock bearer token from the keychain. Two consumers, two shapes
+// (--format):
+//   - "json"  (default) → {"access_token":...,"expires_in":N} — the Grok CLI's
+//     auth_provider_command reads this (see internal/provider/grok.go).
+//   - "token"           → the BARE token on one line — the Codex CLI's
+//     auth.command trims stdout and uses the whole thing as the bearer token
+//     (verified in openai/codex external_bearer.rs), so it must NOT be JSON.
+//
+// stdout MUST contain ONLY the token payload — any stray text breaks parsing —
+// so all diagnostics go to stderr.
 var authTokenCmd = &cobra.Command{
 	Use:          "auth-token",
-	Short:        "Print the Bedrock bearer token as JSON (used by the Grok CLI auth provider)",
+	Short:        "Print the Bedrock bearer token (used by the Grok/Codex external auth providers)",
 	Hidden:       true,
 	SilenceUsage: true,
 	RunE:         runAuthToken,
 }
 
 func init() {
+	authTokenCmd.Flags().StringVar(&authTokenFormat, "format", "json",
+		"output format: json (Grok) or token (Codex, bare token)")
 	rootCmd.AddCommand(authTokenCmd)
 }
 
 func runAuthToken(_ *cobra.Command, _ []string) error {
+	if authTokenFormat != "json" && authTokenFormat != "token" {
+		return fmt.Errorf("invalid --format %q — must be json or token", authTokenFormat)
+	}
 	home, err := homeDir()
 	if err != nil {
 		return err
 	}
 	token, err := keychain.Default().GetWithFallback(home)
 	if err != nil {
-		// Diagnostics go to stderr; stdout stays clean so Grok never mis-parses
-		// an error message as a token.
+		// Diagnostics go to stderr; stdout stays clean so the caller never
+		// mis-parses an error message as a token.
 		return fmt.Errorf("reading Bedrock API key from keychain: %w", err)
 	}
 	if token == "" {
 		return errors.New("no Bedrock bearer token stored in the keychain — " +
-			"run juggernaut apply --cli=grok with --auth=" + authmode.BedrockAPIKey + " to store one")
+			"run juggernaut apply with --auth=" + authmode.BedrockAPIKey + " to store one")
 	}
-	out := buildAuthTokenJSON(token, time.Now().UTC())
-	fmt.Println(out)
+	fmt.Println(buildAuthTokenOutput(token, authTokenFormat, time.Now().UTC()))
 	return nil
+}
+
+// buildAuthTokenOutput renders the token in the requested shape. "token" emits
+// the bare token (Codex); anything else emits the Grok JSON.
+func buildAuthTokenOutput(token, format string, now time.Time) string {
+	if format == "token" {
+		return token
+	}
+	return buildAuthTokenJSON(token, now)
 }
 
 // buildAuthTokenJSON renders the token in Grok's expected stdout shape:

--- a/cmd/auth_token_test.go
+++ b/cmd/auth_token_test.go
@@ -101,6 +101,45 @@ func TestAuthToken_Command_EmitsKeychainToken(t *testing.T) {
 	}
 }
 
+// TestAuthToken_Command_FormatToken: --format=token prints the BARE token (no
+// JSON), which is what Codex's auth.command reads (it trims stdout and uses the
+// whole thing as the bearer token — verified in openai/codex external_bearer.rs).
+func TestAuthToken_Command_FormatToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("kc-bare-456", home); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	t.Cleanup(func() { _ = store.DeleteWithFallback(home) })
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"auth-token", "--format=token"}); err != nil {
+			t.Fatalf("auth-token --format=token: %v", err)
+		}
+	})
+	got := strings.TrimSpace(out)
+	if got != "kc-bare-456" {
+		t.Errorf("bare output = %q, want exactly the token kc-bare-456", got)
+	}
+	if strings.Contains(got, "{") || strings.Contains(got, "access_token") {
+		t.Errorf("--format=token must emit no JSON, got %q", got)
+	}
+}
+
+// TestBuildAuthTokenOutput_Formats pins the pure renderer for both formats.
+func TestBuildAuthTokenOutput_Formats(t *testing.T) {
+	now := time.Now().UTC()
+	if got := buildAuthTokenOutput("tok", "token", now); got != "tok" {
+		t.Errorf("token format = %q, want bare tok", got)
+	}
+	jsonOut := buildAuthTokenOutput("tok", "json", now)
+	if !strings.HasPrefix(jsonOut, "{") || !strings.Contains(jsonOut, "access_token") {
+		t.Errorf("json format = %q, want a JSON object", jsonOut)
+	}
+}
+
 // TestAuthToken_Command_ErrorsWhenNoToken: with no stored token, the command
 // errors (non-zero) and prints nothing parseable as a token to stdout, so Grok
 // falls through to its normal login.

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -167,9 +167,39 @@ func TestCodex_BuildConfig_MantleBlock(t *testing.T) {
 	}
 }
 
+// TestCodex_BuildConfig_AuthCommand: the Mantle provider block uses a command-
+// backed auth provider (reads the keychain via `juggernaut auth-token
+// --format=token`) instead of env_key. env_key requires the launch wrapper to
+// inject AWS_BEARER_TOKEN_BEDROCK; running codex directly then fails with
+// "Missing environment variable". The auth.command is self-contained (verified
+// in openai/codex external_bearer.rs: it execs the command and uses trimmed
+// stdout as the bearer token, refreshing after a 401).
+func TestCodex_BuildConfig_AuthCommand(t *testing.T) {
+	p, _ := Get("codex")
+	plan, err := p.BuildConfig(testConfig(), baseOpts())
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	bm := plan.Keys["model_providers"].(map[string]any)["bedrock-mantle"].(map[string]any)
+	if _, hasEnvKey := bm["env_key"]; hasEnvKey {
+		t.Errorf("env_key must NOT be set (it needs the launch wrapper); got %v", bm["env_key"])
+	}
+	auth, ok := bm["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("bedrock-mantle.auth block missing: %v", bm)
+	}
+	if auth["command"] != "juggernaut" {
+		t.Errorf("auth.command = %v, want juggernaut", auth["command"])
+	}
+	args, ok := auth["args"].([]string)
+	if !ok || len(args) < 2 || args[0] != "auth-token" || args[1] != "--format=token" {
+		t.Errorf("auth.args = %v, want [auth-token --format=token]", auth["args"])
+	}
+}
+
 // TestCodex_BuildConfig_SkipsOpenAILogin verifies the Mantle provider block sets
 // requires_openai_auth = false. Without it, the Codex CLI shows its ChatGPT
-// login screen on launch even with a valid custom provider + env_key token
+// login screen on launch even with a valid custom provider
 // (verified in openai/codex tui/src/lib.rs should_show_login_screen: login is
 // skipped ONLY when the active provider's requires_openai_auth is false).
 func TestCodex_BuildConfig_SkipsOpenAILogin(t *testing.T) {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -135,12 +135,20 @@ func (codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) 
 		"name":     "Amazon Bedrock (Mantle)",
 		"base_url": baseURL,
 		"wire_api": m.WireAPI,
-		"env_key":  bedrockAuthEnvName,
 		// Skip the ChatGPT/OpenAI login screen. Codex prompts for OpenAI auth only
 		// when the active provider's requires_openai_auth is true (verified in
-		// openai/codex tui should_show_login_screen); our credential is the bearer
-		// token in env_key, so declare no OpenAI auth is required.
+		// openai/codex tui should_show_login_screen).
 		"requires_openai_auth": false,
+		// Command-backed auth: Codex execs this and uses the trimmed stdout as the
+		// bearer token, refreshing after a 401 (openai/codex external_bearer.rs).
+		// This reads the keychain directly, so it works even when codex is launched
+		// WITHOUT Juggernaut's wrapper — unlike env_key, which needs the wrapper to
+		// inject AWS_BEARER_TOKEN_BEDROCK and fails ("Missing environment variable")
+		// on a direct `codex` run. --format=token emits the BARE token Codex wants.
+		"auth": map[string]any{
+			"command": "juggernaut",
+			"args":    []string{"auth-token", "--format=token"},
+		},
 	}
 
 	keys := map[string]any{


### PR DESCRIPTION
## What

Running `codex` **directly** (not through `juggernaut launch codex`) failed with:

```
■ Missing environment variable: AWS_BEARER_TOKEN_BEDROCK
```

Our Codex config used `env_key = "AWS_BEARER_TOKEN_BEDROCK"`, which only resolves when the launch wrapper injects that var. A bare `codex` invocation has nothing to inject it. (The earlier sign-in fix `requires_openai_auth=false` and the region auto-switch both work now — this was the last gap; the config was being read correctly, it just had no token.)

## Fix — command-backed auth (what makes Grok self-contained)

Switch Codex from `env_key` to a **command-backed auth provider** (verified supported in `openai/codex` — `ModelProviderAuthInfo` / `external_bearer.rs`):

```toml
[model_providers.bedrock-mantle.auth]
command = "juggernaut"
args = ["auth-token", "--format=token"]
```

Codex execs the command and uses the **trimmed stdout** as the bearer token, refreshing after a 401 (`external_bearer.rs` reads stdout as the raw token — not JSON). Because it reads the keychain directly, it works whether `codex` is launched via the wrapper **or directly**.

Codex's auth command wants a **bare token**, but `juggernaut auth-token` prints JSON for Grok. So `auth-token` gains **`--format`**: `json` (default → Grok, unchanged) and `token` (bare → Codex). One command, two consumers.

## Tests (TDD)

- `auth-token --format=token` → bare token; default → JSON; `buildAuthTokenOutput` pins both.
- Codex BuildConfig: `[.auth]` block with `command=juggernaut`, `args=[auth-token,--format=token]`, **no** `env_key`.
- **E2E verified**: valid nested TOML written; region still auto-switches to us-east-1; bare vs JSON output confirmed; a user's own `[model_providers.*]` survives apply + uninstall (deep-merge with the nested `.auth` block). Full suite + gosec + Claude golden clean.

Follow-up to v5.3.2. This should make Codex work on a direct run like Grok does.