### PR TITLE
refactor: deduplicate activation and provider packages

### DIFF
--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -493,7 +493,7 @@ func uninstallCLIBlocks(home string, opts UninstallOptions) ([]string, error) {
 
 	seen := map[string]bool{}
 	for _, target := range targets {
-		key := profilePathKey(target.Path)
+		key := pathKey(target.Path)
 		if seen[key] {
 			continue
 		}
@@ -657,38 +657,44 @@ func HasBlockWithMarkers(content, begin, end string) bool {
 	return strings.Contains(content, begin) && strings.Contains(content, end)
 }
 
+// HasLegacyBlock reports whether content contains both begin and end markers.
+func HasLegacyBlock(content, begin, end string) bool {
+	return strings.Contains(content, begin) && strings.Contains(content, end)
+}
+
 // HasLegacyLauncherBlock reports whether content contains a legacy
 // "# BEGIN: Juggernaut Launcher" block.
 func HasLegacyLauncherBlock(content string) bool {
-	return strings.Contains(content, LegacyLauncherBegin) && strings.Contains(content, LegacyLauncherEnd)
+	return HasLegacyBlock(content, LegacyLauncherBegin, LegacyLauncherEnd)
 }
 
 // HasLegacyBedrockBlock reports whether content contains a legacy
 // "# BEGIN: Claude Code Bedrock Configuration" block.
 func HasLegacyBedrockBlock(content string) bool {
-	return strings.Contains(content, LegacyBedrockBegin) && strings.Contains(content, LegacyBedrockEnd)
+	return HasLegacyBlock(content, LegacyBedrockBegin, LegacyBedrockEnd)
+}
+
+// removeLegacyBlock removes a legacy block from content. It only removes the
+// block if both the begin and end markers are present; an orphaned begin marker
+// is left untouched.
+func removeLegacyBlock(content, begin, end string) (string, bool) {
+	content = normalizeNewlines(content)
+	if !strings.Contains(content, end) {
+		return content, false
+	}
+	return removeBlockWithMarkers(content, begin, end)
 }
 
 // removeLegacyLauncherBlock removes a legacy "# BEGIN: Juggernaut Launcher"
-// block from content. It only removes the block if both the begin and end
-// markers are present; an orphaned begin marker is left untouched.
+// block from content.
 func removeLegacyLauncherBlock(content string) (string, bool) {
-	content = normalizeNewlines(content)
-	if !strings.Contains(content, LegacyLauncherEnd) {
-		return content, false
-	}
-	return removeBlockWithMarkers(content, LegacyLauncherBegin, LegacyLauncherEnd)
+	return removeLegacyBlock(content, LegacyLauncherBegin, LegacyLauncherEnd)
 }
 
 // removeLegacyBedrockBlock removes a legacy "# BEGIN: Claude Code Bedrock
-// Configuration" block from content. It only removes the block if both the
-// begin and end markers are present; an orphaned begin marker is left untouched.
+// Configuration" block from content.
 func removeLegacyBedrockBlock(content string) (string, bool) {
-	content = normalizeNewlines(content)
-	if !strings.Contains(content, LegacyBedrockEnd) {
-		return content, false
-	}
-	return removeBlockWithMarkers(content, LegacyBedrockBegin, LegacyBedrockEnd)
+	return removeLegacyBlock(content, LegacyBedrockBegin, LegacyBedrockEnd)
 }
 
 // removeBlockWithMarkers removes blocks delimited by begin and end markers.
@@ -982,7 +988,7 @@ func installPowerShellActivationForSpec(home string, psResult *ProfileResolverRe
 	// can override or retain a stale duplicate of the global activation).
 	installSet := map[string]bool{}
 	for _, target := range result.InstallTargets {
-		installSet[profilePathKey(target.Path)] = true
+		installSet[pathKey(target.Path)] = true
 		changed, err := InstallTargetFor(target, spec)
 		if err != nil {
 			return installed, err
@@ -1003,7 +1009,7 @@ func installPowerShellActivationForSpec(home string, psResult *ProfileResolverRe
 	stalePaths = append(stalePaths, result.MigrationTargets...)
 	seenStale := map[string]bool{}
 	for _, path := range stalePaths {
-		key := profilePathKey(path)
+		key := pathKey(path)
 		if installSet[key] || seenStale[key] {
 			continue
 		}
@@ -1018,13 +1024,6 @@ func installPowerShellActivationForSpec(home string, psResult *ProfileResolverRe
 	}
 
 	return installed, nil
-}
-
-// profilePathKey normalizes a profile path for set membership. Delegates to
-// pathKey so InstallTargets and MigrationTargets that differ only by casing
-// still match.
-func profilePathKey(path string) string {
-	return pathKey(path)
 }
 
 // UninstallPowerShellActivation removes activation blocks from all discovered

--- a/internal/activation/coverage_gaps_test.go
+++ b/internal/activation/coverage_gaps_test.go
@@ -149,15 +149,15 @@ func TestUninstallWith_RemoveTargetWithLegacyError(t *testing.T) {
 	}
 }
 
-func TestProfilePathKey_Clean(t *testing.T) {
+func TestPathKey_Clean(t *testing.T) {
 	// Smoke: key is stable under Clean; on Windows casing folds.
-	a := profilePathKey(filepath.Join("C:", "Users", "X", "a.ps1"))
-	b := profilePathKey(filepath.Join("C:", "Users", "X", "a.ps1"))
+	a := pathKey(filepath.Join("C:", "Users", "X", "a.ps1"))
+	b := pathKey(filepath.Join("C:", "Users", "X", "a.ps1"))
 	if a != b {
 		t.Fatalf("keys differ: %q vs %q", a, b)
 	}
 	if runtime.GOOS == "windows" {
-		upper := profilePathKey(filepath.Join("C:", "USERS", "X", "A.PS1"))
+		upper := pathKey(filepath.Join("C:", "USERS", "X", "A.PS1"))
 		if upper != strings.ToLower(upper) {
 			t.Fatalf("windows key should be lowercased: %q", upper)
 		}

--- a/internal/activation/coverage_gaps_wrappers_test.go
+++ b/internal/activation/coverage_gaps_wrappers_test.go
@@ -536,10 +536,10 @@ func TestNonWindowsHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("profilePathKey", func(t *testing.T) {
-		got := profilePathKey("/Users/test/profile.ps1")
+	t.Run("pathKey", func(t *testing.T) {
+		got := pathKey("/Users/test/profile.ps1")
 		if got != "/Users/test/profile.ps1" {
-			t.Errorf("profilePathKey = %q, want /Users/test/profile.ps1", got)
+			t.Errorf("pathKey = %q, want /Users/test/profile.ps1", got)
 		}
 	})
 

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -177,10 +177,8 @@ func (c codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error
 	if regionMsg != "" {
 		warnings = append(warnings, fmt.Sprintf("%s: %s", m.ModelID, regionMsg))
 	}
-	if hasMantleCatalog, selectedAvailable := catalogSelectionState(opts.ModelCatalog, m.ModelID, c, opts.RefreshedSources); hasMantleCatalog && !selectedAvailable {
-		warnings = append(warnings, fmt.Sprintf(
-			"model %q was not returned as ACTIVE and available by Mantle in %s; refresh the catalog or select a listed model",
-			m.ModelID, region))
+	if w := catalogUnavailableWarning(opts.ModelCatalog, m.ModelID, region, "refresh the catalog or select a listed model", c, opts.RefreshedSources); w != "" {
+		warnings = append(warnings, w)
 	}
 	return ConfigPlan{
 		Keys:        keys,

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -146,10 +146,8 @@ func (g grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error)
 	if regionMsg != "" {
 		warnings = append(warnings, modelID+" "+regionMsg)
 	}
-	if hasMantleCatalog, selectedAvailable := catalogSelectionState(opts.ModelCatalog, modelID, g, opts.RefreshedSources); hasMantleCatalog && !selectedAvailable {
-		warnings = append(warnings, fmt.Sprintf(
-			"model %q was not returned as ACTIVE and available by Mantle in %s; refresh the catalog or select a listed model",
-			modelID, region))
+	if w := catalogUnavailableWarning(opts.ModelCatalog, modelID, region, "refresh the catalog or select a listed model", g, opts.RefreshedSources); w != "" {
+		warnings = append(warnings, w)
 	}
 	return ConfigPlan{
 		Keys:        keys,

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -118,10 +118,8 @@ func (o opencode) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, er
 			models[discovered.ID] = map[string]any{"name": discovered.ID}
 		}
 	}
-	if hasMantleCatalog, selectedAvailable := catalogSelectionState(opts.ModelCatalog, modelID, o, opts.RefreshedSources); hasMantleCatalog && !selectedAvailable {
-		warnings = append(warnings, fmt.Sprintf(
-			"model %q was not returned as ACTIVE and available by Mantle in %s; it remains configured for explicit use",
-			modelID, opts.Region))
+	if w := catalogUnavailableWarning(opts.ModelCatalog, modelID, opts.Region, "it remains configured for explicit use", o, opts.RefreshedSources); w != "" {
+		warnings = append(warnings, w)
 	}
 
 	baseURL := fmt.Sprintf("https://bedrock-mantle.%s.api.aws/v1", opts.Region)

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -116,6 +116,20 @@ func catalogSelectionState(models []CatalogModel, selectedID string, p CatalogPr
 	return hasRelevantSource, selectedAvailable
 }
 
+// catalogUnavailableWarning returns a warning message when the provider's
+// catalog is present but the selected model was not returned as available.
+// The suffix parameter allows providers to customize the action text.
+// Returns an empty string when the catalog is absent or the model is available.
+func catalogUnavailableWarning(models []CatalogModel, selectedID, region, suffix string, p CatalogProvider, refreshedSources []string) string {
+	hasRelevant, selectedAvailable := catalogSelectionState(models, selectedID, p, refreshedSources)
+	if !hasRelevant || selectedAvailable {
+		return ""
+	}
+	return fmt.Sprintf(
+		"model %q was not returned as ACTIVE and available by Mantle in %s; %s",
+		selectedID, region, suffix)
+}
+
 // Capability identifies an optional feature a Provider may support, so cmd/ can
 // gate CLI-specific flags without hardcoding per-CLI knowledge.
 type Capability int

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -141,11 +141,11 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	if fable == "" {
 		fable = cfg.Models.Fable
 	}
-	fallbackModels, err := normalizeFallbackModels(opts.FallbackModels)
+	fallbackModels, err := normalizeModelList(opts.FallbackModels, "fallback model chain")
 	if err != nil {
 		return nil, err
 	}
-	availableModels, err := normalizeAvailableModels(opts.AvailableModels)
+	availableModels, err := normalizeModelList(opts.AvailableModels, "available models list")
 	if err != nil {
 		return nil, err
 	}
@@ -423,32 +423,15 @@ func persistedEffortLevel(effort string) string {
 	return effort
 }
 
-func normalizeFallbackModels(models []string) ([]string, error) {
+func normalizeModelList(models []string, context string) ([]string, error) {
 	if len(models) == 0 {
 		return nil, nil
 	}
-
 	out := make([]string, 0, len(models))
 	for _, model := range models {
 		trimmed := strings.TrimSpace(model)
 		if trimmed == "" {
-			return nil, fmt.Errorf("fallback model chain contains an empty model ID")
-		}
-		out = append(out, trimmed)
-	}
-	return out, nil
-}
-
-func normalizeAvailableModels(models []string) ([]string, error) {
-	if len(models) == 0 {
-		return nil, nil
-	}
-
-	out := make([]string, 0, len(models))
-	for _, model := range models {
-		trimmed := strings.TrimSpace(model)
-		if trimmed == "" {
-			return nil, fmt.Errorf("available models list contains an empty model ID")
+			return nil, fmt.Errorf("%s contains an empty model ID", context)
 		}
 		out = append(out, trimmed)
 	}


### PR DESCRIPTION
## Summary

Continue structural deduplication across `internal/` packages — following up on PR #314 which cleaned up `cmd/`.

## Changes

### 1. `normalizeModelList` — merge model normalization helpers

`normalizeFallbackModels` and `normalizeAvailableModels` in `internal/schema/` were identical except for their error messages. Consolidated into `normalizeModelList(models, context)` where `context` is the label for error messages.

### 2. `removeLegacyBlock` and `HasLegacyBlock` — generic legacy marker helpers

`removeLegacyLauncherBlock` and `removeLegacyBedrockBlock` in `internal/activation/` shared the same 3-step pattern (normalize, check end marker, remove). Extracted `removeLegacyBlock(content, begin, end)` and `HasLegacyBlock(content, begin, end)` as shared helpers. The specific wrappers remain for existing callers.

### 3. `catalogUnavailableWarning` — centralize catalog warning

Three `BuildConfig` implementations (`codex`, `grok`, `opencode`) each had their own `catalogSelectionState` + `fmt.Sprintf` for the "model not available" warning. Consolidated into a single `catalogUnavailableWarning` helper in `plan.go` with a customizable suffix parameter.

### 4. `profilePathKey` removal

`profilePathKey` was a one-line wrapper around `pathKey`. Replaced 3 internal call sites with direct `pathKey` calls and removed the wrapper. Updated tests accordingly.

## Verification

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all 12 packages pass
- `git diff --check` — no whitespace issues
- Net change: -10 lines (55 added, 65 removed across 8 files)

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No unrelated changes in the diff
- [x] No new dependencies added
- [x] No behavioral changes — pure refactor