### PR TITLE
fix: address P2 review findings from PR #266

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -99,11 +99,21 @@ func validateApplyArgs(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	name, _, hasValue := strings.Cut(args[0], "=")
+	name, value, hasValue := strings.Cut(args[0], "=")
 	if hasValue && cmd.Flags().Lookup(name) != nil {
-		return fmt.Errorf("unexpected argument %q; did you mean --%s?", args[0], args[0])
+		// Redact the value for secret-bearing flags so a mistyped
+		// `bedrock-key=<api key>` does not leak the credential to stderr/logs.
+		if isSecretFlag(name) {
+			return fmt.Errorf("unexpected argument %s=<redacted>; did you mean --%s?", name, name)
+		}
+		return fmt.Errorf("unexpected argument %q; did you mean --%s=%s?", args[0], name, value)
 	}
 	return cobra.NoArgs(cmd, args)
+}
+
+// isSecretFlag returns true for flags that carry credentials.
+func isSecretFlag(name string) bool {
+	return name == "bedrock-key"
 }
 
 func runApply(_ *cobra.Command, _ []string) error {

--- a/cmd/apply_flags_test.go
+++ b/cmd/apply_flags_test.go
@@ -105,3 +105,23 @@ func TestApply_ValidateArgsEmptyArgs(t *testing.T) {
 		t.Fatalf("apply with no positional args should succeed, got: %v", err)
 	}
 }
+
+// TestApply_RedactsBedrockKey verifies that a mistyped bedrock-key argument
+// does not leak the secret value in the error message.
+func TestApply_RedactsBedrockKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	err := ExecuteArgs([]string{"apply", "bedrock-key=sk-secret-12345"})
+	if err == nil {
+		t.Fatal("expected bedrock-key argument to be rejected")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "sk-secret-12345") {
+		t.Fatalf("error message leaked secret value: %s", msg)
+	}
+	if !strings.Contains(msg, "redacted") {
+		t.Fatalf("expected redacted hint, got: %s", msg)
+	}
+}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
+	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +70,17 @@ func launchNamedCLI(cli string, args []string) error {
 	if err != nil {
 		return err
 	}
-	return activation.LaunchCLI(home, args, launchTargetFor(prov))
+
+	selfPaths := resolveSelfPaths()
+	return activation.LaunchWithOptions(activation.LaunchOptions{
+		Home:        home,
+		Args:        args,
+		Path:        os.Getenv("PATH"),
+		TokenGetter: func() (string, error) { return keychain.Default().GetWithFallback(home) },
+		Runner:      activation.RunBinary,
+		Target:      launchTargetFor(prov),
+		SelfPaths:   selfPaths,
+	})
 }
 
 // launchTargetFor maps a provider's LaunchSpec + binary names onto the
@@ -79,4 +93,24 @@ func launchTargetFor(p provider.Provider) activation.LaunchTarget {
 		StaticEnv:   spec.StaticEnv,
 		NeedsToken:  spec.NeedsToken,
 	}
