### PR TITLE
chore: fix CodeQL code scanning configuration

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL Config"
+
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, go, javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

CodeQL code scanning was configured via the GitHub UI (default setup) only, with no committed workflow or config file. This causes:

- "3 configurations not found" warning on every PR
- No PR-level diff reporting (scans run on push to main only)
- No visibility into the scanning config in the repo

## Fix

Add explicit CodeQL workflow and config:

- `.github/codeql/codeql-config.yml` — uses `security-extended` query suite
- `.github/workflows/codeql.yml` — matrix over `actions`, `go`, `javascript-typescript` languages; runs on push, PR, and weekly schedule

## Details

- `actions/checkout` pinned to v7.0.0 commit SHA (already used elsewhere in CI)
- `github/codeql-action` uses `@v3` tag ref (SHA pinning fails due to annotated tag resolution)
- `security-extended` includes all security + quality queries (superset of default)