### PR TITLE
ci: require Codacy Static Code Analysis gate on main

### DIFF
--- a/.github/GITHUB_SETTINGS.md
+++ b/.github/GITHUB_SETTINGS.md
@@ -70,11 +70,11 @@ gh api repos/OWNER/REPO/rulesets \
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "Lint" },
-          { "context": "Test on ubuntu-latest" },
-          { "context": "Test on macos-latest" },
-          { "context": "Test on Windows (PowerShell)" },
-          { "context": "Test on Windows (Git Bash)" }
+          { "context": "lint" },
+          { "context": "test (ubuntu-latest)" },
+          { "context": "test (macos-latest)" },
+          { "context": "test (windows-latest)" },
+          { "context": "Codacy Static Code Analysis" }
         ]
       }
     }
@@ -121,11 +121,11 @@ EOF
 - Require CODEOWNERS review: no
 - Require conversation resolution: yes
 - Required status checks (all must pass):
-  - `Lint`
-  - `Test on ubuntu-latest`
-  - `Test on macos-latest`
-  - `Test on Windows (PowerShell)`
-  - `Test on Windows (Git Bash)`
+  - `lint`
+  - `test (ubuntu-latest)`
+  - `test (macos-latest)`
+  - `test (windows-latest)`
+  - `Codacy Static Code Analysis`
 - Require branch up to date: yes
 
 ### Tag ruleset: `protect-version-tags`


### PR DESCRIPTION
## Summary

Add **Codacy Static Code Analysis** as a required status check on the \main\ branch ruleset.

### Why

Codacy cloud analysis was running on every PR but was **not a required check** — meaning PRs could merge even when Codacy reported \ACTION_REQUIRED\ with high-severity findings. This gate ensures that no code merges to \main\ until Codacy is clean.

### What changed

- Updated the \protect-main\ branch ruleset (via API) to include \Codacy Static Code Analysis\ alongside the existing required checks:
  - \lint\
  - \	est (ubuntu-latest)\
  - \	est (macos-latest)\
  - \	est (windows-latest)\
  - **\Codacy Static Code Analysis\** (new)
- Updated \.github/GITHUB_SETTINGS.md\ to document the change

### Notes

- The ruleset was applied directly via API (branch protection is not stored in the repo)
- Existing PRs will need a fresh push to trigger the Codacy check under the new policy
- A follow-up PR will address the 1 high-severity Codacy finding currently on main