### PR TITLE
chore: pin github/codeql-action to commit SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,12 +26,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- `github/codeql-action` has been the one unpinned action in this repo since it was added in #273 — every other workflow step (`actions/checkout`, `actions/setup-go`, `codecov/codecov-action`, etc.) is already pinned to a full commit SHA per the repo's stated convention. Dependabot's recent v3→v4 bump (#287) correctly mirrored the existing (already-inconsistent) style rather than introducing a new gap.
- Pins both `github/codeql-action/init` and `github/codeql-action/analyze` to `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` — the commit the `v4` tag currently resolves to, verified via the GitHub API (tag → tag object → commit), matching the `@<sha>  # v4` comment style used elsewhere.

## Test plan
- [x] Verified the SHA via `gh api repos/github/codeql-action/git/refs/tags/v4` → tag object → `.object.sha`
- [x] CI (CodeQL workflow itself) will exercise the pinned action on this PR