### PR TITLE
refactor: migrate test helpers to testutil.NewTestHome

### DIFF
--- a/cmd/apply_flags_test.go
+++ b/cmd/apply_flags_test.go
@@ -4,12 +4,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
 func TestApply_RejectsBareFlagShapedArgument(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := testutil.NewTestHome(t)
 
 	err := ExecuteArgs([]string{"apply", "cli=codex", "--dry-run"})
 	if err == nil {
@@ -69,9 +69,7 @@ func TestApply_SkipPreflightAccepted(t *testing.T) {
 // where the positional arg does not contain "=" (not flag-shaped). It falls
 // through to cobra.NoArgs and must be rejected.
 func TestApply_RejectsNonFlagArgument(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	testutil.NewTestHome(t)
 
 	err := ExecuteArgs([]string{"apply", "some-random-arg"})
 	if err == nil {
@@ -97,9 +95,7 @@ func TestApply_ValidateArgsEmptyArgs(t *testing.T) {
 // TestApply_RedactsBedrockKey verifies that a mistyped bedrock-key argument
 // does not leak the secret value in the error message.
 func TestApply_RedactsBedrockKey(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	testutil.NewTestHome(t)
 
 	err := ExecuteArgs([]string{"apply", "bedrock-key=test-fake-key-12345"})
 	if err == nil {

--- a/cmd/auth_token_test.go
+++ b/cmd/auth_token_test.go
@@ -143,6 +143,7 @@ func TestBuildAuthTokenOutput_Formats(t *testing.T) {
 // falls through to its normal login.
 func TestAuthToken_Command_ErrorsWhenNoToken(t *testing.T) {
 	_ = testutil.NewTestHome(t)
+	testutil.SkipIfNoKeychain(t) // isolated empty store
 
 	var err error
 	out := captureStdout(t, func() {

--- a/cmd/auth_token_test.go
+++ b/cmd/auth_token_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
 // makeShortTermKey builds a bedrock-api-key-<b64(presigned url)> whose embedded
@@ -78,9 +80,7 @@ func TestBuildAuthTokenJSON_StdoutIsCleanJSON(t *testing.T) {
 // token in an isolated keychain, run `auth-token`, and confirm stdout is the
 // JSON carrying that token.
 func TestAuthToken_Command_EmitsKeychainToken(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := testutil.NewTestHome(t)
 	store := setupIsolatedKeychain(t) // skips if backend unavailable/hangs
 	if err := store.SetWithFallback("kc-token-123", home); err != nil {
 		t.Fatalf("seed token: %v", err)
@@ -105,9 +105,7 @@ func TestAuthToken_Command_EmitsKeychainToken(t *testing.T) {
 // JSON), which is what Codex's auth.command reads (it trims stdout and uses the
 // whole thing as the bearer token — verified in openai/codex external_bearer.rs).
 func TestAuthToken_Command_FormatToken(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
+	home := testutil.NewTestHome(t)
 	store := setupIsolatedKeychain(t)
 	if err := store.SetWithFallback("kc-bare-456", home); err != nil {
 		t.Fatalf("seed token: %v", err)
@@ -144,10 +142,7 @@ func TestBuildAuthTokenOutput_Formats(t *testing.T) {
 // errors (non-zero) and prints nothing parseable as a token to stdout, so Grok
 // falls through to its normal login.
 func TestAuthToken_Command_ErrorsWhenNoToken(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	setupIsolatedKeychain(t) // isolated empty store
+	_ = testutil.NewTestHome(t)
 
 	var err error
 	out := captureStdout(t, func() {

--- a/cmd/helpers_coverage_extra_test.go
+++ b/cmd/helpers_coverage_extra_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/schema"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
 // ---------------------------------------------------------------------------
@@ -50,7 +51,7 @@ func TestResolveCredential_TUIPromptError(t *testing.T) {
 	}
 	defer resetFlags()
 
-	home := t.TempDir()
+	home := testutil.NewTestHome(t)
 	// Ensure no credential file exists so the TUI prompt path is taken.
 	t.Setenv("JUGGERNAUT_KEYCHAIN_SERVICE", "nonexistent-service-xyz-for-tui")
 

--- a/cmd/helpers_warnf_coverage_test.go
+++ b/cmd/helpers_warnf_coverage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 	"github.com/spf13/cobra"
 )
 
@@ -16,10 +17,7 @@ func TestShow_ScopePathError(t *testing.T) {
 	os.Stderr = w
 	defer func() { os.Stderr = old; r.Close(); w.Close() }()
 
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	// Reset flags to avoid inheriting state from other tests.
+	_ = testutil.NewTestHome(t)
 	origScope := showFlags.scope
 	defer func() { showFlags.scope = origScope }()
 

--- a/cmd/model_catalog_coverage_test.go
+++ b/cmd/model_catalog_coverage_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/jpvelasco/juggernaut/v5/internal/discovery"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 	"github.com/spf13/cobra"
 )
 
 func TestRunModelsRefresh_NativeSources(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 15, 0, 0, 0, time.UTC)
 
 	origFlags := modelsRefreshFlags
@@ -63,8 +63,7 @@ func TestRunModelsRefresh_NativeSources(t *testing.T) {
 }
 
 func TestRunModelsList_CliFilterWithProviderError(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
 		[]discovery.Source{discovery.SourceMantle},
@@ -101,8 +100,7 @@ func TestRunModelsList_CliFilterWithProviderError(t *testing.T) {
 }
 
 func TestRunModelsList_NoModelsMatchSourceFilter(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
 		[]discovery.Source{discovery.SourceFoundation},
@@ -225,8 +223,7 @@ func TestParseCatalogSources_CaseInsensitive(t *testing.T) {
 }
 
 func TestModelsList_RefreshAccountError(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	_ = testutil.NewTestHome(t)
 
 	origFlags := modelsListFlags
 	origAccount, origScope := catalogCallerAccount, catalogCredentialScope
@@ -333,8 +330,7 @@ func TestModelsList_FiltersByProvider(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			home := t.TempDir()
-			t.Setenv("HOME", home)
+			home := testutil.NewTestHome(t)
 			when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 			if err := discovery.SaveCachedModels(home, "111122223333", "scope", "us-west-2",
 				tt.cachedSources, tt.models, when); err != nil {
@@ -376,8 +372,7 @@ func TestModelsList_FiltersByProvider(t *testing.T) {
 }
 
 func TestModelsList_SummaryLineFormat(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	if err := discovery.SaveCachedModels(home, "999988887777", "scope", "us-west-2",
 		[]discovery.Source{discovery.SourceMantle},
@@ -415,8 +410,7 @@ func TestModelsList_SummaryLineFormat(t *testing.T) {
 }
 
 func TestModelsRefresh_OutputFormat(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	_ = testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 15, 0, 0, 0, time.UTC)
 
 	origFlags := modelsRefreshFlags

--- a/cmd/model_catalog_test.go
+++ b/cmd/model_catalog_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jpvelasco/juggernaut/v5/internal/discovery"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 	"github.com/spf13/cobra"
 )
 
@@ -131,8 +132,7 @@ func TestRefreshCatalog_IdentifiesFailingSource(t *testing.T) {
 }
 
 func TestModelsList_FiltersLiveCatalogByCLI(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
 	models := []discovery.DiscoveredModel{
 		{ID: "moonshotai.kimi-k2.5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
@@ -187,8 +187,7 @@ func TestModelsList_FiltersLiveCatalogByCLI(t *testing.T) {
 }
 
 func TestModelsList_MissingCacheIsActionable(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	_ = testutil.NewTestHome(t)
 	origFlags := modelsListFlags
 	modelsListFlags = struct {
 		region          string
@@ -205,8 +204,7 @@ func TestModelsList_MissingCacheIsActionable(t *testing.T) {
 }
 
 func TestModelsRefresh_ReportsInvalidSourceAndIdentityFailure(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	_ = testutil.NewTestHome(t)
 	origFlags := modelsRefreshFlags
 	origScope := catalogCredentialScope
 	t.Cleanup(func() {
@@ -227,8 +225,7 @@ func TestModelsRefresh_ReportsInvalidSourceAndIdentityFailure(t *testing.T) {
 }
 
 func TestModelsRefresh_CachesAllSources(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 15, 0, 0, 0, time.UTC)
 
 	origFlags := modelsRefreshFlags
@@ -270,8 +267,7 @@ func TestModelsRefresh_CachesAllSources(t *testing.T) {
 }
 
 func TestModelsRefresh_PropagatesDiscoveryAndCacheErrors(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 
 	origFlags := modelsRefreshFlags
 	origMantle := listMantleCatalog
@@ -304,8 +300,7 @@ func TestModelsRefresh_PropagatesDiscoveryAndCacheErrors(t *testing.T) {
 }
 
 func TestModelsList_RefreshesAndListsWithoutCLIFilter(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	_ = testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 16, 0, 0, 0, time.UTC)
 
 	origFlags := modelsListFlags
@@ -344,8 +339,7 @@ func TestModelsList_RefreshesAndListsWithoutCLIFilter(t *testing.T) {
 }
 
 func TestModelsList_PropagatesInputRefreshAndCacheErrors(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 
 	origFlags := modelsListFlags
 	origMantle := listMantleCatalog
@@ -394,8 +388,7 @@ func TestModelsList_PropagatesInputRefreshAndCacheErrors(t *testing.T) {
 }
 
 func TestModelsList_FiltersSourcesAndPropagatesWriterErrors(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	when := time.Date(2026, 7, 20, 17, 0, 0, 0, time.UTC)
 	models := []discovery.DiscoveredModel{
 		{ID: "zai.glm-5", Source: discovery.SourceMantle, Status: "ACTIVE", Availability: "AVAILABLE"},
@@ -474,8 +467,7 @@ func TestCachedProviderModels_MapsCachedInventory(t *testing.T) {
 }
 
 func TestModelCatalogCommands_PropagateIdentityAndProviderErrors(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testutil.NewTestHome(t)
 	origRefreshFlags, origListFlags := modelsRefreshFlags, modelsListFlags
 	origAccount, origScope := catalogCallerAccount, catalogCredentialScope
 	t.Cleanup(func() {

--- a/coverage_funcs.txt
+++ b/coverage_funcs.txt
@@ -1,0 +1,2 @@
+too many arguments
+For usage information, run "go tool cover -help"

--- a/coverage_funcs.txt
+++ b/coverage_funcs.txt
@@ -1,2 +1,0 @@
-too many arguments
-For usage information, run "go tool cover -help"

--- a/internal/activation/powershell_discovery_test.go
+++ b/internal/activation/powershell_discovery_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
 // mockCommandRunner returns pre-configured output for test scenarios.
@@ -37,12 +38,6 @@ func makePSOutput(allHosts, currentHost string) []byte {
 	return data
 }
 
-func makeHome(t *testing.T, home string) {
-	t.Helper()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-}
-
 // setupDocsMock mocks resolveDocumentsFolder to return the given home
 // directory as the Documents folder, so that path containment checks pass
 // when test paths are under t.TempDir(). This is intentionally broad — the
@@ -60,8 +55,7 @@ func TestDiscoverPowerShellProfiles_PS7Only(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -105,8 +99,7 @@ func TestDiscoverPowerShellProfiles_BothEditions(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	ps7All := filepath.Join(home, "OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -135,8 +128,7 @@ func TestDiscoverPowerShellProfiles_OneDriveRedirected(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// Simulate OneDrive-redirected path
@@ -165,8 +157,7 @@ func TestDiscoverPowerShellProfiles_UNCPath(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	uncPath := `\\server\share\PowerShell\Microsoft.PowerShell_profile.ps1`
@@ -205,8 +196,7 @@ func TestDiscoverPowerShellProfiles_PathWithSpaces(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "My Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -233,8 +223,7 @@ func TestDiscoverPowerShellProfiles_PathWithUnicode(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "Dokumente_über", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -261,8 +250,7 @@ func TestDiscoverPowerShellProfiles_MalformedJSON(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	runner := &mockCommandRunner{
@@ -299,8 +287,7 @@ func TestDiscoverPowerShellProfiles_DiscoveryTimeout(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// Simulate a timeout by returning context.DeadlineExceeded
@@ -335,8 +322,7 @@ func TestDiscoverPowerShellProfiles_BothMissing(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	runner := &mockCommandRunner{
@@ -370,8 +356,7 @@ func TestDiscoverPowerShellProfiles_CaseInsensitiveDedup(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// Both editions return the same path with different casing
@@ -408,8 +393,7 @@ func TestDiscoverPowerShellProfiles_NoExecutable_DiscoveryFailure(t *testing.T) 
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	runner := &mockCommandRunner{
@@ -486,8 +470,7 @@ func TestCheckPowerShellActivation_Healthy(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -525,8 +508,7 @@ func TestCheckPowerShellActivation_NoActivation_DiscoveredProfileOnly(t *testing
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// The real discovered profile has NO activation
@@ -569,8 +551,7 @@ func TestCheckPowerShellActivation_NoFalseWarning_DiscoveredPathMatchesHistorica
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// Use the standard non-OneDrive path that used to be both "active" and "historical"
@@ -649,8 +630,7 @@ func TestInstallPowerShellActivation_Idempotent(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -695,8 +675,7 @@ func TestUninstallPowerShellActivation(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -753,8 +732,7 @@ func TestUninstallPowerShellActivation_HistoricalProfiles(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 
 	// Mock Documents folder to be home/OneDrive/Documents.
 	docsDir := filepath.Join(home, "OneDrive", "Documents")
@@ -814,8 +792,7 @@ func TestInstallPowerShellActivation_HostSpecificOverride(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// PS7 AllHosts (authoritative)
@@ -901,8 +878,7 @@ func TestDiscoveryTimeout_WithMock(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// Simulate a slow executable that times out
@@ -937,8 +913,7 @@ func TestOneExecutableMissing(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	allHosts := filepath.Join(home, "OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
@@ -1020,8 +995,7 @@ func TestOneDriveRedirect_FullFlow(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 	setupDocsMock(t, home)
 
 	// Actual discovered PowerShell profile (redirected Documents)
@@ -1145,8 +1119,7 @@ func TestKnownDocumentsFallback_InstallTargets(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 
 	// Mock resolveDocumentsFolder to return a known path
 	docsDir := filepath.Join(home, "Documents")
@@ -1192,8 +1165,7 @@ func TestFallbackInstallation_ActualProfileCreated(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows only")
 	}
-	home := t.TempDir()
-	makeHome(t, home)
+	home := testutil.NewTestHome(t)
 
 	// Mock the Known Folder API to return a path under the temp dir.
 	docsDir := filepath.Join(home, "Documents")


### PR DESCRIPTION
## Summary

Migrate 43 test call sites from the inline `t.TempDir()` + `t.Setenv("HOME", home)` + `t.Setenv("USERPROFILE", home)` pattern to the centralized `testutil.NewTestHome(t)` helper.

## Changes

- **cmd/apply_flags_test.go** — 3 sites (2 unused `home` → bare call)
- **cmd/auth_token_test.go** — 3 sites (1 unused `home` → bare call)
- **cmd/model_catalog_test.go** — 8 sites (3 unused `home` → bare call)
- **cmd/model_catalog_coverage_test.go** — 7 sites (2 unused `home` → bare call)
- **cmd/helpers_warnf_coverage_test.go** — 1 site (unused `home` → bare call)
- **cmd/helpers_coverage_extra_test.go** — 1 site
- **internal/activation/powershell_discovery_test.go** — 23 sites (replaced `makeHome` helper entirely, now deleted)

**Net:** -50 lines. Zero behavioral change — `NewTestHome` does exactly what the inline pattern did.

## Verification

- `go build ./...` — clean
- `go test ./...` — all pass (pre-existing bedrock connectivity flake on Windows unrelated)