### PR TITLE
fix: deduplicate near-identical test pairs flagged by Codacy

### DIFF
--- a/cmd/helpers_test_phases_test.go
+++ b/cmd/helpers_test_phases_test.go
@@ -1301,87 +1301,79 @@ func TestResolveApplyInputs_OwnedConfigPreservesAuthMode(t *testing.T) {
 	}
 }
 
-func TestResolveApplyInputs_OwnedConfigPreservesPermissionMode(t *testing.T) {
-	defer resetFlags()
-	resetFlags()
-	applyFlags.scope = "user"
-
-	home := setupApplyTest(t)
-
-	// Pre-write a settings.json that Juggernaut owns with permission mode in meta.
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil { //nolint:gosec // test-only temp dir
-		t.Fatalf("mkdir: %v", err)
-	}
-	ownedConfig := `{
-		"juggernaut": {
-			"auth": {"mode": "iam", "region": "us-west-2"},
-			"meta": {"managedBy": "juggernaut", "permissionMode": "acceptEdits"}
-		}
-	}`
-	if err := os.WriteFile(settingsPath, []byte(ownedConfig), 0o600); err != nil {
-		t.Fatalf("write owned config: %v", err)
-	}
-
-	bCfg, err := loadBedrockConfig()
-	if err != nil {
-		t.Skipf("no bedrock config: %v", err)
-	}
-	prov, err := provider.Get("claude")
-	if err != nil {
-		t.Fatalf("get claude provider: %v", err)
-	}
-
-	// No --mode flag set — should preserve "acceptEdits" from meta.
-	_, _, _, err = resolveApplyInputs(home, bCfg, prov)
-	if err != nil {
-		t.Fatalf("resolveApplyInputs: %v", err)
-	}
-	if applyFlags.mode != "acceptEdits" {
-		t.Errorf("applyFlags.mode = %q, want 'acceptEdits' (preserved from existing meta)", applyFlags.mode)
-	}
-}
-
-func TestResolveApplyInputs_OwnedConfigPreservesNativePermissionMode(t *testing.T) {
-	defer resetFlags()
-	resetFlags()
-	applyFlags.scope = "user"
-
-	home := setupApplyTest(t)
-
-	// Pre-write an owned config where permissionMode is set only in the native
-	// permissions.defaultMode (not in meta) — simulating Claude Code's Shift+Tab.
-	settingsPath := filepath.Join(home, ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil { //nolint:gosec // test-only temp dir
-		t.Fatalf("mkdir: %v", err)
-	}
-	ownedConfig := `{
-		"juggernaut": {
-			"auth": {"mode": "iam", "region": "us-west-2"},
-			"meta": {"managedBy": "juggernaut"}
+// TestResolveApplyInputs_OwnedConfigPreservesPermissionModeSources covers the
+// two places an owned config can carry a permission mode when --mode is
+// omitted: Juggernaut's own meta.permissionMode, and the native
+// permissions.defaultMode Claude Code's Shift+Tab writes directly. Both must
+// be preserved/adopted onto applyFlags.mode.
+func TestResolveApplyInputs_OwnedConfigPreservesPermissionModeSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		ownedJSON  string
+		wantMode   string
+		wantReason string
+	}{
+		{
+			name: "meta",
+			ownedJSON: `{
+				"juggernaut": {
+					"auth": {"mode": "iam", "region": "us-west-2"},
+					"meta": {"managedBy": "juggernaut", "permissionMode": "acceptEdits"}
+				}
+			}`,
+			wantMode:   "acceptEdits",
+			wantReason: "preserved from existing meta",
 		},
-		"permissions": {"defaultMode": "plan"}
-	}`
-	if err := os.WriteFile(settingsPath, []byte(ownedConfig), 0o600); err != nil {
-		t.Fatalf("write owned config: %v", err)
+		{
+			// permissionMode is set only in the native permissions.defaultMode
+			// (not in meta) — simulating Claude Code's Shift+Tab.
+			name: "native",
+			ownedJSON: `{
+				"juggernaut": {
+					"auth": {"mode": "iam", "region": "us-west-2"},
+					"meta": {"managedBy": "juggernaut"}
+				},
+				"permissions": {"defaultMode": "plan"}
+			}`,
+			wantMode:   "plan",
+			wantReason: "adopted from native permissions.defaultMode",
+		},
 	}
 
-	bCfg, err := loadBedrockConfig()
-	if err != nil {
-		t.Skipf("no bedrock config: %v", err)
-	}
-	prov, err := provider.Get("claude")
-	if err != nil {
-		t.Fatalf("get claude provider: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer resetFlags()
+			resetFlags()
+			applyFlags.scope = "user"
 
-	_, _, _, err = resolveApplyInputs(home, bCfg, prov)
-	if err != nil {
-		t.Fatalf("resolveApplyInputs: %v", err)
-	}
-	// resolveApplyInputs should adopt the native permissions.defaultMode.
-	if applyFlags.mode != "plan" {
-		t.Errorf("applyFlags.mode = %q, want 'plan' (adopted from native permissions.defaultMode)", applyFlags.mode)
+			home := setupApplyTest(t)
+
+			settingsPath := filepath.Join(home, ".claude", "settings.json")
+			if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil { //nolint:gosec // test-only temp dir
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(settingsPath, []byte(tt.ownedJSON), 0o600); err != nil {
+				t.Fatalf("write owned config: %v", err)
+			}
+
+			bCfg, err := loadBedrockConfig()
+			if err != nil {
+				t.Skipf("no bedrock config: %v", err)
+			}
+			prov, err := provider.Get("claude")
+			if err != nil {
+				t.Fatalf("get claude provider: %v", err)
+			}
+
+			// No --mode flag set.
+			_, _, _, err = resolveApplyInputs(home, bCfg, prov)
+			if err != nil {
+				t.Fatalf("resolveApplyInputs: %v", err)
+			}
+			if applyFlags.mode != tt.wantMode {
+				t.Errorf("applyFlags.mode = %q, want %q (%s)", applyFlags.mode, tt.wantMode, tt.wantReason)
+			}
+		})
 	}
 }
 

--- a/cmd/model_catalog_coverage_test.go
+++ b/cmd/model_catalog_coverage_test.go
@@ -278,130 +278,100 @@ func TestCatalogProviderModels_MapsAllFields(t *testing.T) {
 	}
 }
 
-func TestModelsList_WithGroKProvider(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
-	models := []discovery.DiscoveredModel{
-		{ID: "xai.grok-4.3", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
-		{ID: "moonshotai.kimi-k2.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
-	}
-	if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
-		[]discovery.Source{discovery.SourceMantle}, models, when); err != nil {
-		t.Fatal(err)
-	}
-
-	origFlags := modelsListFlags
-	origScope := catalogCredentialScope
-	t.Cleanup(func() {
-		modelsListFlags = origFlags
-		catalogCredentialScope = origScope
-	})
-	modelsListFlags.region = "us-west-2"
-	modelsListFlags.source = "mantle"
-	modelsListFlags.cli = "grok"
-	modelsListFlags.refresh = false
-	modelsListFlags.showUnsupported = false
-	catalogCredentialScope = func(string) (string, error) { return "scope", nil }
-
-	var output bytes.Buffer
-	command := &cobra.Command{}
-	command.SetOut(&output)
-	if err := runModelsList(command, nil); err != nil {
-		t.Fatal(err)
-	}
-	got := output.String()
-	if !strings.Contains(got, "xai.grok-4.3") {
-		t.Fatalf("grok list missing supported model:\n%s", got)
-	}
-	if strings.Contains(got, "moonshotai.kimi-k2.5") {
-		t.Fatalf("grok list should not include kimi without show-unsupported:\n%s", got)
-	}
-}
-
-func TestModelsList_WithCodexProvider(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
-	models := []discovery.DiscoveredModel{
-		{ID: "openai.gpt-5.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
-		{ID: "xai.grok-4.3", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
-	}
-	if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
-		[]discovery.Source{discovery.SourceMantle}, models, when); err != nil {
-		t.Fatal(err)
-	}
-
-	origFlags := modelsListFlags
-	origScope := catalogCredentialScope
-	t.Cleanup(func() {
-		modelsListFlags = origFlags
-		catalogCredentialScope = origScope
-	})
-	modelsListFlags.region = "us-west-2"
-	modelsListFlags.source = "mantle"
-	modelsListFlags.cli = "codex"
-	modelsListFlags.refresh = false
-	modelsListFlags.showUnsupported = false
-	catalogCredentialScope = func(string) (string, error) { return "scope", nil }
-
-	var output bytes.Buffer
-	command := &cobra.Command{}
-	command.SetOut(&output)
-	if err := runModelsList(command, nil); err != nil {
-		t.Fatal(err)
-	}
-	got := output.String()
-	if !strings.Contains(got, "openai.gpt-5.5") {
-		t.Fatalf("codex list missing supported model:\n%s", got)
-	}
-	if strings.Contains(got, "xai.grok-4.3") {
-		t.Fatalf("codex list should not include grok without show-unsupported:\n%s", got)
-	}
-}
-
-func TestModelsList_WithClaudeProvider(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
-	models := []discovery.DiscoveredModel{
-		{ID: "anthropic.claude-opus-4-8", Source: discovery.SourceFoundation, Status: "ACTIVE", Availability: "AVAILABLE"},
-		{ID: "global.anthropic.claude-sonnet-4-6", Source: discovery.SourceProfile, Status: "ACTIVE", Availability: "AVAILABLE"},
-		{ID: "openai.gpt-5.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
-	}
-	if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
-		[]discovery.Source{discovery.SourceFoundation, discovery.SourceProfile, discovery.SourceMantle},
-		models, when); err != nil {
-		t.Fatal(err)
+// TestModelsList_FiltersByProvider covers models list for grok, codex, and
+// claude: each provider's compatible models must appear in its list output,
+// while models exclusive to other protocols stay hidden without
+// --show-unsupported.
+func TestModelsList_FiltersByProvider(t *testing.T) {
+	tests := []struct {
+		name          string
+		source        string
+		cli           string
+		cachedSources []discovery.Source
+		models        []discovery.DiscoveredModel
+		wantPresent   []string
+		wantAbsent    []string
+	}{
+		{
+			name:          "grok",
+			source:        "mantle",
+			cli:           "grok",
+			cachedSources: []discovery.Source{discovery.SourceMantle},
+			models: []discovery.DiscoveredModel{
+				{ID: "xai.grok-4.3", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
+				{ID: "moonshotai.kimi-k2.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
+			},
+			wantPresent: []string{"xai.grok-4.3"},
+			wantAbsent:  []string{"moonshotai.kimi-k2.5"},
+		},
+		{
+			name:          "codex",
+			source:        "mantle",
+			cli:           "codex",
+			cachedSources: []discovery.Source{discovery.SourceMantle},
+			models: []discovery.DiscoveredModel{
+				{ID: "openai.gpt-5.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
+				{ID: "xai.grok-4.3", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
+			},
+			wantPresent: []string{"openai.gpt-5.5"},
+			wantAbsent:  []string{"xai.grok-4.3"},
+		},
+		{
+			name:          "claude",
+			source:        "native",
+			cli:           "claude",
+			cachedSources: []discovery.Source{discovery.SourceFoundation, discovery.SourceProfile, discovery.SourceMantle},
+			models: []discovery.DiscoveredModel{
+				{ID: "anthropic.claude-opus-4-8", Source: discovery.SourceFoundation, Status: "ACTIVE", Availability: "AVAILABLE"},
+				{ID: "global.anthropic.claude-sonnet-4-6", Source: discovery.SourceProfile, Status: "ACTIVE", Availability: "AVAILABLE"},
+				{ID: "openai.gpt-5.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
+			},
+			wantPresent: []string{"anthropic.claude-opus-4-8", "global.anthropic.claude-sonnet-4-6"},
+			wantAbsent:  []string{"openai.gpt-5.5"},
+		},
 	}
 
-	origFlags := modelsListFlags
-	origScope := catalogCredentialScope
-	t.Cleanup(func() {
-		modelsListFlags = origFlags
-		catalogCredentialScope = origScope
-	})
-	modelsListFlags.region = "us-west-2"
-	modelsListFlags.source = "native"
-	modelsListFlags.cli = "claude"
-	modelsListFlags.refresh = false
-	modelsListFlags.showUnsupported = false
-	catalogCredentialScope = func(string) (string, error) { return "scope", nil }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+			if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
+				tt.cachedSources, tt.models, when); err != nil {
+				t.Fatal(err)
+			}
 
-	var output bytes.Buffer
-	command := &cobra.Command{}
-	command.SetOut(&output)
-	if err := runModelsList(command, nil); err != nil {
-		t.Fatal(err)
-	}
-	got := output.String()
-	for _, id := range []string{"anthropic.claude-opus-4-8", "global.anthropic.claude-sonnet-4-6"} {
-		if !strings.Contains(got, id) {
-			t.Errorf("claude list missing model %q:\n%s", id, got)
-		}
-	}
-	if strings.Contains(got, "openai.gpt-5.5") {
-		t.Fatalf("claude native list should not include Mantle model:\n%s", got)
+			origFlags := modelsListFlags
+			origScope := catalogCredentialScope
+			t.Cleanup(func() {
+				modelsListFlags = origFlags
+				catalogCredentialScope = origScope
+			})
+			modelsListFlags.region = "us-west-2"
+			modelsListFlags.source = tt.source
+			modelsListFlags.cli = tt.cli
+			modelsListFlags.refresh = false
+			modelsListFlags.showUnsupported = false
+			catalogCredentialScope = func(string) (string, error) { return "scope", nil }
+
+			var output bytes.Buffer
+			command := &cobra.Command{}
+			command.SetOut(&output)
+			if err := runModelsList(command, nil); err != nil {
+				t.Fatal(err)
+			}
+			got := output.String()
+			for _, id := range tt.wantPresent {
+				if !strings.Contains(got, id) {
+					t.Errorf("%s list missing model %q:\n%s", tt.cli, id, got)
+				}
+			}
+			for _, id := range tt.wantAbsent {
+				if strings.Contains(got, id) {
+					t.Errorf("%s list should not include %q without show-unsupported:\n%s", tt.cli, id, got)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -120,78 +120,56 @@ func TestUninstall_ConfirmYes(t *testing.T) {
 	}
 }
 
-// TestUninstall_ConfirmAbort exercises the prompt being declined (anything but y).
-func TestUninstall_ConfirmAbort(t *testing.T) {
-	home := setupApplyTest(t)
-
-	if err := ExecuteArgs([]string{
-		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
-	}); err != nil {
-		t.Fatalf("apply error: %v", err)
+// TestUninstall_AbortPaths covers the two ways the confirmation prompt can
+// decline: an explicit "n" and a closed stdin (EOF on the first Scan, e.g.
+// Ctrl+D or a closed pipe). Both must abort without completing and preserve
+// the juggernaut block.
+func TestUninstall_AbortPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		stdin      string
+		wantErrMsg string
+	}{
+		{name: "declined", stdin: "n\n", wantErrMsg: "declining the prompt should abort"},
+		{name: "eof", stdin: "", wantErrMsg: "EOF on the prompt should abort"},
 	}
 
-	var out string
-	withStdin(t, "n\n", func() {
-		out = captureStdout(t, func() {
-			if err := ExecuteArgs([]string{"uninstall"}); err != nil {
-				t.Fatalf("uninstall error: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := setupApplyTest(t)
+
+			if err := ExecuteArgs([]string{
+				"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+			}); err != nil {
+				t.Fatalf("apply error: %v", err)
+			}
+
+			var out string
+			withStdin(t, tt.stdin, func() {
+				out = captureStdout(t, func() {
+					if err := ExecuteArgs([]string{"uninstall"}); err != nil {
+						t.Fatalf("uninstall error: %v", err)
+					}
+				})
+			})
+
+			if !strings.Contains(out, "Aborted") {
+				t.Errorf("%s, got:\n%s", tt.wantErrMsg, out)
+			}
+			if strings.Contains(out, "Uninstall complete") {
+				t.Errorf("aborted uninstall must not complete, got:\n%s", out)
+			}
+
+			// Block must survive an aborted uninstall.
+			data := readSettingsJSON(t, home)
+			var settings map[string]any
+			if err := json.Unmarshal(data, &settings); err != nil {
+				t.Fatalf("parsing settings.json: %v", err)
+			}
+			if _, ok := settings["juggernaut"]; !ok {
+				t.Error("aborted uninstall should preserve the juggernaut block")
 			}
 		})
-	})
-
-	if !strings.Contains(out, "Aborted") {
-		t.Errorf("declining the prompt should abort, got:\n%s", out)
-	}
-	if strings.Contains(out, "Uninstall complete") {
-		t.Errorf("aborted uninstall must not complete, got:\n%s", out)
-	}
-
-	// Block must survive an aborted uninstall.
-	data := readSettingsJSON(t, home)
-	var settings map[string]any
-	if err := json.Unmarshal(data, &settings); err != nil {
-		t.Fatalf("parsing settings.json: %v", err)
-	}
-	if _, ok := settings["juggernaut"]; !ok {
-		t.Error("aborted uninstall should preserve the juggernaut block")
-	}
-}
-
-// TestUninstall_EOFAborts verifies that closing stdin without input (e.g. Ctrl+D
-// or a closed pipe) is treated as a decline: the uninstall aborts and the block
-// survives. Covers the scanner.Scan()==false EOF branch of confirmUninstallAborted.
-func TestUninstall_EOFAborts(t *testing.T) {
-	home := setupApplyTest(t)
-
-	if err := ExecuteArgs([]string{
-		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
-	}); err != nil {
-		t.Fatalf("apply error: %v", err)
-	}
-
-	var out string
-	withStdin(t, "", func() { // empty input -> EOF on first Scan
-		out = captureStdout(t, func() {
-			if err := ExecuteArgs([]string{"uninstall"}); err != nil {
-				t.Fatalf("uninstall error: %v", err)
-			}
-		})
-	})
-
-	if !strings.Contains(out, "Aborted") {
-		t.Errorf("EOF on the prompt should abort, got:\n%s", out)
-	}
-	if strings.Contains(out, "Uninstall complete") {
-		t.Errorf("EOF-aborted uninstall must not complete, got:\n%s", out)
-	}
-
-	data := readSettingsJSON(t, home)
-	var settings map[string]any
-	if err := json.Unmarshal(data, &settings); err != nil {
-		t.Fatalf("parsing settings.json: %v", err)
-	}
-	if _, ok := settings["juggernaut"]; !ok {
-		t.Error("EOF-aborted uninstall should preserve the juggernaut block")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Codacy's last PR check flagged a `2 duplication` metric. Confirmed locally with golangci-lint's `dupl` linter (the underlying detector Codacy uses for this metric): 3 duplicate pairs / 6 findings, all in test files, none in production code.
- `cmd/uninstall_test.go`: `TestUninstall_ConfirmAbort` + `TestUninstall_EOFAborts` merged into table-driven `TestUninstall_AbortPaths` (differed only by stdin input).
- `cmd/model_catalog_coverage_test.go`: `TestModelsList_WithGroKProvider` + `TestModelsList_WithCodexProvider` + `TestModelsList_WithClaudeProvider` merged into table-driven `TestModelsList_FiltersByProvider` (differed only by cached models/cli flag/expected IDs).
- `cmd/helpers_test_phases_test.go`: the two `TestResolveApplyInputs_OwnedConfigPreserves*PermissionMode` tests merged into table-driven `TestResolveApplyInputs_OwnedConfigPreservesPermissionModeSources` (differed only by which JSON path carries the mode).
- Test-only refactor, no behavior change, no version bump.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] All new table-driven subtests pass; full `go test ./...` green except the pre-existing environment-specific `TestApply_WritesSettings_IAM` flake (reproduces identically on unmodified `main`)
- [x] `golangci-lint run --timeout=5m ./...` (v2.9, matching CI) — 0 issues
- [x] `golangci-lint run --no-config -E dupl ./...` — 0 duplicate pairs (was 3 before this change)