### PR TITLE
docs: mark legacy/v3 as protected branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,6 @@ discard changes without explicit authorization.
 Use conventional commit subjects when asked to commit. Release tags are `v*`
 and trigger publishing; do not create or push a release tag unless explicitly
 requested.
+
+**Protected branches:** `legacy/v3` must never be deleted — it is required for
+older releases. When cleaning up branches, skip any branch named `legacy/*`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,12 @@ Single Go binary. Entry point: `main.go` → `cmd/` → `internal/`.
 
 Version must stay in sync across **three** locations: `VERSION`, `bedrock-config.json` (`.version`), and `var Version` in `cmd/root.go`. CI enforces this — a mismatch fails the lint job.
 
+## Git Branches
+
+**Protected branches:** `legacy/v3` must never be deleted — it is required for
+older releases. When cleaning up branches after merges, skip any branch named
+`legacy/*`.
+
 ## Testing
 
 - Standard Go `testing` package. Run with `go test ./... -v` or `make test`.


### PR DESCRIPTION
Add protected branch notice to CLAUDE.md and AGENTS.md to prevent accidental deletion of \legacy/v3\ — required for older releases.