### PR TITLE
docs: document Opus 5 defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ with `auth_provider_command` pointing at `juggernaut auth-token`.
   route through Mantle because native Bedrock is Claude-only.
 - `apply --mode=auto` must keep the Bedrock auto-mode guardrails: it writes
   `CLAUDE_CODE_ENABLE_AUTO_MODE=1`, but should warn unless the resolved active
-  model is Opus 4.7/4.8-capable.
+  model is Opus 4.7-or-later capable, including Opus 5.
 - `--fallback-model`, `--service-tier`, `--always-thinking`, `--effort`, and
   `skipWebFetchPreflight` are managed settings; `max` and `auto` effort levels
   are env-only, while fixed levels also persist as native `effortLevel`.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -68,7 +68,7 @@ juggernaut doctor
 
 - Bedrock routing enabled (auth-gated)
 - Claude Sonnet 5 as the primary model (Global CRIS inference profile)
-- Claude Opus 5 as the default Opus override, with adaptive thinking, 1M context, and 128K output
+- Claude Opus 5 as the default Opus override, with adaptive thinking and 1M context accounting (the default output cap is 32768 tokens; the model supports up to 128K)
 - Claude Haiku 4.5 as fast/background model
 - Claude Code 1M context accounting for Opus and Sonnet by default
 - All three model tiers visible in `/model` selector

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -67,7 +67,8 @@ juggernaut doctor
 ## What Gets Configured
 
 - Bedrock routing enabled (auth-gated)
-- Claude Sonnet 4.6 as primary model (Global CRIS inference profile)
+- Claude Sonnet 5 as the primary model (Global CRIS inference profile)
+- Claude Opus 5 as the default Opus override, with adaptive thinking, 1M context, and 128K output
 - Claude Haiku 4.5 as fast/background model
 - Claude Code 1M context accounting for Opus and Sonnet by default
 - All three model tiers visible in `/model` selector

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ juggernaut apply --auth=iam --mode=auto             # enable agentic safety-clas
 juggernaut apply --auth=iam --always-thinking       # extended thinking on by default
 juggernaut apply --auth=iam --service-tier=flex     # Bedrock service tier: default | flex | priority
 juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>
-juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-4-8
-juggernaut apply --auth=iam --available-models=sonnet,claude-opus-4-8 --enforce-available-models
+juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-5
+juggernaut apply --auth=iam --available-models=sonnet,claude-opus-5 --enforce-available-models
 juggernaut apply --auth=iam --mantle                # enable Mantle routing
 juggernaut apply --auth=iam --dry-run               # preview without writing
 juggernaut apply --auth=iam --scope=project         # write to ./.claude/settings.json
@@ -198,24 +198,24 @@ Each provider filters the live inventory by what its client protocol can use: Cl
 
 | Tier | Model | Global CRIS Profile |
 |------|-------|---------------------|
-| **Primary** | Claude Sonnet 4.6 | `global.anthropic.claude-sonnet-4-6` |
+| **Primary** | Claude Sonnet 5 | `global.anthropic.claude-sonnet-5` |
 | **Opus** | Claude Opus 5 | `global.anthropic.claude-opus-5` |
 | **Fable alias** | Claude Fable 5 | `global.anthropic.claude-fable-5` |
 | **Fast / subagent** | Claude Haiku 4.5 | `global.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
 Juggernaut appends Claude Code's `[1m]` suffix to the Opus and Sonnet alias environment variables by default, and to the configured Fable alias when it matches Claude Code's Fable ID. Claude Code accounts against 1M context for supported aliases locally, then strips that suffix before calling Bedrock. Use `--no-1m-context` to opt out.
 
-Fable defaults to `global.anthropic.claude-fable-5`, verified live against AWS Bedrock's `ListFoundationModels`/`ListInferenceProfiles` APIs (`ACTIVE` status). Pass `--fable-model` to override with a different Bedrock-accessible model ID.
+Claude Opus 5 is the default Opus tier and supports adaptive thinking, max effort, 1M context, and 128K output on Bedrock. Opus 4.7 and 4.8 remain available by passing `--opus-model`. Fable defaults to `global.anthropic.claude-fable-5`, verified live against AWS Bedrock's `ListFoundationModels`/`ListInferenceProfiles` APIs (`ACTIVE` status). Pass `--fable-model` to override with a different Bedrock-accessible model ID.
 
 > **Fable data retention:** Anthropic requires opting in to `provider_data_share` before Fable calls succeed on Bedrock — AWS retains inputs/outputs for up to 30 days and shares them with Anthropic for abuse detection/human review ([AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/abuse-detection.html)). Juggernaut has no way to check your account's actual opt-in status (no AWS API exposes it), so `apply` and `doctor` both print this as a standing warning whenever Fable is configured — it is not a promise about what is or isn't collected, only what AWS documents.
 
 Override any tier:
 
 ```bash