+}
+
+// resolveSelfPaths returns additional executable paths that resolveBinary should
+// skip alongside os.Executable(). On Windows staged launches, the npm shim sets
+// JUGGERNAUT_ORIGINAL_BIN to the installed binary path so that PATH candidates
+// hardlinked to the installed binary are also skipped (os.Executable() returns
+// the temp copy, not the installed binary).
+func resolveSelfPaths() []string {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	originalBin := os.Getenv("JUGGERNAUT_ORIGINAL_BIN")
+	if originalBin == "" {
+		return nil
+	}
+	// Normalize to absolute to avoid any ambiguity.
+	if !filepath.IsAbs(originalBin) {
+		return nil
+	}
+	return []string{originalBin}
 }

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -329,5 +330,37 @@ func TestLaunch_DefaultsToClaude(t *testing.T) {
 	// Should reach provider.Get("claude") → activation, not a parse error.
 	if strings.Contains(err.Error(), "requires a CLI name") {
 		t.Fatalf("launch should not require a CLI name, got: %v", err)
+	}
+}
+
+// TestResolveSelfPaths_NoEnv returns nil when JUGGERNAUT_ORIGINAL_BIN is not set.
+func TestResolveSelfPaths_NoEnv(t *testing.T) {
+	orig := os.Getenv("JUGGERNAUT_ORIGINAL_BIN")
+	os.Unsetenv("JUGGERNAUT_ORIGINAL_BIN")
+	t.Cleanup(func() { os.Setenv("JUGGERNAUT_ORIGINAL_BIN", orig) })
+	result := resolveSelfPaths()
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+// TestResolveSelfPaths_RelativePath returns nil for a relative (unsafe) path.
+func TestResolveSelfPaths_RelativePath(t *testing.T) {
+	t.Setenv("JUGGERNAUT_ORIGINAL_BIN", "relative/path.exe")
+	result := resolveSelfPaths()
+	if result != nil {
+		t.Errorf("expected nil for relative path, got %v", result)
+	}
+}
+
+// TestResolveSelfPaths_AbsolutePath returns the path when it's absolute.
+func TestResolveSelfPaths_AbsolutePath(t *testing.T) {
+	t.Setenv("JUGGERNAUT_ORIGINAL_BIN", "C:\\some\\path\\juggernaut.exe")
+	result := resolveSelfPaths()
+	if len(result) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(result))
+	}
+	if result[0] != "C:\\some\\path\\juggernaut.exe" {
+		t.Errorf("expected original path, got %q", result[0])
 	}
 }

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -364,9 +364,6 @@ func TestResolveSelfPaths_AbsolutePath(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-only")
 	}
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-only")
-	}
 	t.Setenv("JUGGERNAUT_ORIGINAL_BIN", "C:\\some\\path\\juggernaut.exe")
 	result := resolveSelfPaths()
 	if len(result) != 1 {

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -345,7 +346,11 @@ func TestResolveSelfPaths_NoEnv(t *testing.T) {
 }
 
 // TestResolveSelfPaths_RelativePath returns nil for a relative (unsafe) path.
+// Windows-only: resolveSelfPaths returns nil on non-Windows before checking the env var.
 func TestResolveSelfPaths_RelativePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only")
+	}
 	t.Setenv("JUGGERNAUT_ORIGINAL_BIN", "relative/path.exe")
 	result := resolveSelfPaths()
 	if result != nil {
@@ -354,7 +359,14 @@ func TestResolveSelfPaths_RelativePath(t *testing.T) {
 }
 
 // TestResolveSelfPaths_AbsolutePath returns the path when it's absolute.
+// Windows-only: resolveSelfPaths returns nil on non-Windows before checking the env var.
 func TestResolveSelfPaths_AbsolutePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only")
+	}
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only")
+	}
 	t.Setenv("JUGGERNAUT_ORIGINAL_BIN", "C:\\some\\path\\juggernaut.exe")
 	result := resolveSelfPaths()
 	if len(result) != 1 {

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -97,6 +97,13 @@ type LaunchOptions struct {
 	// Bedrock). A zero Target defaults to Claude Code, so existing callers are
 	// unaffected. cmd/ populates it from the resolved Provider's LaunchSpec.
 	Target LaunchTarget
+
+	// SelfPaths are additional executable paths that resolveBinary should skip
+	// alongside os.Executable(). This is needed on Windows when the npm shim
+	// stages the binary to a temp copy: os.Executable() returns the temp path,
+	// but PATH candidates hardlinked to the original installed binary must also
+	// be skipped to prevent recursive self-invocation.
+	SelfPaths []string
 }
 
 // LaunchTarget carries the per-CLI launch configuration, mirroring
@@ -577,7 +584,7 @@ func LaunchCLI(home string, args []string, target LaunchTarget) error {
 		Args:        args,
 		Path:        os.Getenv("PATH"),
 		TokenGetter: func() (string, error) { return keychain.Default().GetWithFallback(home) },
-		Runner:      runBinary,
+		Runner:      RunBinary,
 		Target:      target,
 	})
 }
