### PR TITLE
fix: consolidate Codacy tokens into a single repository API token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,16 +104,19 @@ jobs:
           files: ./coverage.out
           fail_ci_if_error: ${{ matrix.os != 'windows-latest' }}
       # Codacy coverage complements Codecov — feeds the Codacy dashboard's
-      # coverage tab. Uses the project token (not OIDC — Codacy doesn't
-      # support it). force-coverage-parser: go is required — the default
-      # LCOV parser cannot parse Go's native coverprofile format. Linux-only:
-      # the Windows-only PowerShell/keychain code makes the merged-OS report
+      # coverage tab. Uses a repository API token (not OIDC — Codacy doesn't
+      # support it). Codacy has exactly two token types, Account and
+      # Repository — the action's `project-token` input just expects a
+      # Repository API token under a legacy name, not a distinct third type.
+      # force-coverage-parser: go is required — the default LCOV parser
+      # cannot parse Go's native coverprofile format. Linux-only: the
+      # Windows-only PowerShell/keychain code makes the merged-OS report
       # meaningful, but Codacy's uploader only needs one representative report.
       - name: Upload coverage to Codacy
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN }}
           coverage-reports: coverage.out
           force-coverage-parser: go
           language: Go


### PR DESCRIPTION
## Summary
- Codacy has exactly two token types \u2014 Account and Repository (per docs.codacy.com/codacy-api/api-tokens/). "Project token" is not a third type; it's just the coverage-reporter action's legacy input name for a Repository API token.
- #331 introduced two secrets (`CODACY_PROJECT_TOKEN`, `CODACY_REPOSITORY_API_TOKEN`) under the mistaken assumption they were different credential types. They're the same kind of token doing overlapping work.
- Deleted both old secrets, created a single `CODACY_REPOSITORY_API_TOKEN` secret, and repointed both the coverage-upload step's `project-token` input and the `codacy-issues-gate` job at it.

## Test plan
- [x] `gh secret list` confirms exactly one Codacy secret on the repo
- [x] Verify CI: coverage upload to Codacy succeeds with the new token
- [x] Verify CI: `codacy-issues-gate` (push-only) would authenticate correctly with the same token