-juggernaut apply --auth=iam --opus-model=us.anthropic.claude-opus-5
+juggernaut apply --auth=iam --opus-model=global.anthropic.claude-opus-5
 juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>
-juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6  # override all model aliases
-juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-5,global.anthropic.claude-sonnet-4-6
+juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-5  # override all model aliases
+juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-5,global.anthropic.claude-sonnet-5
 juggernaut apply --auth=iam --available-models=sonnet,claude-opus-5 --enforce-available-models
 ```
 
@@ -223,7 +223,7 @@ juggernaut apply --auth=iam --available-models=sonnet,claude-opus-5 --enforce-av
 
 ## Effort Levels
 
-Controls adaptive thinking depth. Valid values are `low`, `medium`, `high`, `xhigh`, `max`, and `auto`; Claude Code falls back to the highest supported level for the active model. Juggernaut writes fixed persisted levels (`low`, `medium`, `high`, `xhigh`) to both native `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`; `max` and `auto` are env-only because Claude Code settings do not accept them as persisted `effortLevel` values. Ultracode is separate from `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`, so Juggernaut does not expose it as `--effort`. Juggernaut defaults to `high`, which matches Sonnet 4.6.
+Controls adaptive thinking depth. Valid values are `low`, `medium`, `high`, `xhigh`, `max`, and `auto`; Claude Code falls back to the highest supported level for the active model. Juggernaut writes fixed persisted levels (`low`, `medium`, `high`, `xhigh`) to both native `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`; `max` and `auto` are env-only because Claude Code settings do not accept them as persisted `effortLevel` values. Ultracode is separate from `effortLevel` and `CLAUDE_CODE_EFFORT_LEVEL`, so Juggernaut does not expose it as `--effort`. Juggernaut defaults to `high`, which matches the supported effort levels of Sonnet 5 and Opus 5.
 
 | Level | Behavior |
 |-------|----------|
@@ -291,7 +291,7 @@ The hidden `juggernaut launch` command reads the Bedrock API key from the OS key
     "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32768",
     "MAX_THINKING_TOKENS": "65536",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "global.anthropic.claude-opus-5[1m]",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "global.anthropic.claude-sonnet-4-6[1m]",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "global.anthropic.claude-sonnet-5[1m]",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
     "CLAUDE_CODE_EFFORT_LEVEL": "high",
     "ENABLE_PROMPT_CACHING_1H": "1",

--- a/npm/README.md
+++ b/npm/README.md
@@ -132,16 +132,16 @@ The inventory is cached per account/region at `~/.juggernaut/model-catalog.json`
 
 | Tier | Model | Global inference profile |
 |------|-------|--------------------------|
-| **Primary** | Claude Sonnet 4.6 | `global.anthropic.claude-sonnet-4-6` |
+| **Primary** | Claude Sonnet 5 | `global.anthropic.claude-sonnet-5` |
 | **Opus** | Claude Opus 5 | `global.anthropic.claude-opus-5` |
 | **Fable** | Claude Fable 5 | `global.anthropic.claude-fable-5` |
 | **Fast** | Claude Haiku 4.5 | `global.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
-Juggernaut enables Claude Code's 1M context accounting for Opus and Sonnet by appending `[1m]` to the alias environment variables. Use `--no-1m-context` to opt out.
+Claude Opus 5 is the default Opus tier on Bedrock, with adaptive thinking, 1M context, and 128K output. Opus 4.7 and 4.8 remain available through `--opus-model`. Juggernaut enables Claude Code's 1M context accounting for Opus and Sonnet by appending `[1m]` to the alias environment variables. Use `--no-1m-context` to opt out.
 
-Override all aliases: `juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-4-6`
+Override all aliases: `juggernaut apply --auth=iam --model=global.anthropic.claude-sonnet-5`
 Override one tier: `juggernaut apply --auth=iam --fable-model=<bedrock-fable-model-id>`
-Set native fallback chain: `juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-5,global.anthropic.claude-sonnet-4-6`
+Set native fallback chain: `juggernaut apply --auth=iam --fallback-model=global.anthropic.claude-opus-5,global.anthropic.claude-sonnet-5`
 
 ## Effort levels
 


### PR DESCRIPTION
## Summary
- document Claude Sonnet 5 as the primary Bedrock model
- document Claude Opus 5 capabilities and explicit Opus 4.7/4.8 overrides
- align the root README, quickstart, npm README, and repository guidance with bedrock-config.json

## Validation
- go test ./...
- go vet ./...
- npm test
- git diff --check