### PR TITLE
fix: bump go.mod to 1.26.5 (2 stdlib CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/juggernaut/v5
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary
- Bumps `go.mod`'s `go` directive from `1.26.4` to `1.26.5`, fixing two Trivy-flagged stdlib CVEs Codacy surfaced against `go.mod`:
  - **High**: CVE-2026-39822 — `os.Root` symlink-following directory traversal
  - **Warning**: CVE-2026-42505 — `crypto/tls` Encrypted Client Hello information disclosure
- Closes #295.

## Why this needed re-verification
A prior attempt in PR #293 (commit `e960bf3`) reverted this same bump because CI runners only had Go 1.26.4 available under `GOTOOLCHAIN=local`. Go 1.26.5 is now officially released, and CI's `actions/setup-go@v6` steps use the floating `go-version: "1.26"`, which should resolve to the latest 1.26.x patch automatically. This PR exists to confirm that in CI before merging.

## Test plan
- [x] `go mod tidy` — no go.sum changes
- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass locally on 1.26.5
- [ ] CI lint/test/race/gosec jobs pass on all three OSes (this is the actual thing being verified)