@@ -594,7 +601,7 @@ func LaunchWithOptions(opts LaunchOptions) error {
 		opts.TokenGetter = func() (string, error) { return keychain.Default().GetWithFallback(opts.Home) }
 	}
 	if opts.Runner == nil {
-		opts.Runner = runBinary
+		opts.Runner = RunBinary
 	}
 	if opts.Warner == nil {
 		opts.Warner = func(msg string) { fmt.Fprintln(os.Stderr, msg) }
@@ -647,7 +654,8 @@ func LaunchWithOptions(opts LaunchOptions) error {
 		env = unsetEnv(env, tokenEnvVar)
 	}
 
-	binPath, err := resolveBinary(opts.Path, target.BinaryNames)
+	self, _ := os.Executable()
+	binPath, err := resolveBinaryFrom(opts.Path, target.BinaryNames, self, opts.SelfPaths)
 	if err != nil {
 		return fmt.Errorf("real %s binary not found on PATH", target.BinaryNames[0])
 	}
@@ -927,14 +935,28 @@ func normalizeNewlines(content string) string {
 // the launcher for any CLI (claude, codex, …).
 func resolveBinary(pathList string, names []string) (string, error) {
 	self, _ := os.Executable()
-	return resolveBinaryFrom(pathList, names, self)
+	return resolveBinaryFrom(pathList, names, self, nil)
 }
 
-func resolveBinaryFrom(pathList string, names []string, self string) (string, error) {
+func resolveBinaryFrom(pathList string, names []string, self string, selfPaths []string) (string, error) {
 	for _, dir := range filepath.SplitList(pathList) {
 		for _, name := range names {
 			candidate := filepath.Join(dir, name)
 			if sameExecutable(candidate, self) {
+				continue
+			}
+			// On Windows staged launches, os.Executable() returns the temp copy
+			// path. A stale claude.exe/codex.exe hardlinked to the installed
+			// binary won't match the temp copy's inode, so also check against
+			// any additional self paths passed by the caller.
+			skip := false
+			for _, sp := range selfPaths {
+				if sameExecutable(candidate, sp) {
+					skip = true
+					break
+				}
+			}
+			if skip {
 				continue
 			}
 			// Reject legacy v4.2.6 claude.cmd/claude.bat shims that invoke
@@ -957,7 +979,7 @@ func resolveClaudeBinary(pathList, self string) (string, error) {
 	if runtime.GOOS == "windows" {
 		names = []string{"claude.exe", "claude.cmd", "claude.bat"}
 	}
-	return resolveBinaryFrom(pathList, names, self)
+	return resolveBinaryFrom(pathList, names, self, nil)
 }
 
 // isLegacyClaudeShim returns true if the file at path is a legacy v4.2.6
@@ -1048,7 +1070,10 @@ func authModes(home string) ([]string, error) {
 	return modes, nil
 }
 
-func runBinary(path string, args []string, env []string) error {
+// RunBinary executes the resolved CLI binary with the given args and environment,
+// inheriting stdin/stdout/stderr. Exported for cmd/launch.go which constructs
+// LaunchOptions directly instead of using LaunchCLI.
+func RunBinary(path string, args []string, env []string) error {
 	// path is the resolved real Claude Code executable from ResolveClaudeBinary;
 	// exec.Command is intentionally used without a shell to preserve arguments.
 	cmd := exec.Command(path, args...) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command, go_subproc_rule-subproc

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -930,14 +930,6 @@ func normalizeNewlines(content string) string {
 	return strings.ReplaceAll(content, "\r\n", "\n")
 }
 
-// resolveBinary finds a real CLI executable on pathList by trying each of names,
-// skipping this juggernaut binary and known v4.2.6 launcher artifacts. Used by
-// the launcher for any CLI (claude, codex, …).
-func resolveBinary(pathList string, names []string) (string, error) {
-	self, _ := os.Executable()
-	return resolveBinaryFrom(pathList, names, self, nil)
-}
-
 func resolveBinaryFrom(pathList string, names []string, self string, selfPaths []string) (string, error) {
 	for _, dir := range filepath.SplitList(pathList) {
 		for _, name := range names {

--- a/internal/activation/resolve_authmodes_test.go
+++ b/internal/activation/resolve_authmodes_test.go
@@ -95,6 +95,59 @@ func claudeName() string {
 	return "claude"
 }
 
+// TestResolveBinaryFrom_SelfPaths covers the staged-launch scenario on Windows:
+// os.Executable() returns the temp copy path, but a stale claude.exe hardlinked
+// to the installed binary must also be skipped. resolveBinaryFrom with SelfPaths
+// ensures both the temp copy AND the original installed binary are skipped.
+func TestResolveBinaryFrom_SelfPaths(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	// "installed" is the original installed Juggernaut binary (hardlinked target).
+	installed := filepath.Join(dirA, "juggernaut-installed")
+	writeExecutableFile(t, dirA, installed, "installed-binary")
+
+	// "tempCopy" simulates os.Executable() on a staged Windows launch —
+	// a different file on disk (not hardlinked to installed).
+	tempCopy := filepath.Join(dirA, "juggernaut-temp")
+	writeExecutableFile(t, dirA, tempCopy, "temp-copy-binary")
+
+	// Stale claude.exe in dirA is hardlinked to the installed binary.
+	// It should be skipped because it's the same file as the installed binary.
+	staleClaude := filepath.Join(dirA, claudeName())
+	if err := os.Link(installed, staleClaude); err != nil {
+		if err := os.Symlink(installed, staleClaude); err != nil {
+			t.Skipf("cannot link/symlink to simulate staged launch: %v", err)
+		}
+	}
+
+	// Real claude in dirB — the correct target.
+	realClaude := filepath.Join(dirB, claudeName())
+	writeExecutableFile(t, dirB, realClaude, "real-claude")
+
+	pathList := strings.Join([]string{dirA, dirB}, string(os.PathListSeparator))
+
+	// Without SelfPaths: tempCopy is os.Executable(), staleClaude is NOT
+	// the same file as tempCopy → staleClaude would be selected (WRONG).
+	gotWithoutSelfPaths, err := resolveBinaryFrom(pathList, []string{claudeName()}, tempCopy, nil)
+	if err != nil {
+		t.Fatalf("resolveBinaryFrom (no selfPaths): %v", err)
+	}
+	if gotWithoutSelfPaths != staleClaude {
+		t.Errorf("without SelfPaths, expected stale claude at %q (demonstrating the bug), got %q", staleClaude, gotWithoutSelfPaths)
+	}
+
+	// With SelfPaths containing the installed binary: staleClaude IS the same
+	// file as installed → skipped → real claude selected (CORRECT).
+	gotWithSelfPaths, err := resolveBinaryFrom(pathList, []string{claudeName()}, tempCopy, []string{installed})
+	if err != nil {
+		t.Fatalf("resolveBinaryFrom (with selfPaths): %v", err)
+	}
+	if gotWithSelfPaths != realClaude {
+		t.Errorf("with SelfPaths, expected real claude at %q, got %q", realClaude, gotWithSelfPaths)
+	}
+}
+
 // TestAuthModes_SkipsMalformedSettings covers the guard branches: a juggernaut
 // block missing the managedBy marker, or with wrong-typed auth, contributes no
 // mode instead of erroring.

--- a/npm/index.js
+++ b/npm/index.js
@@ -204,11 +204,18 @@ if (require.main === module) {
     ? stageLaunchBinary(bin)
     : void 0;
   var runBin = staged ? staged.bin : bin;
+  // When staging, pass the original installed binary path so resolveBinary
+  // can also skip PATH candidates hardlinked to it (os.Executable() returns
+  // the temp copy, not the installed binary).
+  var launchEnv = Object.assign({}, process.env);
+  if (staged) {
+    launchEnv.JUGGERNAUT_ORIGINAL_BIN = bin;
+  }
   var result;
   try {
     result = childProcess.spawnSync(runBin, args, {
       stdio: "inherit",
-      env: Object.assign({}, process.env),
+      env: launchEnv,
       shell: false,
       windowsHide: true
     });


### PR DESCRIPTION
## Summary

Address 2 unresolved P2 review findings from PR #266 (`fix: harden multi-CLI launch safety on Windows`).

### P2 #1: Redact bedrock-key secret values from argument errors

When a user mistypes `bedrock-key=<api key>` as a positional argument instead of `--bedrock-key=...`, the error message now redacts the value (`bedrock-key=<redacted>`) instead of printing the raw credential to stderr/logs. Non-secret flags still show the full value in the hint.

### P2 #2: Prevent staged Windows launches from breaking resolveBinary self-skipping

On Windows staged launches, `os.Executable()` returns the temp copy path. A stale `claude.exe`/`codex.exe` hardlinked to the installed Juggernaut binary earlier on PATH won't match the temp copy, causing recursive self-invocation instead of finding the real CLI. 

Fix: new `LaunchOptions.SelfPaths` field carries the original installed binary path. `resolveBinaryFrom` checks candidates against both `os.Executable()` and each `SelfPaths` entry. The npm shim sets `JUGGERNAUT_ORIGINAL_BIN` env var when staging, and `cmd/launch.go` reads it and passes it through.

## Changes

- `cmd/apply.go` — `validateApplyArgs` redacts secret flag values; new `isSecretFlag` helper
- `cmd/apply_flags_test.go` — `TestApply_RedactsBedrockKey`
- `cmd/launch.go` — `launchNamedCLI` uses `LaunchWithOptions` with `SelfPaths`; new `resolveSelfPaths()` helper
- `cmd/launch_test.go` — 3 tests for `resolveSelfPaths` (no env, relative path, absolute path)
- `internal/activation/activation.go` — `resolveBinaryFrom` accepts `selfPaths []string`; `LaunchOptions.SelfPaths` field; `runBinary` → `RunBinary` (exported)
- `internal/activation/resolve_authmodes_test.go` — `TestResolveBinaryFrom_SelfPaths`
- `npm/index.js` — set `JUGGERNAUT_ORIGINAL_BIN` env var when staging

## Verification

- `go test ./...` — all 12 packages pass
- `go vet ./...` — clean
- `npm test` — 25/25 pass
- Coverage: 79.2% (Windows local), 60%+ on Linux CI

Follows up on PR #266