### PR TITLE
chore: migrate GitHub Actions from node20 to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,10 @@ jobs:
       # enforces the local Linux floor and uploads JUnit for Test Analytics.
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3  # v1.2.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           use_oidc: true
+          report_type: test_results
           files: ./junit.xml
 
   npm-test:
@@ -129,7 +130,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('npm/package.json') }}


### PR DESCRIPTION
## Summary

Migrate all remaining JavaScript Actions to node24 runtime before the September 16, 2026 hard cutoff.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/cache` | v4 (node20) | **v6** (node24) |
| `codecov/test-results-action` | deprecated, node20 | **`codecov/codecov-action` v7.0.0** with `report_type: test_results` (composite runner — no node20) |

All other actions (`actions/checkout`, `actions/setup-go`, `actions/setup-node`, `golangci-lint`, `goreleaser`, `codecov-action`, `codeql-action`) were already on node24 or composite/Docker-based.

Both `codecov/codecov-action` uses in `ci.yml` (coverage upload + test results upload) are pinned to the same v7.0.0 SHA.

## Background

Node.js 20 reaches EOL in April 2026. GitHub is removing the node20 runtime from hosted runners on **September 16, 2026**. Actions targeting node20 will fail after that date.

`codecov/test-results-action` is deprecated — the official migration path is `codecov/codecov-action` with `report_type: test_results`.

## Testing
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] `cd npm && npm test` passes (if npm/ touched)
- [ ] `make ci` passes when local tools are available
- [ ] Tested on: (OS / shell / target CLI if relevant)

## Documentation
- [ ] Updated `README.md` / `QUICKSTART.md` (if user-facing)
- [ ] Updated `CLAUDE.md` / `AGENTS.md` (if architecture or conventions change)

## Related Issues

## References
- [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)