### PR TITLE
refactor: deduplicate cmd package — shared helpers and unified patterns

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -57,10 +57,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		r.Check("bedrock-config.json", doctor.OK, "loaded (v"+bCfg.Version+")")
 	}
 
-	scopes := []string{"user", "project"}
-	if doctorFlags.scope != "" {
-		scopes = []string{doctorFlags.scope}
-	}
+	scopes := resolvedScopes(doctorFlags.scope)
 	// Grok is always user-scoped (ConfigPath ignores scope).
 	if cliName == "grok" {
 		if doctorFlags.scope == "project" {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -106,9 +106,10 @@ const credentialEchoMode huh.EchoMode = huh.EchoMode(textinput.EchoNone)
 
 // ---- Shared config helpers ----
 
-// readProviderConfig reads a provider's config file for the given scope.
-// Returns (nil, nil) when the file does not exist.
-func readProviderConfig(prov provider.Provider, home, scope string) (map[string]any, error) {
+// newProviderManager resolves the config path and format for a provider and
+// returns a ready-to-use Manager. Both read and write paths use this so the
+// ConfigPath → FormatByName → NewManagerWithFormat sequence lives in one place.
+func newProviderManager(prov provider.Provider, home, scope string) (*config.Manager, error) {
 	path, err := prov.ConfigPath(home, scope)
 	if err != nil {
 		return nil, err
@@ -117,12 +118,17 @@ func readProviderConfig(prov provider.Provider, home, scope string) (map[string]
 	if err != nil {
 		return nil, err
 	}
-	mgr := config.NewManagerWithFormat(path, format)
-	data, err := mgr.Read()
+	return config.NewManagerWithFormat(path, format), nil
+}
+
+// readProviderConfig reads a provider's config file for the given scope.
+// Returns (nil, nil) when the file does not exist.
+func readProviderConfig(prov provider.Provider, home, scope string) (map[string]any, error) {
+	mgr, err := newProviderManager(prov, home, scope)
 	if err != nil {
 		return nil, err
 	}
-	return data, nil
+	return mgr.Read()
 }
 
 // resolvedScopes returns the scopes to operate on, respecting an optional
@@ -418,11 +424,10 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 		}
 	}
 
-	format, err := config.FormatByName(prov.ConfigFormatName())
+	mgr, err := newProviderManager(prov, home, applyFlags.scope)
 	if err != nil {
 		return err
 	}
-	mgr := config.NewManagerWithFormat(path, format)
 	if err := mgr.MergeConfigPlanDeep(plan.Keys, prov.DeepMergeKeys()); err != nil {
 		return err
 	}

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -107,20 +107,31 @@ func runModelsCheck(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-// tierPin returns the currently pinned model ID for tier from cfg.
-func tierPin(cfg *bedrock.Config, tier discovery.Tier) string {
+// tierModelPtr returns a pointer to the model string field for the given tier,
+// or nil if the tier is unknown. Used by both tierPin (read) and
+// applyModelWrites (write) so the tier↔field mapping lives in one place.
+func tierModelPtr(m *bedrock.ModelSet, tier discovery.Tier) *string {
 	switch tier {
 	case discovery.TierOpus:
-		return cfg.Models.Opus
+		return &m.Opus
 	case discovery.TierSonnet:
-		return cfg.Models.Sonnet
+		return &m.Sonnet
 	case discovery.TierHaiku:
-		return cfg.Models.Haiku
+		return &m.Haiku
 	case discovery.TierFable:
-		return cfg.Models.Fable
+		return &m.Fable
 	default:
+		return nil
+	}
+}
+
+// tierPin returns the currently pinned model ID for tier from cfg.
+func tierPin(cfg *bedrock.Config, tier discovery.Tier) string {
+	p := tierModelPtr(&cfg.Models, tier)
+	if p == nil {
 		return ""
 	}
+	return *p
 }
 
 // buildModelsReport is a pure function (no I/O) so it's directly unit
@@ -282,15 +293,8 @@ func applyModelWrites(cfg *bedrock.Config, sets map[discovery.Tier]string, anthr
 	}
 
 	for tier, id := range sets {
-		switch tier {
-		case discovery.TierOpus:
-			cfg.Models.Opus = id
-		case discovery.TierSonnet:
-			cfg.Models.Sonnet = id
-		case discovery.TierHaiku:
-			cfg.Models.Haiku = id
-		case discovery.TierFable:
-			cfg.Models.Fable = id
+		if p := tierModelPtr(&cfg.Models, tier); p != nil {
+			*p = id
 		}
 	}
 	return nil

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -31,10 +31,7 @@ func runShow(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	scopes := []string{"user", "project"}
-	if showFlags.scope != "" {
-		scopes = []string{showFlags.scope}
-	}
+	scopes := resolvedScopes(showFlags.scope)
 
 	results := map[string]any{}
 	for _, scope := range scopes {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
-	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/spf13/cobra"
@@ -100,17 +99,11 @@ func uninstallSettingsBlocks(home string, prov provider.Provider) {
 }
 
 func uninstallSettingsBlock(home, scope string, prov provider.Provider) {
-	path, err := prov.ConfigPath(home, scope)
+	mgr, err := newProviderManager(prov, home, scope)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: invalid %s config path: %v\n", scope, err)
+		fmt.Fprintf(os.Stderr, "Warning: %s config: %v\n", scope, err)
 		return
 	}
-	format, err := config.FormatByName(prov.ConfigFormatName())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-		return
-	}
-	mgr := config.NewManagerWithFormat(path, format)
 	has, err := mgr.HasManagedKeys(prov.NativeManagedKeys())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not check %s scope: %v\n", scope, err)


### PR DESCRIPTION
## Summary

Eliminate structural duplication across the `cmd/` package by extracting shared helpers and consolidating mirrored logic.

## Changes

### 1. `newProviderManager()` — central config manager creation

The `ConfigPath` → `FormatByName` → `NewManagerWithFormat` sequence was repeated in `readProviderConfig`, `uninstallSettingsBlock`, and `commitApply`. Extracted to a single helper so the three-step setup lives in one place. Both read and write paths now use it.

### 2. `resolvedScopes()` — eliminate inline scope resolution

`doctor.go` and `show.go` had their own copy of the scope-filter pattern already implemented by `resolvedScopes()` in `helpers.go`. Replaced inline code with the existing helper.

### 3. `tierModelPtr()` — unify tier↔model mapping

`tierPin()` (read) and `applyModelWrites()` (write) had mirror switch statements mapping `discovery.Tier` to `cfg.Models.X`. Consolidated into a single pointer helper used by both.

## Verification

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all 12 packages pass
- `git diff --check` — no whitespace issues
- Net change: -4 lines (36 added, 40 removed across 5 files)

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No unrelated changes in the diff
- [x] No new dependencies added
- [x] No behavioral changes — pure refactor