### PR TITLE
refactor: deduplicate toMap — single shared provider.ToMap

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -70,13 +70,9 @@ func settingsPath(homeDir, scope string) (string, error) {
 	return safepath.JoinUnder(homeDir, ".claude", "settings.json")
 }
 
+// toMap delegates to the single shared implementation in internal/provider.
 func toMap(v any) (map[string]any, error) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return nil, fmt.Errorf("serializing block: %w", err)
-	}
-	var m map[string]any
-	return m, json.Unmarshal(b, &m)
+	return provider.ToMap(v)
 }
 
 // fromMap is the reverse of toMap: it JSON round-trips a generic map into the

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -91,7 +91,7 @@ func (c claude) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, erro
 	}
 	native := block.NativeKeys()
 
-	blockMap, err := toMapViaJSON(block)
+	blockMap, err := ToMap(block)
 	if err != nil {
 		return ConfigPlan{}, err
 	}

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -167,7 +167,7 @@ func (c codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error
 			AppliedAt:     fmt.Sprintf("%d", time.Now().Unix()),
 		},
 	}
-	blockMap, err := toMapViaJSON(juggernautBlock)
+	blockMap, err := ToMap(juggernautBlock)
 	if err != nil {
 		return ConfigPlan{}, fmt.Errorf("serialize juggernaut block: %w", err)
 	}

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 )
 
-// toMapViaJSON serializes a struct to a generic map via JSON round-trip (mirrors
-// cmd.toMap), so a typed block becomes ConfigPlan.Keys content.
-func toMapViaJSON(v any) (map[string]any, error) {
+// ToMap serializes any value to a generic map via JSON round-trip.
+// Used by providers to turn typed structs into ConfigPlan.Keys content.
+// cmd/helpers.go delegates to this function — there should be only one
+// implementation across the project.
+func ToMap(v any) (map[string]any, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return nil, fmt.Errorf("serializing block: %w", err)

--- a/internal/provider/plan_coverage_test.go
+++ b/internal/provider/plan_coverage_test.go
@@ -5,23 +5,23 @@ import (
 	"testing"
 )
 
-func TestToMapViaJSON_MarshalError(t *testing.T) {
+func TestToMap_MarshalError(t *testing.T) {
 	// Channel values cannot be marshaled to JSON, exercising the marshal error path.
 	ch := make(chan int)
-	_, err := toMapViaJSON(ch)
+	_, err := ToMap(ch)
 	if err == nil || !strings.Contains(err.Error(), "serializing block") {
 		t.Fatalf("expected marshal error, got %v", err)
 	}
 }
 
-func TestToMapViaJSON_Success(t *testing.T) {
+func TestToMap_Success(t *testing.T) {
 	type block struct {
 		Model  string `json:"model"`
 		Region string `json:"region"`
 	}
-	got, err := toMapViaJSON(block{Model: "sonnet", Region: "us-west-2"})
+	got, err := ToMap(block{Model: "sonnet", Region: "us-west-2"})
 	if err != nil {
-		t.Fatalf("toMapViaJSON: %v", err)
+		t.Fatalf("ToMap: %v", err)
 	}
 	if got["model"] != "sonnet" || got["region"] != "us-west-2" {
 		t.Fatalf("unexpected map: %+v", got)


### PR DESCRIPTION
Eliminates byte-identical toMap / toMapViaJSON duplication across cmd/ and internal/provider/. Exported provider.ToMap; cmd/helpers.go delegates to it. Zero behavioral change.