### PR TITLE
ci: add octocov coverage metrics and Octopus Review workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -1,0 +1,24 @@
+name: Octocov
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
+        with:
+          go-version: "1.26"
+      - name: Run tests with coverage
+        run: go test ./... -v -coverprofile=coverage.out -covermode=atomic
+      - name: Run octocov
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9  # v1.5.1

--- a/.github/workflows/octopus.yml
+++ b/.github/workflows/octopus.yml
@@ -1,0 +1,14 @@
+name: Octopus Review
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octopusreview/action@c7156c0dc465c20e8b06da84b92b64f9ae8c7c36

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,12 +1,4 @@
-octocov:
-  coverage:
-    # Go test coverage from the CI test-coverage job
-    files:
-      - coverage.out
-    format: gocover
-    threshold: 60.0
-  measure:
-    # Code-to-test ratio and test execution time
-    tool: go
-  test_time:
-    tool: go
+coverage:
+  paths:
+    - coverage.out
+  acceptable: 60%

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,12 @@
+octocov:
+  coverage:
+    # Go test coverage from the CI test-coverage job
+    files:
+      - coverage.out
+    format: gocover
+    threshold: 60.0
+  measure:
+    # Code-to-test ratio and test execution time
+    tool: go
+  test_time:
+    tool: go


### PR DESCRIPTION
## Summary

Add two new CI quality gates as GitHub Actions workflows:

- **Octocov** — measures code coverage, code-to-test ratio, and test execution time. Posts coverage reports on PRs. Threshold: 60% (matches existing `test-coverage` floor).
- **Octopus Review** — AI-powered code review on PR targets. Posts review comments on `opened` and `synchronize` events.

Both are free for open source. All actions pinned to commit SHAs per project convention.

## Notes

- **Codecov** is already configured in `ci.yml` (OIDC upload) — no changes needed.
- **Socket Security** is already active as a GitHub App — runs on every commit and shows as `Socket Security: Project Report` check. No workflow file needed.

## Files

| File | Purpose |
|------|---------|
| `.octocov.yml` | Coverage threshold config (60%) |
| `.github/workflows/octocov.yml` | Octocov measurement job |
| `.github/workflows/octopus.yml` | Octopus Review PR action |

## Next Steps

After merge, update the `protect-main` ruleset to require:
- `measure` (octocov)
- `review` (Octopus Review)
- `Socket Security: Project Report` (already running via GitHub App)
