### PR TITLE
refactor: deduplicate model list validation into schema.ValidateModelList

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -237,8 +237,8 @@ func runApply(_ *cobra.Command, _ []string) error {
 	return commitApply(home, authMode, token, block, prov, bCfg, provOpts)
 }
 
-// parseCommaSeparatedModels splits a comma-separated model ID string, rejecting
-// empty entries. Returns nil for an empty/whitespace-only input.
+// parseCommaSeparatedModels splits a comma-separated model ID string, then
+// delegates validation to schema.ValidateModelList. Returns nil for empty input.
 func parseCommaSeparatedModels(raw string, flagName string) ([]string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -248,11 +248,7 @@ func parseCommaSeparatedModels(raw string, flagName string) ([]string, error) {
 	parts := strings.Split(trimmed, ",")
 	models := make([]string, 0, len(parts))
 	for _, part := range parts {
-		model := strings.TrimSpace(part)
-		if model == "" {
-			return nil, fmt.Errorf("%s contains an empty model ID", flagName)
-		}
-		models = append(models, model)
+		models = append(models, strings.TrimSpace(part))
 	}
-	return models, nil
+	return schema.ValidateModelList(models, flagName)
 }

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -141,11 +141,11 @@ func Build(cfg *bedrock.Config, opts Options) (*Block, error) {
 	if fable == "" {
 		fable = cfg.Models.Fable
 	}
-	fallbackModels, err := normalizeModelList(opts.FallbackModels, "fallback model chain")
+	fallbackModels, err := ValidateModelList(opts.FallbackModels, "fallback model chain")
 	if err != nil {
 		return nil, err
 	}
-	availableModels, err := normalizeModelList(opts.AvailableModels, "available models list")
+	availableModels, err := ValidateModelList(opts.AvailableModels, "available models list")
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,10 @@ func persistedEffortLevel(effort string) string {
 	return effort
 }
 
-func normalizeModelList(models []string, context string) ([]string, error) {
+// ValidateModelList trims and validates a list of model IDs, rejecting empty
+// entries. Returns nil for empty input. Used by Build and cmd/apply — there
+// should be only one implementation across the project.
+func ValidateModelList(models []string, context string) ([]string, error) {
 	if len(models) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
Consolidate model list validation: rename unexported `normalizeModelList` to exported `schema.ValidateModelList`, and update `cmd/apply.go`'s `parseCommaSeparatedModels` to split the comma string then delegate validation to the shared function.