### PR TITLE
fix(auto-mode): enable var when any configured model is capable; add Sonnet 5

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -331,20 +331,29 @@ func parseFallbackModels(raw string) ([]string, error) {
 	return models, nil
 }
 
-// warnAutoModeModel alerts the user when --mode=auto was requested but the
-// active session model won't unlock auto mode on Bedrock. Claude Code only
-// offers auto mode there when the model is Opus 4.7/4.8, so with Juggernaut's
-// default Sonnet model the Shift+Tab cycle hides auto entirely.
+// warnAutoModeModel handles the two --mode=auto outcomes. If at least one
+// configured model can use auto mode (AutoModeAvailable), Juggernaut has enabled
+// it — print how to actually reach it, since auto only appears in the Shift+Tab
+// cycle when the ACTIVE session model is capable (Sonnet 5 / Opus 4.7 / 4.8), not
+// when the Sonnet-tier default is active. If NO configured model is capable, warn
+// that auto can't be enabled at all. Only relevant when --mode=auto was requested.
 func warnAutoModeModel(block *schema.Block) {
-	if block.Meta.PermissionMode != "auto" || block.AutoModeUsable() {
+	if block.Meta.PermissionMode != "auto" {
 		return
 	}
 	fmt.Println()
-	fmt.Println("⚠ Auto mode on Bedrock requires Opus 4.7 or 4.8 (Claude Code v2.1.158+).")
-	fmt.Printf("  Your default session model is %s, which Claude Code does\n", block.Models.Sonnet)
-	fmt.Println("  not support for auto mode, so auto will not appear in the Shift+Tab cycle.")
-	fmt.Println("  Run Claude Code on Opus to unlock it — launch with `claude --model opus`")
-	fmt.Println("  or switch with `/model opus` inside a session (your opus alias is pinned to Opus 4.8).")
+	if block.AutoModeAvailable() {
+		fmt.Println("ℹ Auto mode is enabled (CLAUDE_CODE_ENABLE_AUTO_MODE=1).")
+		fmt.Println("  On Bedrock it appears in the Shift+Tab cycle only while your active session")
+		fmt.Println("  model is Sonnet 5, Opus 4.7, or Opus 4.8 — not the Sonnet-tier default. Run")
+		fmt.Println("  `claude --model opus` (or `/model opus` in a session) to use it. Requires")
+		fmt.Println("  Claude Code v2.1.158+.")
+		return
+	}
+	fmt.Println("⚠ Auto mode cannot be enabled: none of the configured models support it.")
+	fmt.Println("  On Bedrock auto mode requires Sonnet 5, Opus 4.7, or Opus 4.8 (Claude Code")
+	fmt.Println("  v2.1.158+). Configure one of those (e.g. keep the default Opus 4.8 alias) and")
+	fmt.Println("  re-run with --mode=auto.")
 }
 
 // warnMantleTradeoffs alerts the user that routing through Mantle disables

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -906,7 +906,11 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(out)
 }
 
-func TestApply_AutoMode_WarnsWhenModelNotOpus(t *testing.T) {
+// TestApply_AutoMode_EnabledWithDefaultConfig: the default config configures Opus
+// 4.8 (auto-capable) as the opus override even though the default model is Sonnet,
+// so --mode=auto ENABLES auto mode and prints the "enabled / how to reach it" info
+// — NOT the incapable-model warning. This is the fix for JP's case.
+func TestApply_AutoMode_EnabledWithDefaultConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -920,12 +924,18 @@ func TestApply_AutoMode_WarnsWhenModelNotOpus(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(out, "Auto mode on Bedrock requires Opus") {
-		t.Errorf("expected auto-mode model warning with default Sonnet model, got:\n%s", out)
+	if !strings.Contains(out, "Auto mode is enabled") {
+		t.Errorf("expected the auto-mode-enabled info with the default config, got:\n%s", out)
+	}
+	if strings.Contains(out, "cannot be enabled") {
+		t.Errorf("must not warn 'cannot be enabled' when Opus 4.8 is configured, got:\n%s", out)
 	}
 }
 
-func TestApply_AutoMode_NoWarnWhenModelIsOpus(t *testing.T) {
+// TestApply_AutoMode_WarnsWhenNoCapableModel: force every model tier to a
+// non-capable one → auto can't be enabled → the warning fires and the enable var
+// is absent.
+func TestApply_AutoMode_WarnsWhenNoCapableModel(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -934,14 +944,17 @@ func TestApply_AutoMode_NoWarnWhenModelIsOpus(t *testing.T) {
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"apply", "--auth=iam", "--region=us-west-2", "--mode=auto",
-			"--model", "global.anthropic.claude-opus-4-8", "--skip-preflight",
+			"--model", "global.anthropic.claude-sonnet-4-6", "--skip-preflight",
 		}); err != nil {
 			t.Fatalf("apply error: %v", err)
 		}
 	})
 
-	if strings.Contains(out, "Auto mode on Bedrock requires Opus") {
-		t.Errorf("did not expect auto-mode warning when model is Opus, got:\n%s", out)
+	if !strings.Contains(out, "cannot be enabled") {
+		t.Errorf("expected the incapable-model warning when no model is auto-capable, got:\n%s", out)
+	}
+	if got := readNativeEnvValue(t, home, "CLAUDE_CODE_ENABLE_AUTO_MODE"); got == "1" {
+		t.Errorf("enable var must be absent when no configured model is capable, got %q", got)
 	}
 }
 

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -178,8 +178,14 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 			env["ANTHROPIC_BEDROCK_MANTLE_BASE_URL"] = opts.MantleURL
 		}
 	}
