### PR TITLE
fix: use repo-relative paths in codacy.config.json

### DIFF
--- a/.codacy/codacy.config.json
+++ b/.codacy/codacy.config.json
@@ -172,7 +172,7 @@
     },
     {
       "toolId": "shellcheck",
-      "localConfigurationFile": "F:\\source\\juggernaut\\.shellcheckrc",
+      "localConfigurationFile": ".shellcheckrc",
       "patterns": [
         {
           "patternId": "shellcheck_SC2326"
@@ -4350,7 +4350,7 @@
     },
     {
       "toolId": "markdownlint",
-      "localConfigurationFile": "F:\\source\\juggernaut\\.markdownlint.json",
+      "localConfigurationFile": ".markdownlint.json",
       "useLocalConfigurationFile": true,
       "patterns": []
     },


### PR DESCRIPTION
## Summary

Fix absolute Windows paths in `codacy.config.json` that were captured by `analysis-cli init --remote`.

### Problem

The `localConfigurationFile` paths for shellcheck and markdownlint were saved as absolute Windows paths (`F:\source\juggernaut\...`) — these only work on the machine where the config was generated. On Codacy Cloud or any other checkout, these paths don't resolve, so the tools run without their intended config files.

### Fix

Replace absolute paths with repo-relative ones:
- `F:\source\juggernaut\.shellcheckrc` → `.shellcheckrc`
- `F:\source\juggernaut\.markdownlint.json` → `.markdownlint.json`

### Context

Follows up on [#312](https://github.com/jpvelasco/juggernaut/pull/312) which migrated to the new analysis-cli config format. Addresses [this review comment](https://github.com/jpvelasco/juggernaut/pull/312#discussion_r3620843190).