### PR TITLE
fix: replace gitleaks false positive test secret value

### DIFF
--- a/cmd/apply_flags_test.go
+++ b/cmd/apply_flags_test.go
@@ -113,12 +113,12 @@ func TestApply_RedactsBedrockKey(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 
-	err := ExecuteArgs([]string{"apply", "bedrock-key=sk-secret-12345"})
+	err := ExecuteArgs([]string{"apply", "bedrock-key=test-fake-key-12345"})
 	if err == nil {
 		t.Fatal("expected bedrock-key argument to be rejected")
 	}
 	msg := err.Error()
-	if strings.Contains(msg, "sk-secret-12345") {
+	if strings.Contains(msg, "test-fake-key-12345") {
 		t.Fatalf("error message leaked secret value: %s", msg)
 	}
 	if !strings.Contains(msg, "redacted") {


### PR DESCRIPTION
## Problem

Codacy's gitleaks generic-api-key detector flagged a false positive in \cmd/apply_flags_test.go:116\: the test used \sk-secret-12345\ as a fake Bedrock key value. The \sk-\ prefix matches the generic API key pattern, triggering an **Insecure Storage** finding.

## Fix

Replace \sk-secret-12345\ with \	est-fake-key-12345\ — a value that doesn't resemble any real API key format. The test behavior is unchanged: it still verifies that a mistyped \edrock-key=\ argument is rejected and the secret value is redacted in the error message.

## Verification

- \go test ./cmd/... -run TestApply_RedactsBedrockKey -v\ — **PASS**
- \go test ./...\ — **all PASS**