-	if opts.PermissionMode == "auto" {
-		// Required on Bedrock/Vertex/Foundry — without it auto mode silently does nothing.
+	// Enable auto mode when it's the requested mode AND at least one configured
+	// model can use it (Opus/Sonnet/Fable; Haiku never qualifies). The var only
+	// makes auto AVAILABLE in the Shift+Tab cycle — Claude Code gates it by the
+	// live session model — so a Sonnet-tier default with an auto-capable Opus
+	// override (the standard config) still gets it. Required on
+	// Bedrock/Vertex/Foundry; without it auto silently never appears.
+	if opts.PermissionMode == "auto" &&
+		(IsAutoModeCapableModel(opus) || IsAutoModeCapableModel(sonnet) || IsAutoModeCapableModel(fable)) {
 		env["CLAUDE_CODE_ENABLE_AUTO_MODE"] = "1"
 	}
 	if opts.ServiceTier != "" {
@@ -218,26 +224,46 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	}, nil
 }
 
-// IsAutoModeCapableModel reports whether modelID is an Opus 4.7 or 4.8 model.
-// On Bedrock, Vertex, and Foundry, auto mode is offered only when the active
-// session model is one of these; Sonnet, Haiku, and older models are excluded.
-// See https://code.claude.com/docs/en/permission-modes.
+// IsAutoModeCapableModel reports whether modelID is a model that can use auto
+// permission mode on Bedrock/Vertex/Foundry: Claude Sonnet 5, Opus 4.7, or Opus
+// 4.8. Sonnet 4.6, Haiku, older Opus, and Fable are excluded. Verified against
+// https://code.claude.com/docs/en/permission-modes ("only Claude Sonnet 5, Opus
+// 4.7, and Opus 4.8"). Note claude-sonnet-5 is capable while claude-sonnet-4-6 is
+// not — the version digits matter, so match the full token, not just "sonnet".
 func IsAutoModeCapableModel(modelID string) bool {
 	normalized := strings.TrimSuffix(modelID, "[1m]")
 	for _, prefix := range regionalInferencePrefixes {
 		normalized = strings.TrimPrefix(normalized, prefix)
 	}
 	return strings.Contains(normalized, "claude-opus-4-8") ||
-		strings.Contains(normalized, "claude-opus-4-7")
+		strings.Contains(normalized, "claude-opus-4-7") ||
+		strings.Contains(normalized, "claude-sonnet-5")
 }
 
