### PR TITLE
fix: derive CI Go version from go.mod, not a hardcoded string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: Verify version sync
         run: |
           FILE_VERSION=$(cat VERSION)
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       # Run in bash on every OS so the working directory and tooling are
       # consistent. Go on the Windows runner writes coverage.out with CRLF line
       # endings, which Codecov's parser rejects (the upload lands in an ERROR
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: Run tests with race detector
         run: go test -race ./... -v
 
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0
       - name: Run tests with coverage
@@ -153,6 +153,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: Run gosec
         run: go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -exclude=G204,G304,G702,G703 ./...


### PR DESCRIPTION
## Summary
- Replaces `go-version: "1.26"` with `go-version-file: go.mod` across all 5 `setup-go` steps in `ci.yml` (lint, test, test-race, test-coverage, gosec).
- `go.mod` becomes the single source of truth for the Go version CI installs — bumping it there is now sufficient, no matching `ci.yml` edit required.

## Why
After #297 bumped `go.mod` to `1.26.5`, the PR's CI passed (that `macos-latest` runner happened to have `1.26.5` already cached), but the post-merge run on `main` landed on a *different* `macos-latest` runner instance that still had `1.26.4` cached. Since `setup-go` was pinned to the floating string `"1.26"` with `check-latest: false`, it silently used the stale cached `1.26.4` — which no longer satisfied `go.mod`'s `go 1.26.5` minimum — and the job failed with:

```
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

The underlying problem: `go.mod`'s version and `ci.yml`'s hardcoded version were two separate values that had to be manually kept in sync, with no guardrail catching drift until a runner's cache happened to expose it. `go-version-file: go.mod` removes the second value entirely — `setup-go` parses the `go` directive from the file itself.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI green on all 3 OSes — confirms `setup-go` resolves the same exact version everywhere regardless of per-runner cache state