### PR TITLE
refactor: single-source StripRegionPrefix in internal/bedrock

### DIFF
--- a/cmd/models.go
+++ b/cmd/models.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/discovery"
-	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 	"github.com/spf13/cobra"
 )
 
@@ -195,9 +194,9 @@ func pinStatus(pinned string, anthropic, profiles []discovery.DiscoveredModel) (
 		}
 		return "", false
 	}
-	bare := schema.StripRegionPrefix(pinned)
+	bare := bedrock.StripRegionPrefix(pinned)
 	for _, m := range anthropic {
-		if m.ID == bare || schema.StripRegionPrefix(m.ID) == bare {
+		if m.ID == bare || bedrock.StripRegionPrefix(m.ID) == bare {
 			return m.Status, true
 		}
 	}
@@ -205,7 +204,7 @@ func pinStatus(pinned string, anthropic, profiles []discovery.DiscoveredModel) (
 }
 
 func hasRegionalPrefix(modelID string) bool {
-	return schema.StripRegionPrefix(modelID) != modelID
+	return bedrock.StripRegionPrefix(modelID) != modelID
 }
 
 // activeCandidatesForTier returns every ACTIVE model matching tier, sorted

--- a/cmd/models_test.go
+++ b/cmd/models_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/discovery"
-	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 )
 
 func testBedrockConfigForModels() *bedrock.Config {
@@ -152,8 +151,8 @@ func TestBareModelID_StripsRegionalPrefixes(t *testing.T) {
 		{"", ""},
 	}
 	for _, c := range cases {
-		if got := schema.StripRegionPrefix(c.id); got != c.want {
-			t.Errorf("schema.StripRegionPrefix(%q) = %q, want %q", c.id, got, c.want)
+		if got := bedrock.StripRegionPrefix(c.id); got != c.want {
+			t.Errorf("bedrock.StripRegionPrefix(%q) = %q, want %q", c.id, got, c.want)
 		}
 	}
 }

--- a/internal/bedrock/connectivity.go
+++ b/internal/bedrock/connectivity.go
@@ -14,6 +14,24 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 )
 
+// RegionalInferencePrefixes are the Bedrock cross-region inference profile
+// prefixes stripped to recover the bare provider model ID. This is the single
+// source of truth — StripRegionPrefix, schema, and all callers use it.
+var RegionalInferencePrefixes = []string{"global.", "us.", "us-gov.", "eu.", "apac."}
+
+// StripRegionPrefix removes a cross-region inference profile prefix from a
+// model ID, recovering the bare provider model identifier. This is the single
+// exported function for region-prefix stripping — callers in cmd, bedrock, and
+// schema all use it. Uses RegionalInferencePrefixes as the authoritative list.
+func StripRegionPrefix(modelID string) string {
+	for _, prefix := range RegionalInferencePrefixes {
+		if rest, ok := strings.CutPrefix(modelID, prefix); ok {
+			return rest
+		}
+	}
+	return modelID
+}
+
 const defaultTimeout = 15 * time.Second
 
 // httpClient is the client used for connectivity probes. It is a package var so
@@ -155,20 +173,9 @@ func (r *ConnectivityResult) IsAuthFailure() bool {
 	return r.StatusCode == 401 || r.StatusCode == 403
 }
 
-// stripRegionPrefix removes the Bedrock cross-region inference profile prefix so the
-// model ID is valid for direct API calls (InvokeModel). This mirrors
-// schema.StripRegionPrefix but must live here to avoid a circular import:
-// internal/schema imports internal/bedrock (for bedrock.Config in schema.Build),
-// so internal/bedrock cannot import internal/schema back. The prefix list below
-// is kept identical to schema.RegionalInferencePrefixes; if that list changes,
-// update this one too.
+// stripRegionPrefix delegates to the exported StripRegionPrefix.
 func stripRegionPrefix(modelID string) string {
-	for _, prefix := range []string{"global.", "us.", "us-gov.", "eu.", "apac."} {
-		if rest, ok := strings.CutPrefix(modelID, prefix); ok {
-			return rest
-		}
-	}
-	return modelID
+	return StripRegionPrefix(modelID)
 }
 
 func formatResponseError(status int, body []byte) string {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -267,16 +267,11 @@ func buildEnv(cfg *bedrock.Config, opts Options, opus, sonnet, haiku, fable stri
 }
 
 // StripRegionPrefix removes a cross-region inference profile prefix from a
-// model ID, recovering the bare provider model identifier. This is the single
-// exported function for region-prefix stripping — callers in cmd, bedrock, and
-// schema all use it. Uses RegionalInferencePrefixes as the authoritative list.
+// model ID, recovering the bare provider model identifier. This is a re-export
+// of bedrock.StripRegionPrefix for backward compatibility — the authoritative
+// implementation lives in internal/bedrock.
 func StripRegionPrefix(modelID string) string {
-	for _, prefix := range RegionalInferencePrefixes {
-		if rest, ok := strings.CutPrefix(modelID, prefix); ok {
-			return rest
-		}
-	}
-	return modelID
+	return bedrock.StripRegionPrefix(modelID)
 }
 
 // normalizeModelID strips the [1m] context suffix and regional inference
@@ -358,11 +353,9 @@ func (b *Block) AutoModeAvailable() bool {
 		IsAutoModeCapableModel(b.Models.Fable)
 }
 
-// RegionalInferencePrefixes are the Bedrock cross-region inference profile
-// prefixes stripped to recover the bare provider model ID. Keep this the single
-// source of truth so StripRegionPrefix, supportsClaudeCode1M, and
-// IsAutoModeCapableModel all normalize identically.
-var RegionalInferencePrefixes = []string{"global.", "us.", "us-gov.", "eu.", "apac."}
+// RegionalInferencePrefixes is a re-export of bedrock.RegionalInferencePrefixes
+// for backward compatibility.
+var RegionalInferencePrefixes = bedrock.RegionalInferencePrefixes
 
 func mantleModelID(model string) string {
 	return StripRegionPrefix(model)


### PR DESCRIPTION
Fixes the verification panel gap: the local \stripRegionPrefix\ in \connectivity.go\ had a hand-maintained prefix list duplicated from \schema.RegionalInferencePrefixes\.

**What changed:**
- Moved \RegionalInferencePrefixes\ and \StripRegionPrefix\ from \internal/schema\ to \internal/bedrock/connectivity.go\ where they belong conceptually (Bedrock model ID normalization).
- The local \stripRegionPrefix\ in \connectivity.go\ now delegates to the exported \edrock.StripRegionPrefix\ instead of maintaining its own prefix list.
- \schema.StripRegionPrefix\ and \schema.RegionalInferencePrefixes\ remain as re-exports for backward compatibility.
- \cmd/models.go\ now calls \edrock.StripRegionPrefix\ directly.
- Tests updated to use \edrock.StripRegionPrefix\.

**Why bedrock, not schema:** \internal/schema\ imports \internal/bedrock\ (for \edrock.Config\), so \internal/bedrock\ cannot import \internal/schema\ back. Placing the function in \edrock\ breaks the circular import and serves all callers.

**Production behavior:** byte-identical. Same prefix list, same logic, single source of truth.