-// AutoModeUsable reports whether auto mode will actually be offered by Claude
-// Code for this block. It requires PermissionMode=="auto" AND the active default
-// session model (the Sonnet-tier pin, which is the account default on Bedrock)
-// to be an Opus 4.7/4.8 model. opusplan does not qualify: its execution phase
-// runs on Sonnet, and the session's default model is still Sonnet-tier.
+// AutoModeUsable reports whether auto mode will be offered for this block's
+// ACTIVE DEFAULT session model (the Sonnet-tier pin, the account default on
+// Bedrock). Distinct from AutoModeAvailable: this is the stricter "auto works
+// out of the box without switching models" check. opusplan does not qualify —
+// its execution phase runs on Sonnet, and the default model is still Sonnet-tier.
 func (b *Block) AutoModeUsable() bool {
 	return b.Meta.PermissionMode == "auto" && IsAutoModeCapableModel(b.Models.Sonnet)
+}
+
+// AutoModeAvailable reports whether Juggernaut should enable auto mode (write
+// CLAUDE_CODE_ENABLE_AUTO_MODE=1) for this block: PermissionMode=="auto" AND at
+// least one configured model (Opus, Sonnet, or Fable — Haiku is never capable)
+// can use auto mode. The env var only makes auto AVAILABLE in the Shift+Tab
+// cycle; Claude Code still gates it by the live session model. So enabling it
+// whenever a capable model is configured is correct — the user unlocks auto by
+// running a capable model (e.g. `claude --model opus`), even when the default
+// pin is Sonnet-tier.
+func (b *Block) AutoModeAvailable() bool {
+	if b.Meta.PermissionMode != "auto" {
+		return false
+	}
+	return IsAutoModeCapableModel(b.Models.Opus) ||
+		IsAutoModeCapableModel(b.Models.Sonnet) ||
+		IsAutoModeCapableModel(b.Models.Fable)
 }
 
 // regionalInferencePrefixes are the Bedrock cross-region inference profile

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -610,13 +610,18 @@ func TestIsAutoModeCapableModel(t *testing.T) {
 		model string
 		want  bool
 	}{
-		// Supported on Bedrock: Opus 4.7 and 4.8 (with any region prefix / [1m]).
+		// Supported on Bedrock (verified against code.claude.com/docs/en/permission-modes):
+		// Sonnet 5, Opus 4.7, and Opus 4.8 — with any region prefix / [1m] suffix.
 		{"global.anthropic.claude-opus-4-8", true},
 		{"global.anthropic.claude-opus-4-8[1m]", true},
 		{"us.anthropic.claude-opus-4-7", true},
 		{"anthropic.claude-opus-4-7", true},
 		{"claude-opus-4-8", true},
-		// Not supported: Sonnet, Haiku, older Opus, Fable, empty.
+		{"global.anthropic.claude-sonnet-5", true},
+		{"global.anthropic.claude-sonnet-5[1m]", true},
+		{"us.anthropic.claude-sonnet-5", true},
+		{"claude-sonnet-5", true},
+		// Not supported: Sonnet 4.6, Haiku, older Opus, Fable, empty.
 		{"global.anthropic.claude-sonnet-4-6", false},
 		{"global.anthropic.claude-sonnet-4-6[1m]", false},
 		{"us.anthropic.claude-opus-4-6", false},
@@ -675,5 +680,77 @@ func TestBlock_AutoModeUsable_FalseWhenModeNotAuto(t *testing.T) {
 	}
 	if block.AutoModeUsable() {
 		t.Error("expected AutoModeUsable()=false when PermissionMode is not auto")
+	}
+}
+
+// autoOpts is the default-config auto-mode option set: Sonnet-tier default model
+// (not capable) but the Opus 4.8 override IS capable — the exact shape of JP's setup.
+func autoOpts() schema.Options {
+	return schema.Options{
+		AuthMode: "iam", Region: "us-west-2", Effort: "high",
+		Scope: "user", Version: "5.3.0", PermissionMode: "auto", AuthValidated: true,
+	}
+}
+
+// TestBlock_AutoModeAvailable_TrueWithDefaultConfig: the default config pins Sonnet
+// as the default model but always configures Opus 4.8 as the opus override, which IS
+// auto-capable — so auto mode is AVAILABLE (the enable var should be written) even
+// though the default model isn't capable. This is JP's real scenario.
+func TestBlock_AutoModeAvailable_TrueWithDefaultConfig(t *testing.T) {
+	block, err := schema.Build(testConfig(), autoOpts())
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if !block.AutoModeAvailable() {
+		t.Error("expected AutoModeAvailable()=true: the Opus 4.8 override is auto-capable")
+	}
+}
+
+// TestBlock_AutoModeAvailable_FalseWhenModeNotAuto: available only applies at mode=auto.
+func TestBlock_AutoModeAvailable_FalseWhenModeNotAuto(t *testing.T) {
+	opts := autoOpts()
+	opts.PermissionMode = "plan"
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.AutoModeAvailable() {
+		t.Error("expected AutoModeAvailable()=false when PermissionMode != auto")
+	}
+}
+
+// TestBlock_AutoModeAvailable_FalseWhenNoCapableModel: force every model to a
+// non-capable one → no configured model qualifies → not available.
+func TestBlock_AutoModeAvailable_FalseWhenNoCapableModel(t *testing.T) {
+	opts := autoOpts()
+	// --model overrides all tiers → in schema.Options that's every per-tier field.
+	opts.OpusModel = "global.anthropic.claude-sonnet-4-6"
+	opts.SonnetModel = "global.anthropic.claude-sonnet-4-6"
+	opts.HaikuModel = "global.anthropic.claude-sonnet-4-6"
+	opts.FableModel = "global.anthropic.claude-sonnet-4-6"
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.AutoModeAvailable() {
+		t.Error("expected AutoModeAvailable()=false when no configured model is auto-capable")
+	}
+}
+
+// TestBuild_AutoMode_NoEnableVarWhenNoCapableModel: the enable var must NOT be written
+// when no configured model can use auto mode (writing it would mislead — auto still
+// wouldn't appear).
+func TestBuild_AutoMode_NoEnableVarWhenNoCapableModel(t *testing.T) {
+	opts := autoOpts()
+	opts.OpusModel = "global.anthropic.claude-sonnet-4-6"
+	opts.SonnetModel = "global.anthropic.claude-sonnet-4-6"
+	opts.HaikuModel = "global.anthropic.claude-sonnet-4-6"
+	opts.FableModel = "global.anthropic.claude-sonnet-4-6"
+	block, err := schema.Build(testConfig(), opts)
+	if err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+	if block.Env["CLAUDE_CODE_ENABLE_AUTO_MODE"] == "1" {
+		t.Error("CLAUDE_CODE_ENABLE_AUTO_MODE must not be set when no configured model is capable")
 	}
 }


