### PR TITLE
refactor: eliminate provider.Options ↔ schema.Options duplication

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -137,28 +137,9 @@ func resolvedScopes(filter string) []string {
 // toProviderOptions maps the cmd-built schema.Options onto the CLI-neutral
 // provider.Options consumed by Provider.BuildConfig.
 func toProviderOptions(o schema.Options) provider.Options {
-	return provider.Options{
-		AuthMode:               o.AuthMode,
-		Region:                 o.Region,
-		Effort:                 o.Effort,
-		Scope:                  o.Scope,
-		Version:                o.Version,
-		OpusModel:              o.OpusModel,
-		SonnetModel:            o.SonnetModel,
-		HaikuModel:             o.HaikuModel,
-		FableModel:             o.FableModel,
-		Opusplan:               o.Opusplan,
-		FallbackModels:         o.FallbackModels,
-		AvailableModels:        o.AvailableModels,
-		EnforceAvailableModels: o.EnforceAvailableModels,
-		Use1M:                  o.Use1M,
-		UseMantle:              o.UseMantle,
-		MantleURL:              o.MantleURL,
-		AuthValidated:          o.AuthValidated,
-		PermissionMode:         o.PermissionMode,
-		AlwaysThinking:         o.AlwaysThinking,
-		ServiceTier:            o.ServiceTier,
-	}
+	var po provider.Options
+	po.FromSchemaOptions(o)
+	return po
 }
 
 func resolveMantle() (bool, error) {

--- a/cmd/helpers_coverage_extra_test.go
+++ b/cmd/helpers_coverage_extra_test.go
@@ -86,7 +86,9 @@ func TestPrintApplyDryRun_NonClaudeProvider(t *testing.T) {
 		Region:   "us-west-2",
 		Scope:    "user",
 		Version:  "5.4.0",
-		Effort:   "high",
+		SchemaOpts: schema.Options{
+			Effort: "high",
+		},
 	}
 	block := &schema.Block{}
 

--- a/cmd/helpers_test_phases_test.go
+++ b/cmd/helpers_test_phases_test.go
@@ -54,59 +54,59 @@ func TestToProviderOptions_FieldsMapped(t *testing.T) {
 	if po.Region != "us-east-1" {
 		t.Errorf("Region = %q, want %q", po.Region, "us-east-1")
 	}
-	if po.Effort != "high" {
-		t.Errorf("Effort = %q, want %q", po.Effort, "high")
+	if po.SchemaOpts.Effort != "high" {
+		t.Errorf("Effort = %q, want %q", po.SchemaOpts.Effort, "high")
 	}
-	if po.Scope != "user" {
-		t.Errorf("Scope = %q, want %q", po.Scope, "user")
+	if po.SchemaOpts.Scope != "user" {
+		t.Errorf("Scope = %q, want %q", po.SchemaOpts.Scope, "user")
 	}
-	if po.Version != "5.4.0" {
-		t.Errorf("Version = %q, want %q", po.Version, "5.4.0")
+	if po.SchemaOpts.Version != "5.4.0" {
+		t.Errorf("Version = %q, want %q", po.SchemaOpts.Version, "5.4.0")
 	}
-	if po.OpusModel != "global.anthropic.claude-opus-4-8" {
-		t.Errorf("OpusModel = %q", po.OpusModel)
+	if po.SchemaOpts.OpusModel != "global.anthropic.claude-opus-4-8" {
+		t.Errorf("OpusModel = %q", po.SchemaOpts.OpusModel)
 	}
-	if po.SonnetModel != "global.anthropic.claude-sonnet-5" {
-		t.Errorf("SonnetModel = %q", po.SonnetModel)
+	if po.SchemaOpts.SonnetModel != "global.anthropic.claude-sonnet-5" {
+		t.Errorf("SonnetModel = %q", po.SchemaOpts.SonnetModel)
 	}
-	if po.HaikuModel != "anthropic.claude-haiku-4-5-20251001-v1:0" {
-		t.Errorf("HaikuModel = %q", po.HaikuModel)
+	if po.SchemaOpts.HaikuModel != "anthropic.claude-haiku-4-5-20251001-v1:0" {
+		t.Errorf("HaikuModel = %q", po.SchemaOpts.HaikuModel)
 	}
-	if po.FableModel != "global.anthropic.claude-fable-5" {
-		t.Errorf("FableModel = %q", po.FableModel)
+	if po.SchemaOpts.FableModel != "global.anthropic.claude-fable-5" {
+		t.Errorf("FableModel = %q", po.SchemaOpts.FableModel)
 	}
-	if !po.Opusplan {
+	if !po.SchemaOpts.Opusplan {
 		t.Error("Opusplan = false, want true")
 	}
-	if len(po.FallbackModels) != 2 || po.FallbackModels[0] != "global.anthropic.claude-opus-4-8" {
-		t.Errorf("FallbackModels = %v", po.FallbackModels)
+	if len(po.SchemaOpts.FallbackModels) != 2 || po.SchemaOpts.FallbackModels[0] != "global.anthropic.claude-opus-4-8" {
+		t.Errorf("FallbackModels = %v", po.SchemaOpts.FallbackModels)
 	}
-	if len(po.AvailableModels) != 2 || po.AvailableModels[0] != "sonnet" {
-		t.Errorf("AvailableModels = %v", po.AvailableModels)
+	if len(po.SchemaOpts.AvailableModels) != 2 || po.SchemaOpts.AvailableModels[0] != "sonnet" {
+		t.Errorf("AvailableModels = %v", po.SchemaOpts.AvailableModels)
 	}
-	if !po.EnforceAvailableModels {
+	if !po.SchemaOpts.EnforceAvailableModels {
 		t.Error("EnforceAvailableModels = false, want true")
 	}
-	if !po.Use1M {
+	if !po.SchemaOpts.Use1M {
 		t.Error("Use1M = false, want true")
 	}
-	if po.UseMantle {
+	if po.SchemaOpts.UseMantle {
 		t.Error("UseMantle = true, want false")
 	}
-	if po.MantleURL != "" {
-		t.Errorf("MantleURL = %q, want empty", po.MantleURL)
+	if po.SchemaOpts.MantleURL != "" {
+		t.Errorf("MantleURL = %q, want empty", po.SchemaOpts.MantleURL)
 	}
-	if !po.AuthValidated {
+	if !po.SchemaOpts.AuthValidated {
 		t.Error("AuthValidated = false, want true")
 	}
-	if po.PermissionMode != "auto" {
-		t.Errorf("PermissionMode = %q, want %q", po.PermissionMode, "auto")
+	if po.SchemaOpts.PermissionMode != "auto" {
+		t.Errorf("PermissionMode = %q, want %q", po.SchemaOpts.PermissionMode, "auto")
 	}
-	if !po.AlwaysThinking {
+	if !po.SchemaOpts.AlwaysThinking {
 		t.Error("AlwaysThinking = false, want true")
 	}
-	if po.ServiceTier != "flex" {
-		t.Errorf("ServiceTier = %q, want %q", po.ServiceTier, "flex")
+	if po.SchemaOpts.ServiceTier != "flex" {
+		t.Errorf("ServiceTier = %q, want %q", po.SchemaOpts.ServiceTier, "flex")
 	}
 }
 
@@ -114,14 +114,15 @@ func TestToProviderOptions_EmptyOptions(t *testing.T) {
 	o := schema.Options{}
 	po := toProviderOptions(o)
 
-	if po.AuthMode != "" || po.Region != "" || po.Effort != "" ||
-		po.Scope != "" || po.Version != "" || po.OpusModel != "" ||
-		po.SonnetModel != "" || po.HaikuModel != "" || po.FableModel != "" ||
-		po.Opusplan || len(po.FallbackModels) > 0 || len(po.AvailableModels) > 0 ||
-		po.EnforceAvailableModels || po.Use1M || po.UseMantle ||
-		po.MantleURL != "" || po.AuthValidated || po.PermissionMode != "" ||
-		po.AlwaysThinking || po.ServiceTier != "" {
-		t.Errorf("expected all-zero provider.Options, got: %+v", po)
+	// SchemaOpts fields should all be zero.
+	if po.SchemaOpts.AuthMode != "" || po.SchemaOpts.Region != "" || po.SchemaOpts.Effort != "" ||
+		po.SchemaOpts.Scope != "" || po.SchemaOpts.Version != "" || po.SchemaOpts.OpusModel != "" ||
+		po.SchemaOpts.SonnetModel != "" || po.SchemaOpts.HaikuModel != "" || po.SchemaOpts.FableModel != "" ||
+		po.SchemaOpts.Opusplan || len(po.SchemaOpts.FallbackModels) > 0 || len(po.SchemaOpts.AvailableModels) > 0 ||
+		po.SchemaOpts.EnforceAvailableModels || po.SchemaOpts.Use1M || po.SchemaOpts.UseMantle ||
+		po.SchemaOpts.MantleURL != "" || po.SchemaOpts.AuthValidated || po.SchemaOpts.PermissionMode != "" ||
+		po.SchemaOpts.AlwaysThinking || po.SchemaOpts.ServiceTier != "" {
+		t.Errorf("expected all-zero SchemaOpts, got: %+v", po.SchemaOpts)
 	}
 }
 
@@ -810,12 +811,18 @@ func TestCommitApply_CollisionRefusal(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	err = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
@@ -854,12 +861,18 @@ func TestCommitApply_KeychainStorage(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      authmode.BedrockAPIKey,
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      authmode.BedrockAPIKey,
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: authmode.BedrockAPIKey,
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	// Pass a non-empty token — commitApply should store it via keychain.SetWithFallback.
@@ -919,12 +932,18 @@ func TestPrintApplyDryRun_NoCollisions(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {
@@ -984,12 +1003,18 @@ func TestPrintApplyDryRun_CollisionsNoForce(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {
@@ -1516,12 +1541,18 @@ func TestCommitApply_WarningsOutput(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {
@@ -1567,12 +1598,18 @@ func TestPrintApplyDryRun_ClaudeLegacyRecovery(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {
@@ -2012,12 +2049,18 @@ func TestCommitApply_SuccessPath_ActivationInstalled(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {
@@ -2085,12 +2128,18 @@ func TestCommitApply_ForceBypassesCollision(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Scope:         "user",
+			Version:       "5.4.0",
+			Effort:        "high",
+			AuthValidated: true,
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {
@@ -2606,13 +2655,19 @@ func TestCommitApply_AutoModeWarning(t *testing.T) {
 	}
 
 	provOpts := provider.Options{
-		AuthMode:       "iam",
-		Region:         "us-west-2",
-		Scope:          "user",
-		Version:        "5.4.0",
-		Effort:         "high",
-		AuthValidated:  true,
-		PermissionMode: "auto",
+		SchemaOpts: schema.Options{
+			AuthMode:       "iam",
+			Region:         "us-west-2",
+			Scope:          "user",
+			Version:        "5.4.0",
+			Effort:         "high",
+			AuthValidated:  true,
+			PermissionMode: "auto",
+		},
+		AuthMode: "iam",
+		Region:   "us-west-2",
+		Scope:    "user",
+		Version:  "5.4.0",
 	}
 
 	out := captureStdout(t, func() {

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -23,12 +23,18 @@ func testConfig() *bedrock.Config {
 
 func baseOpts() Options {
 	return Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Effort:        "high",
-		Scope:         "user",
-		Version:       "9.9.9",
-		AuthValidated: true,
+		SchemaOpts: schema.Options{
+			AuthMode:      "iam",
+			Region:        "us-west-2",
+			Effort:        "high",
+			Scope:         "user",
+			Version:       "9.9.9",
+			AuthValidated: true,
+		},
+		Region:   "us-west-2",
+		AuthMode: "iam",
+		Scope:    "user",
+		Version:  "9.9.9",
 	}
 }
 
@@ -68,8 +74,8 @@ func TestClaude_BuildConfig_EnvHasBedrockModels(t *testing.T) {
 func TestClaude_BuildConfig_AvailableModels(t *testing.T) {
 	p, _ := Get("claude")
 	opts := baseOpts()
-	opts.AvailableModels = []string{"sonnet", "haiku"}
-	opts.EnforceAvailableModels = true
+	opts.SchemaOpts.AvailableModels = []string{"sonnet", "haiku"}
+	opts.SchemaOpts.EnforceAvailableModels = true
 	plan, err := p.BuildConfig(testConfig(), opts)
 	if err != nil {
 		t.Fatalf("BuildConfig: %v", err)

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -78,7 +78,7 @@ func (c claude) NativeManagedKeys() []string {
 // Claude logic is relocated here, not rewritten — the golden-output test guards
 // against drift.
 func (c claude) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
-	block, err := schema.Build(cfg, toSchemaOptions(opts))
+	block, err := schema.Build(cfg, opts.SchemaOpts)
 	if err != nil {
 		return ConfigPlan{}, err
 	}
@@ -124,33 +124,5 @@ func (c claude) LaunchSpec() LaunchSpec {
 		// The launcher decides via needsBearerToken(authModes). Forcing true here
 		// would break every Claude+IAM launch with "API key not found".
 		NeedsToken: false,
-	}
-}
-
-// toSchemaOptions maps the CLI-neutral provider.Options onto Claude's
-// schema.Options. This mapping is the ONLY place the provider package couples to
-// schema, keeping the coupling isolated to claude.go.
-func toSchemaOptions(o Options) schema.Options {
-	return schema.Options{
-		AuthMode:               o.AuthMode,
-		Region:                 o.Region,
-		Effort:                 o.Effort,
-		Scope:                  o.Scope,
-		Version:                o.Version,
-		OpusModel:              o.OpusModel,
-		SonnetModel:            o.SonnetModel,
-		HaikuModel:             o.HaikuModel,
-		FableModel:             o.FableModel,
-		Opusplan:               o.Opusplan,
-		FallbackModels:         o.FallbackModels,
-		AvailableModels:        o.AvailableModels,
-		EnforceAvailableModels: o.EnforceAvailableModels,
-		Use1M:                  o.Use1M,
-		UseMantle:              o.UseMantle,
-		MantleURL:              o.MantleURL,
-		AuthValidated:          o.AuthValidated,
-		PermissionMode:         o.PermissionMode,
-		AlwaysThinking:         o.AlwaysThinking,
-		ServiceTier:            o.ServiceTier,
 	}
 }

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 )
 
 // ToMap serializes any value to a generic map via JSON round-trip.
@@ -23,38 +25,29 @@ func ToMap(v any) (map[string]any, error) {
 
 // Options are the apply-time inputs a Provider turns into a ConfigPlan. It is a
 // neutral, CLI-agnostic struct: cmd/ populates it, and each provider maps it to
-// its own config shape internally (claude.go maps it to schema.Options; codex.go
-// selects a per-model Mantle block). Kept separate from schema.Options so the
-// provider package stays decoupled from Claude's schema — the mapping lives only
-// in claude.go.
+// its own config shape internally (claude.go passes SchemaOpts through to
+// schema.Build; codex/grok/opencode use the flat fields below).
 type Options struct {
-	AuthMode string
-	Region   string
+	// SchemaOpts carries the original schema.Options for the Claude provider.
+	// The Claude provider passes this directly to schema.Build, avoiding a
+	// field-by-field round-trip. Non-Claude providers ignore this field.
+	SchemaOpts schema.Options
+	// Region is the resolved AWS region. Shared by all providers.
+	Region string
 	// RegionExplicit is true when the user passed --region, false when Region was
 	// filled from the global default. Mantle providers use this to decide whether
 	// they may auto-switch a model to a region that actually serves it (default)
 	// or must honor the user's explicit choice (and only warn).
-	RegionExplicit         bool
-	Effort                 string
-	Scope                  string
-	Version                string
-	Model                  string // friendly model key or override (provider-interpreted)
-	OpusModel              string
-	SonnetModel            string
-	HaikuModel             string
-	FableModel             string
-	Opusplan               bool
-	FallbackModels         []string
-	AvailableModels        []string
-	EnforceAvailableModels bool
-	Use1M                  bool
-	UseMantle              bool
-	MantleURL              string
-	AuthValidated          bool
-	PermissionMode         string
-	AlwaysThinking         bool
-	ServiceTier            string
-	Route                  string // "mantle" (default) or "native"
+	RegionExplicit bool
+	// AuthMode is the auth mode (iam or bedrock-api-key). Used by non-Claude
+	// providers. Claude reads it from SchemaOpts.
+	AuthMode string
+	// Scope is user or project scope. Used by non-Claude providers.
+	Scope string
+	// Version is the Juggernaut version string. Used by non-Claude providers.
+	Version string
+	Model   string // friendly model key or override (provider-interpreted)
+	Route   string // "mantle" (default) or "native"
 	// ModelCatalog is the cached or freshly discovered account/region inventory.
 	// Providers decide which entries their client protocol can actually use.
 	ModelCatalog []CatalogModel
@@ -64,6 +57,19 @@ type Options struct {
 	// which is distinct from "never refreshed" and still counts as proof that
 	// the model is unavailable.
 	RefreshedSources []string
+}
+
+// FromSchemaOptions stores schema.Options directly so the Claude provider can
+// pass it to schema.Build without a field-by-field round-trip. It also populates
+// the flat fields (Region, AuthMode, Scope, Version) that non-Claude providers
+// read. The remaining fields (RegionExplicit, Model, Route, ModelCatalog,
+// RefreshedSources) are the caller's responsibility.
+func (o *Options) FromSchemaOptions(s schema.Options) {
+	o.SchemaOpts = s
+	o.Region = s.Region
+	o.AuthMode = s.AuthMode
+	o.Scope = s.Scope
+	o.Version = s.Version
 }
 
 // CatalogModel is the SDK-independent model fact passed from discovery into a

--- a/internal/provider/plan_coverage_test.go
+++ b/internal/provider/plan_coverage_test.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 )
 
 func TestToMap_MarshalError(t *testing.T) {
@@ -122,5 +124,70 @@ func TestCatalogSelectionState_EmptyCatalogWithRefreshedSource(t *testing.T) {
 	}
 	if selectedAvailable {
 		t.Error("selected model should not be available when catalog is empty")
+	}
+}
+
+func TestFromSchemaOptions_FillsFields(t *testing.T) {
+	src := schema.Options{
+		AuthMode:               "iam",
+		Region:                 "us-west-2",
+		Effort:                 "high",
+		Scope:                  "user",
+		Version:                "5.4.0",
+		OpusModel:              "global.anthropic.claude-opus-4-8",
+		SonnetModel:            "global.anthropic.claude-sonnet-5",
+		HaikuModel:             "anthropic.claude-haiku-4-5",
+		FableModel:             "global.anthropic.claude-fable-5",
+		Opusplan:               true,
+		FallbackModels:         []string{"sonnet", "haiku"},
+		AvailableModels:        []string{"opus"},
+		EnforceAvailableModels: true,
+		Use1M:                  true,
+		UseMantle:              false,
+		MantleURL:              "https://example.com",
+		AuthValidated:          true,
+		PermissionMode:         "auto",
+		AlwaysThinking:         true,
+		ServiceTier:            "flex",
+	}
+	var opts Options
+	opts.FromSchemaOptions(src)
+
+	// Verify SchemaOpts was copied (struct contains slices so compare fields individually).
+	if opts.SchemaOpts.AuthMode != src.AuthMode || opts.SchemaOpts.Region != src.Region {
+		t.Errorf("SchemaOpts not fully copied: got %+v, want %+v", opts.SchemaOpts, src)
+	}
+	if opts.SchemaOpts.OpusModel != src.OpusModel {
+		t.Errorf("SchemaOpts.OpusModel = %q, want %q", opts.SchemaOpts.OpusModel, src.OpusModel)
+	}
+	if opts.SchemaOpts.PermissionMode != src.PermissionMode {
+		t.Errorf("SchemaOpts.PermissionMode = %q, want %q", opts.SchemaOpts.PermissionMode, src.PermissionMode)
+	}
+	if !opts.SchemaOpts.Opusplan || !opts.SchemaOpts.Use1M || !opts.SchemaOpts.AuthValidated {
+		t.Errorf("SchemaOpts booleans not set: opusplan=%v use1m=%v authValidated=%v",
+			opts.SchemaOpts.Opusplan, opts.SchemaOpts.Use1M, opts.SchemaOpts.AuthValidated)
+	}
+	if len(opts.SchemaOpts.FallbackModels) != 2 || opts.SchemaOpts.FallbackModels[0] != "sonnet" {
+		t.Errorf("SchemaOpts.FallbackModels = %v, want [sonnet haiku]", opts.SchemaOpts.FallbackModels)
+	}
+	if opts.Region != "us-west-2" {
+		t.Errorf("Region = %q, want us-west-2", opts.Region)
+	}
+	if opts.AuthMode != "iam" {
+		t.Errorf("AuthMode = %q, want iam", opts.AuthMode)
+	}
+	if opts.Scope != "user" {
+		t.Errorf("Scope = %q, want user", opts.Scope)
+	}
+	if opts.Version != "5.4.0" {
+		t.Errorf("Version = %q, want 5.4.0", opts.Version)
+	}
+}
+
+func TestFromSchemaOptions_Empty(t *testing.T) {
+	var opts Options
+	opts.FromSchemaOptions(schema.Options{})
+	if opts.SchemaOpts.AuthMode != "" || opts.Region != "" || opts.Scope != "" || opts.Version != "" {
+		t.Errorf("expected zero values, got %+v", opts)
 	}
 }


### PR DESCRIPTION
Eliminates the 21-field field-by-field mapping between \provider.Options\ and \schema.Options\ in both directions.

**What changed:**
- \provider.Options\ now embeds \schema.Options\ directly as \SchemaOpts\
- Claude provider passes \SchemaOpts\ directly to \schema.Build\ instead of round-tripping through a 21-line \	oSchema()\ mapping
- \FromSchemaOptions\ is now a single struct assignment instead of 21 field copies
- Non-Claude providers (Codex, Grok, OpenCode) retain flat fields for \Region\, \AuthMode\, \Scope\, and \Version\ — the only fields they actually read