### PR TITLE
chore: OSS stabilization — npm install guard + community docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,20 @@
 ## Summary
-Brief description of what this PR does.
+Brief description of what this PR does and why.
 
 ## Changes
 - Change 1
 - Change 2
 
 ## Testing
-- [ ] Ran `bash ./test.sh` and all tests pass
-- [ ] Tested on: (OS/shell)
+- [ ] `go test ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `cd npm && npm test` passes (if npm/ touched)
+- [ ] `make ci` passes when local tools are available
+- [ ] Tested on: (OS / shell / target CLI if relevant)
 
 ## Documentation
-- [ ] Updated README.md (if applicable)
-- [ ] Updated CLAUDE.md (if applicable)
+- [ ] Updated `README.md` / `QUICKSTART.md` (if user-facing)
+- [ ] Updated `CLAUDE.md` / `AGENTS.md` (if architecture or conventions change)
 
 ## Related Issues
 Closes #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,98 @@
 # Contributing to Juggernaut
 
-Thanks for your interest in contributing!
+Thanks for your interest in contributing. Juggernaut is a Go CLI that configures
+coding agents (Claude Code, Codex, OpenCode, Grok) to route through Amazon Bedrock.
 
 ## Getting Started
 
-1. Fork the repository
-2. Clone your fork
-3. Create a branch for your change
+1. Fork the repository and clone your fork
+2. Install [Go](https://go.dev/dl/) (see `go.mod` for the required version)
+3. Optional but recommended: [golangci-lint](https://golangci-lint.run/) for local lint
+4. Create a branch for your change (`feat/…`, `fix/…`, `docs/…`, `chore/…`)
+
+```bash
+git clone https://github.com/<you>/juggernaut.git
+cd juggernaut
+make build
+make test
+```
+
+On Windows, the same `make` targets work when Make is available; otherwise:
+
+```bash
+go build -o bin/juggernaut .
+go test ./...
+go vet ./...
+```
 
 ## Development
 
 ```bash
-# Run bash tests (requires Bash 4.0+)
-bash ./tests/v2/test_schema.sh
-bash ./tests/v2/test_config_manager.sh
-bash ./tests/v2/test_keychain.sh
-bash ./tests/v2/test_apply.sh
-bash ./tests/v2/test_show.sh
-bash ./tests/v2/test_doctor.sh
-bash ./tests/v2/test_uninstall.sh
-bash ./tests/v2/test_install.sh
+make build          # bin/juggernaut
+make test           # go test ./...
+make test-race      # race detector (Linux/macOS preferred)
+make test-cover     # coverage.out + total
+make lint           # golangci-lint
+make fmt vet        # gofmt + go vet
+make ci             # tidy, format, vet, lint, test
 
-# Run PowerShell tests (Pester 5)
-pwsh -Command "Invoke-Pester ./tests/v2 -CI"
+# Single package / test
+go test ./internal/schema/... -v
+go test ./cmd/... -run TestApply_WritesSettings_IAM -v
 
-# Preview an apply without writing
-./juggernaut apply --auth=iam --dry-run
+# Dry-run apply (no writes)
+./bin/juggernaut apply --auth=iam --dry-run
 
-# Preview an installer wipe without writing
-./install.sh --dry-run
+# npm launcher tests (Node >= 20)
+cd npm && npm test
 