### PR DESCRIPTION
## What

Auto permission mode never turned on for the standard setup — a Sonnet-tier **default** model with Opus 4.8 run at runtime (`claude --model opus`). Verified root cause against **code.claude.com/docs/en/permission-modes**: on Bedrock, auto mode needs `CLAUDE_CODE_ENABLE_AUTO_MODE=1` **and** the *active session model* to be **Sonnet 5 / Opus 4.7 / Opus 4.8**. Two defects:

1. **Enable var keyed off the wrong model.** The var (and the capability gate) checked the pinned **default** (Sonnet) model, so `apply --mode=auto` treated auto as unusable and the warning steered users away — even though the configured Opus 4.8 override *is* capable and the user runs it. The var only makes auto **available** in the Shift+Tab cycle; Claude Code still gates it by the live session model. So the correct rule is: write it when `--mode=auto` **and any configured model** (Opus/Sonnet/Fable) is auto-capable.
2. **Wrong capable set (latent bug).** `IsAutoModeCapableModel` matched only Opus 4.7/4.8 and **excluded Claude Sonnet 5**, which *is* auto-capable on Bedrock. Added `claude-sonnet-5` (distinct from the non-capable `claude-sonnet-4-6`).

## Changes

- `IsAutoModeCapableModel`: now Sonnet 5 + Opus 4.7 + Opus 4.8 (reusing the existing region-prefix/`[1m]` normalization). Doc comment cites the source.
- New `Block.AutoModeAvailable()` — true at `--mode=auto` when **any** configured model is capable — alongside the existing `AutoModeUsable()` (default-model check).
- `Build` writes `CLAUDE_CODE_ENABLE_AUTO_MODE=1` gated on `AutoModeAvailable`'s condition (computed from the resolved model locals, so `--model`/`--opus-model` overrides count).
- `warnAutoModeModel`: prints an accurate **"auto is enabled — reach it via `claude --model opus`"** note when available; only **warns** when *no* configured model is capable.

## Tests (substantial — explicit ask)

- `IsAutoModeCapableModel` truth table incl. Sonnet 5 with prefixes/`[1m]`, and the full non-capable set (Sonnet 4.6, Opus 4.5/4.6, Haiku, Fable, empty).
- `AutoModeAvailable` true/false matrix (default config, mode≠auto, all-non-capable, Sonnet-5-default).
- `Build` emits/omits the var correctly.
- cmd: default `--mode=auto` prints the enabled-info + writes the var; an all-non-capable config prints the warning + omits the var.
- **E2E verified**: `apply --mode=auto` (default config) writes `CLAUDE_CODE_ENABLE_AUTO_MODE=1` + `defaultMode=auto` and prints the info. Claude golden byte-identical; full suite + gosec clean.

Follow-up to v5.3.2. This is the auto-mode fix JP root-caused (missing enable var on Opus 4.8/Bedrock).