### PR TITLE
fix(ci): use Codecov PyPI CLI to avoid GPG key import failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,15 @@ jobs:
       # Upload per-OS coverage so Codecov merges all three legs. Much of the
       # PowerShell/launcher/keychain code is Windows-only, so a Linux-only
       # report understates true coverage; merging the OS matrix reflects it.
+      # use_pypi: true — install CLI from PyPI instead of cli.codecov.io so we
+      # skip native-binary GPG verification (fails with "Could not verify
+      # signature" when key import is empty; codecov/codecov-action#1876).
       - name: Upload coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           use_oidc: true
+          use_pypi: true
           files: ./coverage.out
           fail_ci_if_error: ${{ matrix.os != 'windows-latest' }}
 


### PR DESCRIPTION
Use the Codecov PyPI CLI package instead of the native binary downloader to avoid GPG signature verification failures on macOS and Linux runners.

## Problem

The `codecov/codecov-action` v7 native binary installer fails with `Could not verify signature` when its embedded GPG key import returns empty on GitHub runners. This affects the macOS (and sometimes Linux) coverage upload steps.

## Fix

Add `use_pypi: true` to the codecov-action configuration. This installs the CLI from PyPI via pip instead of downloading the pre-built binary, skipping the broken GPG verification step entirely.

References: codecov/codecov-action#1876