### PR TITLE
fix: warn before uninstall silently disables auto mode

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -47,6 +47,8 @@ func runUninstall(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	warnIfAutoModeWillBeLost(home, prov)
+
 	if aborted, err := confirmUninstallAborted(); aborted || err != nil {
 		return err
 	}
@@ -66,6 +68,35 @@ func runUninstall(_ *cobra.Command, _ []string) error {
 		fmt.Println("Uninstall complete.")
 	}
 	return nil
+}
+
+// warnIfAutoModeWillBeLost prints a heads-up when the config about to be
+// uninstalled has auto permission mode active. Uninstall removes the
+// juggernaut block along with permissions.defaultMode/env — nothing is left
+// for a future `apply` (without --mode=auto) to restore auto mode from, so a
+// re-apply after reinstalling silently comes back in default mode. This only
+// reads, never mutates, so it's safe to run unconditionally (including
+// --dry-run and --force). Claude-only: auto mode is a CapAutoMode feature.
+func warnIfAutoModeWillBeLost(home string, prov provider.Provider) {
+	if !prov.Supports(provider.CapAutoMode) {
+		return
+	}
+	for _, scope := range uninstallScopes() {
+		mgr, err := newProviderManager(prov, home, scope)
+		if err != nil {
+			continue
+		}
+		data, err := mgr.Read()
+		if err != nil {
+			continue
+		}
+		if effectivePermissionMode(data, "") == "auto" {
+			fmt.Println("⚠ Auto mode is currently enabled — uninstalling will disable it.")
+			fmt.Println("  After reinstalling, run `juggernaut apply --mode=auto` to re-enable it;")
+			fmt.Println("  a plain `juggernaut apply` will come back in default mode.")
+			return
+		}
+	}
 }
 
 func confirmUninstallAborted() (aborted bool, err error) {

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -183,6 +183,52 @@ func TestUninstall_EOFAborts(t *testing.T) {
 	}
 }
 
+// TestUninstall_WarnsWhenAutoModeWillBeLost reproduces the real-world
+// incident: apply --mode=auto leaves the config in auto mode, and uninstall
+// wipes that mode with nothing left for a future apply to restore it from.
+// Uninstall must warn about this before removing anything.
+func TestUninstall_WarnsWhenAutoModeWillBeLost(t *testing.T) {
+	_ = setupApplyTest(t)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--mode=auto", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Auto mode is currently enabled") {
+		t.Errorf("expected auto-mode-loss warning before uninstall, got:\n%s", out)
+	}
+}
+
+// TestUninstall_NoAutoModeWarningWhenNotAuto verifies the warning is silent
+// when permission mode was never auto — no false positives on every uninstall.
+func TestUninstall_NoAutoModeWarningWhenNotAuto(t *testing.T) {
+	_ = setupApplyTest(t)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply error: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Auto mode is currently enabled") {
+		t.Errorf("did not expect auto-mode-loss warning when mode was never auto, got:\n%s", out)
+	}
+}
+
 // TestUninstall_NothingInstalled is a clean no-op: uninstall on a fresh home
 // should succeed and still print completion without errors.
 func TestUninstall_NothingInstalled(t *testing.T) {

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -2,9 +2,21 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
+
+// autoModeCapableStub wraps stubProvider (from apply_test.go) to report
+// CapAutoMode support, so warnIfAutoModeWillBeLost's error branches — which
+// are only reached past the CapAutoMode guard — are actually exercised.
+type autoModeCapableStub struct{ stubProvider }
+
+func (autoModeCapableStub) Supports(c provider.Capability) bool { return c == provider.CapAutoMode }
 
 // TestUninstall_DryRun_PreservesBlock verifies that a dry-run reports intended
 // removals but leaves settings.json untouched and never prints completion.
@@ -228,6 +240,47 @@ func TestUninstall_NoAutoModeWarningWhenNotAuto(t *testing.T) {
 		t.Errorf("did not expect auto-mode-loss warning when mode was never auto, got:\n%s", out)
 	}
 }
+
+// TestWarnIfAutoModeWillBeLost_ManagerErrorSkipped covers the newProviderManager
+// error branch: a provider whose ConfigPath fails must be skipped (continue),
+// not treated as a crash or a false "auto mode found" positive.
+func TestWarnIfAutoModeWillBeLost_ManagerErrorSkipped(t *testing.T) {
+	home := t.TempDir()
+	prov := autoModeCapableStub{stubProvider{formatName: "json", pathErr: fmt.Errorf("bad path")}}
+
+	out := captureStdout(t, func() {
+		warnIfAutoModeWillBeLost(home, prov)
+	})
+
+	if strings.Contains(out, "Auto mode is currently enabled") {
+		t.Errorf("a ConfigPath error must not be reported as auto mode found, got:\n%s", out)
+	}
+}
+
+// TestWarnIfAutoModeWillBeLost_ReadErrorSkipped covers the mgr.Read() error
+// branch: a config path pointing at a directory (unreadable as a file) must
+// be skipped (continue), not crash or falsely report auto mode.
+func TestWarnIfAutoModeWillBeLost_ReadErrorSkipped(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "isadir")
+	if err := safepath.MkdirAll(dir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dp := dirPathProvider{stubProvider: stubProvider{formatName: "json"}, dir: dir}
+
+	out := captureStdout(t, func() {
+		warnIfAutoModeWillBeLost(home, autoModeReadErrorStub{dp})
+	})
+
+	if strings.Contains(out, "Auto mode is currently enabled") {
+		t.Errorf("a Read() error must not be reported as auto mode found, got:\n%s", out)
+	}
+}
+
+// autoModeReadErrorStub wraps dirPathProvider to report CapAutoMode support.
+type autoModeReadErrorStub struct{ dirPathProvider }
+
+func (autoModeReadErrorStub) Supports(c provider.Capability) bool { return c == provider.CapAutoMode }
 
 // TestUninstall_NothingInstalled is a clean no-op: uninstall on a fresh home
 // should succeed and still print completion without errors.


### PR DESCRIPTION
## Summary
- `uninstall` now prints a heads-up when the config it's about to remove has `permissionMode: auto` active, since removal wipes `permissions.defaultMode`/`env` and the `juggernaut` block together, leaving nothing for a future `apply` (without `--mode=auto`) to restore auto mode from.
- Root-caused from a real incident: `juggernaut uninstall` + `npm uninstall -g juggernaut-bedrock` collapsed `settings.json` down to only unmanaged keys, and the next `apply` (no `--mode` flag) correctly re-defaulted to `permissionMode=default` — silently losing auto mode with no warning it had happened.
- Read-only check (`warnIfAutoModeWillBeLost`), gated on `CapAutoMode` so it's a no-op for non-Claude providers; reuses the same `effectivePermissionMode` reconciliation `doctor.go` already uses so it also catches auto mode set via Shift+Tab (native `defaultMode`), not just Juggernaut's own meta.

## Test plan
- [x] `go test ./cmd/... -run TestUninstall -v` — all pass, including two new tests:
  - `TestUninstall_WarnsWhenAutoModeWillBeLost` — apply `--mode=auto` then uninstall; asserts the warning appears
  - `TestUninstall_NoAutoModeWarningWhenNotAuto` — plain apply then uninstall; asserts no warning (no false positives)
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` and `gofmt -l` on changed files — clean