### PR TITLE
refactor: extract warnf helper for stderr warnings

### DIFF
--- a/cmd/apply_windows.go
+++ b/cmd/apply_windows.go
@@ -3,9 +3,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
 	xwindows "github.com/charmbracelet/x/windows"
 	"golang.org/x/sys/windows"
 )
@@ -19,6 +16,6 @@ func flushConsoleInput() {
 		return
 	}
 	if err := xwindows.FlushConsoleInputBuffer(conin); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not flush console input buffer: %v\n", err)
+		warnf("could not flush console input buffer: %v", err)
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -27,6 +27,12 @@ func SetEmbeddedConfig(data []byte) {
 	embeddedConfigBytes = data
 }
 
+// warnf prints a formatted warning to stderr. All non-error warnings in the
+// cmd package use this instead of bare fmt.Fprintf(os.Stderr, "Warning: …").
+func warnf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)
+}
+
 // loadBedrockConfig loads bedrock config, preferring the embedded bytes.
 // Falls back to filesystem for tests and development builds.
 func loadBedrockConfig() (*bedrock.Config, error) {
@@ -287,7 +293,7 @@ func resolveCredential(authMode string, home string) (string, error) {
 		if applyFlags.preserveKey {
 			return "", fmt.Errorf("reading existing key: %w", err)
 		}
-		fmt.Fprintf(os.Stderr, "Warning: could not read keychain (will prompt for key): %v\n", err)
+		warnf("could not read keychain (will prompt for key): %v", err)
 	} else if token != "" {
 		return token, nil
 	}
@@ -479,7 +485,7 @@ func installActivation(home string, prov provider.Provider) {
 		Spec: activation.CLISpec{Name: prov.Name(), Begin: begin, End: end},
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not install shell activation: %v\n", err)
+		warnf("could not install shell activation: %v", err)
 		return
 	}
 	title := providerDisplayName(prov.Name())
@@ -510,7 +516,7 @@ func reportLegacyRecovery(home string) {
 	binDir := activation.DefaultBinDir(home)
 	actions, err := activation.RecoverLegacyArtifacts(binDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not recover legacy artifacts: %v\n", err)
+		warnf("could not recover legacy artifacts: %v", err)
 		return
 	}
 	for _, a := range actions {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -162,5 +163,24 @@ func TestFileExists(t *testing.T) {
 	}
 	if fileExists(filepath.Join(dir, "absent")) {
 		t.Error("fileExists should report false for a missing file")
+	}
+}
+
+func TestWarnf_WritesToStderr(t *testing.T) {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	defer func() { os.Stderr = old; r.Close(); w.Close() }()
+
+	warnf("hello %s", "world")
+	w.Close()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	got := string(data)
+	if want := "Warning: hello world\n"; got != want {
+		t.Errorf("warnf output = %q, want %q", got, want)
 	}
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/spf13/cobra"
@@ -37,13 +36,13 @@ func runShow(_ *cobra.Command, _ []string) error {
 	for _, scope := range scopes {
 		path, perr := settingsPath(home, scope)
 		if perr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: could not determine %s scope path: %v\n", scope, perr)
+			warnf("could not determine %s scope path: %v", scope, perr)
 			continue
 		}
 		mgr := config.NewManager(path)
 		data, err := mgr.Read()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: could not read %s settings: %v\n", scope, err)
+			warnf("could not read %s settings: %v", scope, err)
 			continue
 		}
 		results[scope] = data["juggernaut"]

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -101,12 +101,12 @@ func uninstallSettingsBlocks(home string, prov provider.Provider) {
 func uninstallSettingsBlock(home, scope string, prov provider.Provider) {
 	mgr, err := newProviderManager(prov, home, scope)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: %s config: %v\n", scope, err)
+		warnf("%s config: %v", scope, err)
 		return
 	}
 	has, err := mgr.HasManagedKeys(prov.NativeManagedKeys())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not check %s scope: %v\n", scope, err)
+		warnf("could not check %s scope: %v", scope, err)
 		return
 	}
 	if !has {
@@ -117,7 +117,7 @@ func uninstallSettingsBlock(home, scope string, prov provider.Provider) {
 		return
 	}
 	if err := mgr.RemoveManagedKeysDeep(prov.NativeManagedKeys(), prov.OwnedSubKeys()); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not remove %s block: %v\n", scope, err)
+		warnf("could not remove %s block: %v", scope, err)
 		return
 	}
 	fmt.Printf("  ✓ Removed juggernaut block from %s %s config\n", scope, prov.Name())
@@ -125,7 +125,7 @@ func uninstallSettingsBlock(home, scope string, prov provider.Provider) {
 
 func removeKeychainToken(home string) {
 	if err := keychain.Default().DeleteWithFallback(home); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not remove keychain entry: %v\n", err)
+		warnf("could not remove keychain entry: %v", err)
 		return
 	}
 	fmt.Println("  ✓ Removed bearer token from keychain")
@@ -145,7 +145,7 @@ func uninstallActivationFull(home string, prov provider.Provider) {
 		Spec: activation.CLISpec{Name: prov.Name(), Begin: begin, End: end},
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not remove shell activation: %v\n", err)
+		warnf("could not remove shell activation: %v", err)
 	} else if len(removed) > 0 {
 		fmt.Printf("  ✓ Removed %s activation from %d shell profile(s)\n", title, len(removed))
 	}


### PR DESCRIPTION
Replace 11 occurrences of fmt.Fprintf(os.Stderr, Warning) across cmd/ with a single warnf helper in helpers.go. Removes unused fmt/os imports from apply_windows.go and show.go.