-# Lint shell scripts
-shellcheck juggernaut install.sh commands/*.sh lib/keychain.sh lib/schema.sh lib/config_manager.sh lib/profile_paths.sh lib/doctor.sh tests/v2/test_*.sh
+# Install git hooks (optional)
+scripts/setup-hooks.ps1     # Windows
+bash scripts/setup-hooks.sh # Linux/macOS
 ```
+
+Architecture, provider inventory, managed keys, and CI/release design live in
+[`CLAUDE.md`](CLAUDE.md) and [`AGENTS.md`](AGENTS.md). Read those before changing
+`internal/provider`, apply/uninstall behavior, or the npm package.
 
 ## Guidelines
 
-- **Test your changes** — run the test suites above before submitting
-- **Update docs** — if adding flags or features, update `README.md`, `QUICKSTART.md`, and `CLAUDE.md`
-- **Keep it simple** — this is a focused utility, not a framework
-- **Cross-platform** — all changes need `.sh` and `.ps1` variants; targets are macOS, Linux, Windows PowerShell 5.1, Windows PowerShell 7, Windows Git Bash, and WSL
+- **Test your changes** — new behavior needs focused tests; run the affected package, then `go test ./...`
+- **Update docs** — flags or user-visible behavior → update `README.md`, `QUICKSTART.md`, and `CLAUDE.md` as needed
+- **Keep it focused** — Juggernaut configures Bedrock routing for coding CLIs; avoid turning it into a general agent framework
+- **Cross-platform** — macOS, Linux, and Windows are first-class; prefer `internal/safepath` and existing helpers over OS-specific shortcuts
+- **Provider isolation** — put CLI-specific logic behind `provider.Provider`; do not hardcode CLI names in `cmd/` beyond capability gates
+- **No secrets in tests or commits** — use non-key-like fixtures; never commit real AWS credentials or Bedrock API keys
+- **Version sync** — if you touch version, keep `VERSION`, `bedrock-config.json` `.version`, and `cmd/root.go` `Version` aligned
+- **Conventional commits** — `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, `ci:`, `build:`, `perf:`
+
+## Configuration
+
+Defaults and model pins live in `bedrock-config.json` (embedded into the binary at
+build time). Do not hardcode Bedrock model IDs or env defaults in scripts.
+
+For Claude Code governance flags (`--available-models`, `--enforce-available-models`),
+remember they write user/project settings only — not OS-level managed settings.
 
 ## Pull Requests
 
-1. Create a descriptive PR title
-2. Explain what the change does and why
-3. Ensure tests pass
-4. Update documentation if needed
-
-## Configuration Changes
-
-All environment variables and defaults live in `bedrock-config.json` — this is the single source of truth. Don't hardcode values in scripts.
+1. Use a descriptive conventional-commit title
+2. Explain what changed and why
+3. Ensure CI-relevant checks pass locally (`go test ./...`, `go vet ./...`; `make ci` when tools are available)
+4. Update documentation when flags or behavior change
+5. Link related issues (`Closes #…`)
 
 ## Reporting Issues
 
 Please include:
-- OS and shell version
-- Output of `juggernaut doctor`
+
+- OS and shell
+- Juggernaut version (`juggernaut version`)
+- Output of `juggernaut doctor` (redact secrets)
+- Target CLI (`claude`, `codex`, `opencode`, `grok`) if relevant
 - Steps to reproduce
+
+Security issues: see [`SECURITY.md`](SECURITY.md) — do not open a public issue for vulnerabilities.
 
 ## License
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025
+Copyright (c) 2025-2026 Juan Pablo Velasco
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,23 +34,29 @@ Upgrading from an older Juggernaut? Install v5 directly with npm; there is no re
 
 ### 4. Configure
 ```bash
-# IAM / SSO (recommended for organizations)
+# IAM / SSO (recommended for organizations) — Claude Code default
 juggernaut apply --auth=iam
 
 # Bedrock API key (key stored securely in OS keychain)
 juggernaut apply --auth=bedrock-api-key
+
+# Other coding CLIs
+juggernaut apply --cli=opencode --auth=iam
+juggernaut apply --cli=codex --auth=iam
+juggernaut apply --cli=grok --auth=bedrock-api-key
 ```
 
 Run without flags for an interactive first-run prompt.
 
-`juggernaut apply` will not write `CLAUDE_CODE_USE_BEDROCK=1` unless a valid credential source is confirmed.
+`juggernaut apply` will not enable Bedrock routing unless a valid credential source is confirmed. If the target config already has foreign values on keys Juggernaut would write, apply refuses unless you pass `--force`.
 
 ### 5. Launch
 ```bash
 claude
+# or codex / opencode / grok after apply --cli=<name>
 ```
 
-Restart your shell, or source the updated profile, then run `claude` normally. Juggernaut installs a shell function and never overwrites the real Claude Code binary.
+Restart your shell, or source the updated profile, then run the CLI normally. Juggernaut installs a marked shell function and never overwrites the real binary.
 
 ## Verify Setup
 
@@ -79,6 +85,9 @@ juggernaut apply --auth=iam --opusplan
 # Auto mode — lets Claude Code auto-approve safe tool calls with background checks
 juggernaut apply --auth=iam --mode=auto
 
+# Curate the /model picker (user/project settings — not OS-managed enforcement)
+juggernaut apply --auth=iam --available-models=sonnet,claude-opus-4-8 --enforce-available-models
+
 # Override the subagent/background model
 juggernaut apply --auth=iam --haiku-model=global.anthropic.claude-sonnet-4-6
 
@@ -87,8 +96,8 @@ juggernaut apply --auth=iam --dry-run
 
 # Show current config
 juggernaut show
-
 ```
+
 
 ## Troubleshooting
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -40,9 +40,9 @@ juggernaut apply --auth=iam
 # Bedrock API key (key stored securely in OS keychain)
 juggernaut apply --auth=bedrock-api-key
 
-# Other coding CLIs
-juggernaut apply --cli=opencode --auth=iam
-juggernaut apply --cli=codex --auth=iam
+# Other coding CLIs (Mantle routes require a Bedrock API key, not IAM)
+juggernaut apply --cli=opencode --auth=bedrock-api-key
+juggernaut apply --cli=codex --auth=bedrock-api-key
 juggernaut apply --cli=grok --auth=bedrock-api-key
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 <h1 align="center">Juggernaut</h1>
 
-<p align="center"><strong>Claude Code → Amazon Bedrock in one command</strong></p>
+<p align="center"><strong>Safe Bedrock routing for coding agents — Claude Code, Codex, OpenCode, and Grok</strong></p>
 
-Single cross-platform binary that configures Claude Code to route through Amazon Bedrock instead of Anthropic's direct API — IAM, SSO, or Bedrock API key auth.
+Single cross-platform binary that configures your coding CLI to route through **Amazon Bedrock** instead of vendor APIs — IAM, SSO, or Bedrock API key auth. Juggernaut is the **safe Bedrock arbiter**: it refuses to clobber foreign config, keeps credentials in the OS keychain, and installs marked shell activation that never overwrites the real CLI binary.
 
 **Install from npm:** [`juggernaut-bedrock`](https://www.npmjs.com/package/juggernaut-bedrock) — `npm install -g juggernaut-bedrock`
 
@@ -97,7 +97,7 @@ Close and reopen PowerShell after `doctor` is green. This avoids the old `C:\Use
 ## Configure
 
 ```bash
-# IAM / SSO (recommended)
+# IAM / SSO (recommended) — Claude Code is the default --cli
 juggernaut apply --auth=iam
 
 # Bedrock API key (stored securely in OS keychain)
@@ -107,9 +107,32 @@ juggernaut apply --auth=bedrock-api-key
 juggernaut apply
 ```
 
-`juggernaut apply` will not write `CLAUDE_CODE_USE_BEDROCK=1` unless a valid credential source is confirmed.
+`juggernaut apply` will not enable Bedrock routing unless a valid credential source is confirmed (for Claude Code: no `CLAUDE_CODE_USE_BEDROCK=1` without validated auth).
 
-**Common options:**
+### Multi-CLI (`--cli`)
+
+| CLI | Flag | Config path (user scope) |
+|-----|------|---------------------------|
+| Claude Code (default) | `--cli=claude` | `~/.claude/settings.json` |
+| OpenAI Codex | `--cli=codex` | `~/.codex/config.toml` |
+| OpenCode | `--cli=opencode` | `~/.config/opencode/opencode.json` |
+| Grok | `--cli=grok` | `~/.grok/config.toml` (user scope only) |
+
+```bash
+juggernaut apply --cli=opencode --auth=iam
+juggernaut apply --cli=codex --auth=iam
+juggernaut apply --cli=grok --auth=bedrock-api-key
+```
+
+Activation blocks for different CLIs coexist in one shell profile. The Bedrock bearer token is **shared** across CLIs — uninstalling one non-Claude CLI does not remove it.
+
+### Safety defaults
+
+- **Collision detection** — if a target config already has foreign values on keys Juggernaut would write, apply refuses unless you pass `--force` (a backup is still created).
+- **Keychain-only secrets** — Bedrock API keys never go into shell profiles or plaintext config.
+- **No binary overwrite** — Juggernaut never installs over an unknown file matching a managed CLI name.
+
+**Common options (Claude Code):**
 
 ```bash
 juggernaut apply --auth=iam --region=us-east-1
@@ -120,27 +143,30 @@ juggernaut apply --auth=iam --always-thinking       # extended thinking on by de
 juggernaut apply --auth=iam --service-tier=flex     # Bedrock service tier: default | flex | priority
 juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>
 juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-4-8
+juggernaut apply --auth=iam --available-models=sonnet,claude-opus-4-8 --enforce-available-models
 juggernaut apply --auth=iam --mantle                # enable Mantle routing
 juggernaut apply --auth=iam --dry-run               # preview without writing
 juggernaut apply --auth=iam --scope=project         # write to ./.claude/settings.json
+juggernaut apply --auth=iam --force                 # overwrite colliding foreign leaves (backup kept)
 ```
 
 ## Launch
 
 ```bash
-claude
+claude          # after apply --cli=claude (default)
+# or: codex / opencode / grok after the matching --cli apply
 ```
 
-`juggernaut apply` installs a shell function named `claude` in your shell profile. Restart your shell, or source the updated profile, then run Claude normally. Juggernaut never installs over the real `claude` binary.
+`juggernaut apply` installs a marked shell function for the target CLI. Restart your shell, or source the updated profile, then run the CLI normally.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `apply` | Write Juggernaut config to `settings.json` and install shell activation. |
-| `show` | Print the current Juggernaut block from user and project scopes. |
-| `doctor` | Read-only diagnostics for settings, credentials, activation, Claude Code, and legacy v4.2.6 artifacts. |
-| `uninstall` | Remove the Juggernaut block and bearer token. Use `--full` to remove shell activation. |
+| `apply` | Write Juggernaut config for the target `--cli` and install shell activation. |
+| `show` | Print the current Juggernaut-managed config from user and project scopes. |
+| `doctor` | Read-only diagnostics for settings, credentials, activation, CLI binary, and legacy artifacts. Supports `--cli=claude\|codex\|opencode\|grok`. |
+| `uninstall` | Remove managed config keys and optionally the bearer token. Use `--full` to remove shell activation. |
 | `models check` | Maintainer tool: check `bedrock-config.json`'s pinned models against AWS Bedrock's live catalog; `--write --set-<tier>=<id>` to update a stale pin. |
 | `version` | Print the installed version. |
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ juggernaut apply
 | Grok | `--cli=grok` | `~/.grok/config.toml` (user scope only) |
 
 ```bash
-juggernaut apply --cli=opencode --auth=iam
-juggernaut apply --cli=codex --auth=iam
+# Codex / OpenCode / Grok route through Mantle and require a Bedrock API key (not IAM)
+juggernaut apply --cli=opencode --auth=bedrock-api-key
+juggernaut apply --cli=codex --auth=bedrock-api-key
 juggernaut apply --cli=grok --auth=bedrock-api-key
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,12 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report it privately rather than opening a public issue.
+If you discover a security vulnerability, report it **privately** — do not open a public issue.
 
 **Contact:** Open a [GitHub Security Advisory](../../security/advisories/new) or contact the maintainers directly.
 
 **Include:**
+
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact
@@ -14,19 +15,67 @@ If you discover a security vulnerability, please report it privately rather than
 
 We'll acknowledge receipt within 48 hours and aim to provide a fix timeline within 7 days.
 
-## Security Considerations
-
-This tool handles:
-- **AWS credentials** - Uses existing AWS CLI/SDK credential chain
-- **API keys** - Can be stored in shell profile (plaintext) or OS keychain (encrypted)
-- **Shell profiles** - Modifies `~/.bashrc`, `~/.zshrc`, etc.
-
-**Recommendations:**
-- Use IAM/SSO authentication when possible (no secrets stored)
-- API keys are stored in the OS keychain; use IAM/SSO authentication when possible to avoid storing secrets
-- Ensure shell profile permissions are restricted (`chmod 600`)
-- Don't commit `.backup.*` files if they contain sensitive data
-
 ## Supported Versions
 
-We provide security updates for the latest release only.
+Security updates are provided for the **latest release** only.
+
+## Threat Model (summary)
+
+Juggernaut is a local CLI that writes coding-agent configuration and optional shell activation so agents call **Amazon Bedrock** instead of vendor APIs. It runs with the privileges of the invoking user.
+
+### Assets
+
+| Asset | Where it lives | Sensitivity |
+|-------|----------------|-------------|
+| Bedrock API key (bearer) | OS keychain (`go-keyring`, service `juggernaut-bedrock`) | High — full Bedrock invoke capability |
+| AWS IAM/SSO credentials | Existing AWS credential chain (env, shared config, SSO) | High — Juggernaut does not store these |
+| Agent config (settings.json, config.toml, …) | User/project paths under home or cwd | Medium — can redirect model traffic |
+| Shell activation blocks | User shell profiles (`~/.bashrc`, `~/.zshrc`, PowerShell profile, …) | Medium — wrap CLI launch |
+| Config backups | `*.backup.*` next to managed config files | Medium — may contain prior env/auth metadata |
+
+### Trust boundaries
+
+1. **User machine** — Juggernaut and the target coding CLI run as the user; compromise of the user account implies compromise of keys and config.
+2. **AWS / Bedrock** — Inference traffic goes to AWS endpoints (or Mantle when configured). Juggernaut does not proxy prompts.
+3. **npm distribution** — Prebuilt binaries ship via `juggernaut-bedrock` optional platform packages; the Node shim resolves an allowlisted package only.
+4. **Upstream coding CLIs** — Claude Code, Codex, OpenCode, Grok are external binaries; Juggernaut must not overwrite unknown files matching their names.
+
+### Threats and mitigations
+
+| Threat | Mitigation in Juggernaut |
+|--------|---------------------------|
+| Silent partial npm install runs a **stale binary** (Windows file lock) | Windows `preinstall` aborts if `juggernaut.exe` is running; launcher refuses version skew between root and platform package |
+| Overwrite of **foreign** agent config | Collision detection refuses apply when owned leaves already hold non-Juggernaut values; `--force` requires intent and still creates a backup |
+| Credential leakage via UserData / plaintext profiles | Bedrock API keys go to the **OS keychain only** — never shell profiles or agent config as plaintext secrets |
+| Path traversal under user-controlled bases | `internal/safepath` containment + owner-only file modes for writes under controlled roots |
+| Recursive/wrapper confusion | Activation resolves the real target binary; never installs over unknown `claude`/`codex`/… binaries |
+| Auth-gated Bedrock without credentials | `CLAUDE_CODE_USE_BEDROCK=1` (and equivalents) only written when auth is validated |
+| Tampering with governance lists in user settings | Documented limitation: `availableModels` in user/project scope is not OS-managed enforcement; org policy requires Claude Code managed settings paths Juggernaut does not write |
+
+### Explicit non-goals
+
+- Juggernaut is **not** an enterprise policy engine or MDM substitute.
+- It does **not** implement Bedrock Guardrails attachment (tracked separately if needed).
+- It does **not** guarantee that a user cannot re-add models via other Claude Code scopes.
+- Live AWS calls in `juggernaut models check` require the operator's AWS credentials; that command is maintainer-facing and is not part of default apply/doctor paths.
+
+## Credential handling
+
+- **Prefer IAM/SSO** (`--auth=iam`) so no long-lived Bedrock API key is stored.
+- **Bedrock API key** (`--auth=bedrock-api-key`) is stored in the OS keychain only.
+- Uninstalling one non-Claude CLI does **not** remove the shared bearer token; only uninstall paths that intentionally clear credentials do.
+- Do not commit `.backup.*` files, `.env`, or real keys. Redact `doctor` output before sharing.
+
+## Recommendations for operators
+
+- Use IAM/SSO when possible
+- Restrict shell profile permissions (`chmod 600` on Unix)
+- Prefer VPN/VPC endpoints for Bedrock in sensitive environments (AWS-side)
+- Review collision refusals carefully before using `--force`
+- Keep Juggernaut and the target coding CLI updated
+
+## Security tooling in this repository
+
+- CI: gosec, CodeQL, Socket, Codacy, multi-OS Go tests
+- npm shim path allowlisting and launch binary staging on Windows
+- No live AWS in default unit tests (discovery uses fakes)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/doctor"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 	"github.com/spf13/cobra"
 )
@@ -26,10 +27,12 @@ var doctorCmd = &cobra.Command{
 var doctorFlags struct {
 	scope   string
 	jsonOut bool
+	cli     string
 }
 
 func init() {
 	doctorCmd.Flags().StringVar(&doctorFlags.scope, "scope", "", "check only user or project scope")
+	doctorCmd.Flags().StringVar(&doctorFlags.cli, "cli", "claude", "coding CLI to diagnose (claude, codex, opencode, grok)")
 	doctorCmd.Flags().BoolVar(&doctorFlags.jsonOut, "json", false, "output as JSON")
 	rootCmd.AddCommand(doctorCmd)
 }
@@ -39,6 +42,12 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	prov, err := provider.Get(doctorFlags.cli)
+	if err != nil {
+		return err
+	}
+	cliName := prov.Name()
+	isClaude := cliName == "claude"
 	r := doctor.NewReport()
 
 	bCfg, err := loadBedrockConfig()
@@ -52,17 +61,27 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	if doctorFlags.scope != "" {
 		scopes = []string{doctorFlags.scope}
 	}
+	// Grok is always user-scoped (ConfigPath ignores scope).
+	if cliName == "grok" {
+		if doctorFlags.scope == "project" {
+			return fmt.Errorf("grok has no project-scope config — omit --scope or use --scope=user")
+		}
+		scopes = []string{"user"}
+	}
 	for _, scope := range scopes {
 		required := scope != "project" || doctorFlags.scope == "project"
-		if status, detail := checkSettingsScope(home, scope, required); status != "" {
-			r.Check("settings.json ("+scope+")", status, detail)
+		label := providerConfigLabel(prov, scope)
+		if status, detail := checkProviderConfigScope(prov, home, scope, required); status != "" {
+			r.Check(label, status, detail)
 		}
-		scopeData := readScopeData(home, scope)
-		if detail, ok := opusplanProblem(scopeData); ok {
-			r.Check("top-level model ("+scope+")", doctor.Warn, detail)
+		scopeData := readProviderScopeData(prov, home, scope)
+		if isClaude {
+			if detail, ok := opusplanProblem(scopeData); ok {
+				r.Check("top-level model ("+scope+")", doctor.Warn, detail)
+			}
+			checkAutoModeReadiness(r, scope, scopeData)
+			checkFableDataRetention(r, scope, scopeData)
 		}
-		checkAutoModeReadiness(r, scope, scopeData)
-		checkFableDataRetention(r, scope, scopeData)
 	}
 
 	token, err := keychain.Default().GetWithFallback(home)
@@ -76,22 +95,36 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		checkKeyExpiry(r, token)
 	}
 
-	checkConnectivity(r, home, token, scopes)
+	// Connectivity reads Claude's juggernaut.auth block; other CLIs store auth differently.
+	if isClaude {
+		checkConnectivity(r, home, token, scopes)
+	}
 
+	begin, end := prov.ActivationMarkers()
+	actLabel := cliName + " activation"
 	// Use the shared resolver to check activation on the effective profiles.
 	if runtime.GOOS == "windows" {
 		psResult := activation.ResolvePowerShellProfiles()
-		healthy, path, warnings := activation.CheckPowerShellActivationWith(home, &psResult)
-		if healthy {
-			r.Check("claude activation", doctor.OK, "active in "+path)
+		if isClaude {
+			// Claude keeps the richer multi-profile warning path.
+			healthy, path, warnings := activation.CheckPowerShellActivationWith(home, &psResult)
+			if healthy {
+				r.Check(actLabel, doctor.OK, "active in "+path)
+			} else {
+				r.Check(actLabel, doctor.Warn, "not active in discovered profiles — run `juggernaut apply` and restart or source your shell")
+			}
+			for _, w := range warnings {
+				r.Check("activation warning", doctor.Warn, w)
+			}
 		} else {
-			r.Check("claude activation", doctor.Warn, "not active in discovered profiles — run `juggernaut apply` and restart or source your shell")
+			activationPaths := activation.InstalledTargetsForMarkers(home, &psResult, begin, end)
+			if len(activationPaths) > 0 {
+				r.Check(actLabel, doctor.OK, "active in "+activationPaths[0])
+			} else {
+				r.Check(actLabel, doctor.Warn, "not active in discovered profiles — run `juggernaut apply --cli="+cliName+"` and restart or source your shell")
+			}
 		}
-		for _, w := range warnings {
-			r.Check("activation warning", doctor.Warn, w)
-		}
-		// Report discovery status (reuse the already-resolved result).
-		// Only emit OK when editions were actually discovered.
+		// PowerShell discovery warnings are Windows-host health, not CLI-specific.
 		if len(psResult.EditionsDiscovered) > 0 {
 			editions := strings.Join(psResult.EditionsDiscovered, ", ")
 			r.Check("powershell discovery", doctor.OK, "editions: "+editions)
@@ -100,17 +133,28 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			r.Check("powershell discovery", doctor.Warn, w)
 		}
 	} else {
-		activationPaths := activation.InstalledTargets(home)
-		if len(activationPaths) > 0 {
-			r.Check("claude activation", doctor.OK, strings.Join(activationPaths, ", "))
+		var activationPaths []string
+		if isClaude {
+			activationPaths = activation.InstalledTargets(home)
 		} else {
-			r.Check("claude activation", doctor.Warn, "not installed — run `juggernaut apply` and restart or source your shell")
+			activationPaths = activation.InstalledTargetsForMarkers(home, nil, begin, end)
+		}
+		if len(activationPaths) > 0 {
+			r.Check(actLabel, doctor.OK, strings.Join(activationPaths, ", "))
+		} else {
+			hint := "`juggernaut apply`"
+			if !isClaude {
+				hint = "`juggernaut apply --cli=" + cliName + "`"
+			}
+			r.Check(actLabel, doctor.Warn, "not installed — run "+hint+" and restart or source your shell")
 		}
 	}
-	if status, detail := claudeCommandStatus(); status != "" {
-		r.Check("claude binary", status, detail)
+	if status, detail := cliBinaryStatus(prov); status != "" {
+		r.Check(cliName+" binary", status, detail)
 	}
-	legacyArtifactStatus(home, r)
+	if isClaude {
+		legacyArtifactStatus(home, r)
+	}
 	if doctorFlags.jsonOut {
 		out, err := r.JSON()
 		if err != nil {
@@ -133,6 +177,33 @@ func claudeCommandStatus() (doctor.Status, string) {
 		return doctor.Warn, "real Claude Code binary not found on PATH"
 	}
 	return doctor.OK, found
+}
+
+func cliBinaryStatus(prov provider.Provider) (doctor.Status, string) {
+	names := prov.BinaryNames()
+	if len(names) == 0 {
+		return doctor.Warn, "no binary names registered for " + prov.Name()
+	}
+	if prov.Name() == "claude" {
+		return claudeCommandStatus()
+	}
+	found, err := activation.ResolveBinary(os.Getenv("PATH"), names)
+	if err != nil {
+		return doctor.Warn, "real " + names[0] + " binary not found on PATH"
+	}
+	return doctor.OK, found
+}
+
+func providerConfigLabel(prov provider.Provider, scope string) string {
+	path, err := prov.ConfigPath("", scope)
+	if err != nil || path == "" {
+		return prov.Name() + " config (" + scope + ")"
+	}
+	base := path
+	if i := strings.LastIndexAny(path, `/\`); i >= 0 {
+		base = path[i+1:]
+	}
+	return base + " (" + scope + ")"
 }
 
 func legacyArtifactStatus(home string, r *doctor.Report) {
@@ -351,30 +422,55 @@ func checkFableDataRetention(r *doctor.Report, scope string, data map[string]any
 }
 
 func checkSettingsScope(home, scope string, required bool) (doctor.Status, string) {
-	path, err := settingsPath(home, scope)
+	// Back-compat helper for Claude-only call sites / tests.
+	prov, err := provider.Get("claude")
 	if err != nil {
 		return doctor.Fail, err.Error()
 	}
-	mgr := config.NewManager(path)
-	has, err := mgr.HasJuggernautBlock()
-	switch {
-	case err != nil:
+	return checkProviderConfigScope(prov, home, scope, required)
+}
+
+func checkProviderConfigScope(prov provider.Provider, home, scope string, required bool) (doctor.Status, string) {
+	path, err := prov.ConfigPath(home, scope)
+	if err != nil {
 		return doctor.Fail, err.Error()
-	case has:
-		return doctor.OK, "juggernaut block present"
-	case required:
-		return doctor.Fail, "juggernaut block not found — run `juggernaut apply`"
-	default:
-		return doctor.OK, "not configured"
 	}
+	format, err := config.FormatByName(prov.ConfigFormatName())
+	if err != nil {
+		return doctor.Fail, err.Error()
+	}
+	mgr := config.NewManagerWithFormat(path, format)
+	data, err := mgr.Read()
+	if err != nil {
+		return doctor.Fail, err.Error()
+	}
+	if prov.OwnsConfig(data) {
+		return doctor.OK, "juggernaut-managed Bedrock config present"
+	}
+	if required {
+		return doctor.Fail, "juggernaut-managed config not found — run `juggernaut apply --cli=" + prov.Name() + "`"
+	}
+	return doctor.OK, "not configured"
 }
 
 func readScopeData(home, scope string) map[string]any {
-	path, err := settingsPath(home, scope)
+	prov, err := provider.Get("claude")
 	if err != nil {
 		return nil
 	}
-	mgr := config.NewManager(path)
+	return readProviderScopeData(prov, home, scope)
+}
+
+func readProviderScopeData(prov provider.Provider, home, scope string) map[string]any {
+	path, err := prov.ConfigPath(home, scope)
+	if err != nil {
+		return nil
+	}
+	format, err := config.FormatByName(prov.ConfigFormatName())
+	if err != nil {
+		return nil
+	}
+	mgr := config.NewManagerWithFormat(path, format)
 	data, err := mgr.Read()
 	if err != nil {
 		return nil

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -440,6 +440,9 @@ func checkProviderConfigScope(prov provider.Provider, home, scope string, requir
 		return doctor.Fail, err.Error()
 	}
 	mgr := config.NewManagerWithFormat(path, format)
+	// Manager.Read returns (empty map, nil) when the file is missing — same
+	// contract as HasJuggernautBlock — so a missing optional project-scope
+	// config falls through to "not configured" rather than Fail.
 	data, err := mgr.Read()
 	if err != nil {
 		return doctor.Fail, err.Error()

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -341,7 +341,7 @@ func TestCheckProviderConfigScope_CodexOwnedOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	if err := safepath.MkdirAll(filepath.Dir(path)); err != nil {
 		t.Fatal(err)
 	}
 	// Minimal OwnsConfig marker for Codex.

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
 	"github.com/jpvelasco/juggernaut/v5/internal/doctor"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 )
@@ -312,6 +313,73 @@ func TestCheckSettingsScope_RequiredScopeMissingFails(t *testing.T) {
 	status, detail := checkSettingsScope(home, "user", true)
 	if status != doctor.Fail {
 		t.Fatalf("expected FAIL for missing required scope, got %s (%s)", status, detail)
+	}
+}
+
+func TestCheckProviderConfigScope_CodexMissingRequiredFails(t *testing.T) {
+	home := t.TempDir()
+	prov, err := provider.Get("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, detail := checkProviderConfigScope(prov, home, "user", true)
+	if status != doctor.Fail {
+		t.Fatalf("expected FAIL for missing codex config, got %s (%s)", status, detail)
+	}
+	if !strings.Contains(detail, "--cli=codex") {
+		t.Errorf("expected apply --cli=codex guidance, got %q", detail)
+	}
+}
+
+func TestCheckProviderConfigScope_CodexOwnedOK(t *testing.T) {
+	home := t.TempDir()
+	prov, err := provider.Get("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := prov.ConfigPath(home, "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Minimal OwnsConfig marker for Codex.
+	if err := os.WriteFile(path, []byte("model_provider = \"amazon-bedrock\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	status, detail := checkProviderConfigScope(prov, home, "user", true)
+	if status != doctor.OK {
+		t.Fatalf("expected OK for owned codex config, got %s (%s)", status, detail)
+	}
+	if !strings.Contains(detail, "present") {
+		t.Errorf("expected present detail, got %q", detail)
+	}
+}
+
+func TestCliBinaryStatus_WarnWhenMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	prov, err := provider.Get("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, detail := cliBinaryStatus(prov)
+	if status != doctor.Warn {
+		t.Fatalf("expected Warn when opencode missing, got %s (%s)", status, detail)
+	}
+	if !strings.Contains(detail, "not found on PATH") {
+		t.Errorf("expected PATH guidance, got %q", detail)
+	}
+}
+
+func TestDoctor_UnknownCLIRejected(t *testing.T) {
+	resetFlags()
+	err := ExecuteArgs([]string{"doctor", "--cli=nonesuch"})
+	if err == nil {
+		t.Fatal("expected error for unknown --cli")
+	}
+	if !strings.Contains(err.Error(), "unknown CLI") {
+		t.Errorf("expected unknown CLI error, got %v", err)
 	}
 }
 

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -454,7 +454,7 @@ func RemoveTargetWithLegacy(path string) (bool, error) {
 	return true, nil
 }
 
-// InstalledTargets returns profile paths currently containing the activation block.
+// InstalledTargets returns profile paths currently containing the Claude activation block.
 // On Windows it checks discovered active targets and POSIX targets.
 func InstalledTargets(home string) []string {
 	return InstalledTargetsWith(home, nil)
@@ -463,6 +463,12 @@ func InstalledTargets(home string) []string {
 // InstalledTargetsWith is like InstalledTargets but accepts a pre-resolved
 // ProfileResolverResult to avoid launching PowerShell.
 func InstalledTargetsWith(home string, psResult *ProfileResolverResult) []string {
+	return InstalledTargetsForMarkers(home, psResult, BeginMarker, EndMarker)
+}
+
+// InstalledTargetsForMarkers returns profile paths containing the given
+// begin/end activation markers (any managed CLI).
+func InstalledTargetsForMarkers(home string, psResult *ProfileResolverResult, begin, end string) []string {
 	var paths []string
 
 	if runtime.GOOS == "windows" {
@@ -473,14 +479,14 @@ func InstalledTargetsWith(home string, psResult *ProfileResolverResult) []string
 		}
 		for _, target := range result.ActiveTargets {
 			data, err := safepath.ReadFile(filepath.Dir(target.Path), target.Path)
-			if err == nil && HasBlock(string(data)) {
+			if err == nil && HasBlockWithMarkers(string(data), begin, end) {
 				paths = append(paths, target.Path)
 			}
 		}
 	} else if psResult != nil {
 		for _, target := range psResult.ActiveTargets {
 			data, err := safepath.ReadFile(filepath.Dir(target.Path), target.Path)
-			if err == nil && HasBlock(string(data)) {
+			if err == nil && HasBlockWithMarkers(string(data), begin, end) {
 				paths = append(paths, target.Path)
 			}
 		}
@@ -488,7 +494,7 @@ func InstalledTargetsWith(home string, psResult *ProfileResolverResult) []string
 
 	for _, target := range DefaultTargets(home) {
 		data, err := safepath.ReadFile(filepath.Dir(target.Path), target.Path)
-		if err == nil && HasBlock(string(data)) {
+		if err == nil && HasBlockWithMarkers(string(data), begin, end) {
 			paths = append(paths, target.Path)
 		}
 	}
@@ -497,7 +503,16 @@ func InstalledTargetsWith(home string, psResult *ProfileResolverResult) []string
 
 // HasBlock reports whether content contains a Juggernaut activation block.
 func HasBlock(content string) bool {
-	return strings.Contains(content, BeginMarker) && strings.Contains(content, EndMarker)
+	return HasBlockWithMarkers(content, BeginMarker, EndMarker)
+}
+
+// HasBlockWithMarkers reports whether content contains the given begin/end
+// activation markers (used for multi-CLI doctor/activation checks).
+func HasBlockWithMarkers(content, begin, end string) bool {
+	if begin == "" || end == "" {
+		return false
+	}
+	return strings.Contains(content, begin) && strings.Contains(content, end)
 }
 
 // HasLegacyLauncherBlock reports whether content contains a legacy
@@ -682,6 +697,13 @@ func LaunchWithOptions(opts LaunchOptions) error {
 func ResolveClaudeBinary(pathList string) (string, error) {
 	self, _ := os.Executable()
 	return resolveClaudeBinary(pathList, self)
+}
+
+// ResolveBinary resolves the first real executable among names on PATH,
+// skipping this process's own executable (wrapper recursion guard).
+func ResolveBinary(pathList string, names []string) (string, error) {
+	self, _ := os.Executable()
+	return resolveBinaryFrom(pathList, names, self, nil)
 }
 
 // DefaultBinDir returns the user-local bin directory where broken v4.2.6

--- a/internal/activation/activation_wrappers_test.go
+++ b/internal/activation/activation_wrappers_test.go
@@ -60,6 +60,18 @@ func TestDefaultBinDir_EmptyHomeFallsBack(t *testing.T) {
 	}
 }
 
+func TestHasBlockWithMarkers(t *testing.T) {
+	if !HasBlockWithMarkers("# BEGIN: X\nbody\n# END: X\n", "# BEGIN: X", "# END: X") {
+		t.Fatal("expected markers present")
+	}
+	if HasBlockWithMarkers("# BEGIN: X\nbody\n", "# BEGIN: X", "# END: X") {
+		t.Fatal("expected missing end marker to fail")
+	}
+	if HasBlockWithMarkers("body", "", "# END: X") {
+		t.Fatal("empty begin must fail closed")
+	}
+}
+
 func TestInstalledTargets_ReflectsInstallState(t *testing.T) {
 	home, psResult := setupActivationFixture(t)
 

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,2 +1,3 @@
 packages/
 index.test.js
+preinstall.test.js

--- a/npm/package.json
+++ b/npm/package.json
@@ -6,6 +6,7 @@
     "juggernaut": "./index.js"
   },
   "scripts": {
+    "preinstall": "node preinstall.js",
     "test": "node --test"
   },
   "optionalDependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "juggernaut-bedrock",
   "version": "0.0.0",
-  "description": "Route Claude Code through Amazon Bedrock in one command — IAM, SSO, or API key. Cross-platform CLI for GenAI developers.",
+  "description": "Safe Amazon Bedrock routing for Claude Code, Codex, OpenCode, and Grok — IAM, SSO, or API key. Cross-platform CLI for GenAI developers.",
   "bin": {
     "juggernaut": "./index.js"
   },

--- a/npm/preinstall.js
+++ b/npm/preinstall.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+var childProcess = require("node:child_process");
+
+/**
+ * @returns {string}
+ */
+function buildBlockMessage() {
+  return (
+    "juggernaut-bedrock: a Claude Code / Juggernaut session is currently " +
+    "running and is locking the Juggernaut binary.\n" +
+    "Installing now would leave the package in a broken state.\n" +
+    "Close all `claude` sessions and terminals, then re-run:\n" +
+    "  npm install -g juggernaut-bedrock\n"
+  );
+}
+
+/**
+ * Detects a running juggernaut.exe on Windows. Fails open (returns false) on
+ * non-Windows platforms and on any probe error, so a misfiring detection can
+ * never wedge a legitimate repair install.
+ * @returns {boolean}
+ */
+function isLockingProcessRunning() {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  try {
+    var out = childProcess.execFileSync(
+      "tasklist",
+      ["/FI", "IMAGENAME eq juggernaut.exe", "/NH"],
+      { encoding: "utf8", windowsHide: true }
+    );
+    return out.toLowerCase().indexOf("juggernaut.exe") !== -1;
+  } catch (_) {
+    return false;
+  }
+}
+
+function main() {
+  if (isLockingProcessRunning()) {
+    process.stderr.write(buildBlockMessage());
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildBlockMessage: buildBlockMessage,
+  isLockingProcessRunning: isLockingProcessRunning,
+  main: main
+};

--- a/npm/preinstall.test.js
+++ b/npm/preinstall.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var nodeTest = require("node:test");
+var describe = nodeTest.describe;
+var it = nodeTest.it;
+var assert = require("assert");
+
+var preinstall = require("./preinstall");
+
+describe("buildBlockMessage", function() {
+  it("names the reinstall command", function() {
+    assert.ok(preinstall.buildBlockMessage().indexOf("npm install -g juggernaut-bedrock") !== -1);
+    return void 0;
+  });
+  it("tells the user to close sessions", function() {
+    assert.ok(/close/i.test(preinstall.buildBlockMessage()));
+    return void 0;
+  });
+  return void 0;
+});
+
+describe("isLockingProcessRunning", function() {
+  it("returns a boolean and never throws", function() {
+    assert.strictEqual(typeof preinstall.isLockingProcessRunning(), "boolean");
+    return void 0;
+  });
+  it("fails open (false) on non-Windows platforms", function() {
+    if (process.platform === "win32") {
+      return void 0; // skip on Windows; non-Windows path is the fail-open contract
+    }
+    assert.strictEqual(preinstall.isLockingProcessRunning(), false);
+    return void 0;
+  });
+  return void 0;
+});


### PR DESCRIPTION
## Summary
Open-source readiness work for Juggernaut (no release cut).

## Changes
- **Safety:** Windows npm `preinstall` gate refuses install while `juggernaut.exe` is locking the binary (complements existing version-skew runtime guard). 31 npm tests green.
- **Docs:** Rewrite `CONTRIBUTING.md` and PR template for Go v5 multi-CLI; expand `SECURITY.md` with threat model + keychain-only credential guidance; position README/QUICKSTART as the safe Bedrock arbiter with `--cli`, collision/`--force`, and governance flag examples.
- **LICENSE:** copyright holder + years.

## Testing
- [x] `cd npm && node --test` — 31 pass
- [x] Docs-only + npm packaging; Go suite unchanged from main

## Out of scope
- Release/tag/npm publish
- Landing `models check` (PR #293)