### PR TITLE
test: cover Claude runtime fallback edge cases

### DIFF
--- a/cmd/apply_reapply_test.go
+++ b/cmd/apply_reapply_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/activation"
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 )
 
 // TestApply_BedrockKey_FlagStoresViaFallback runs a real (non-dry-run) apply
@@ -90,6 +92,59 @@ func TestApply_ProjectScopeDoesNotCreateGlobalRuntimeFallback(t *testing.T) {
 	if _, found, err := activation.LoadRuntimeState(home, "claude"); err != nil || found {
 		t.Fatalf("project apply created global runtime fallback: found %v, err %v", found, err)
 	}
+}
+
+func TestPersistRuntimeStateGuardsAndFailureCleanup(t *testing.T) {
+	originalScope := applyFlags.scope
+	t.Cleanup(func() { applyFlags.scope = originalScope })
+	applyFlags.scope = "user"
+
+	t.Run("provider without persistence", func(t *testing.T) {
+		home := setupApplyTest(t)
+		persistRuntimeState(home, provider.MustGet("codex"), authmode.IAM, provider.ConfigPlan{})
+		if _, found, err := activation.LoadRuntimeState(home, "codex"); err != nil || found {
+			t.Fatalf("non-persistent provider state = found %v, err %v", found, err)
+		}
+	})
+
+	t.Run("case-insensitive token exclusion", func(t *testing.T) {
+		home := setupApplyTest(t)
+		persistRuntimeState(home, provider.MustGet("claude"), authmode.IAM, provider.ConfigPlan{
+			RuntimeEnv: map[string]string{
+				strings.ToLower(authmode.BedrockAuthEnvName): "secret",
+				"AWS_REGION": "us-west-2",
+			},
+		})
+		state, found, err := activation.LoadRuntimeState(home, "claude")
+		if err != nil || !found {
+			t.Fatalf("runtime state = found %v, err %v", found, err)
+		}
+		if _, ok := state.Env[strings.ToLower(authmode.BedrockAuthEnvName)]; ok {
+			t.Fatal("runtime state retained a case-variant bearer token")
+		}
+		if state.Env["CLAUDE_CODE_USE_BEDROCK"] != "1" || state.Env["AWS_REGION"] != "us-west-2" {
+			t.Fatalf("runtime state omitted routing environment: %v", state.Env)
+		}
+	})
+
+	t.Run("failed save removes stale state", func(t *testing.T) {
+		home := setupApplyTest(t)
+		if err := activation.SaveRuntimeState(home, "claude", activation.RuntimeState{
+			AuthMode: authmode.IAM,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		stderr := captureStderr(t, func() {
+			persistRuntimeState(home, provider.MustGet("claude"), "invalid", provider.ConfigPlan{})
+		})
+		if !strings.Contains(stderr, "could not save runtime fallback") {
+			t.Fatalf("missing persistence warning: %q", stderr)
+		}
+		if _, found, err := activation.LoadRuntimeState(home, "claude"); err != nil || found {
+			t.Fatalf("stale state after failed save = found %v, err %v", found, err)
+		}
+	})
 }
 
 // TestApply_ReapplyWithoutAuth_PreservesExistingMode verifies the documented

--- a/cmd/apply_test_helpers_test.go
+++ b/cmd/apply_test_helpers_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -121,6 +123,33 @@ func setNativeDefaultMode(t *testing.T, home, mode string) {
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	return testutil.CaptureStdout(t, fn)
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = orig
+		_ = r.Close()
+		_ = w.Close()
+	}()
+
+	fn()
+
+	os.Stderr = orig
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stderr pipe: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stderr pipe: %v", err)
+	}
+	return string(out)
 }
 
 // withStdin replaces os.Stdin with a pipe preloaded with input for the duration

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -391,6 +391,82 @@ func TestCheckRuntimeFallback_OKWithManagedConfig(t *testing.T) {
 	}
 }
 
+func TestCheckRuntimeFallbackEdgeCases(t *testing.T) {
+	t.Run("provider without persistence", func(t *testing.T) {
+		r := doctor.NewReport()
+		checkRuntimeFallback(r, provider.MustGet("codex"), testutil.NewTestHome(t))
+		if out := r.String(); out != "" {
+			t.Fatalf("non-persistent provider reported runtime fallback:\n%s", out)
+		}
+	})
+
+	t.Run("missing state", func(t *testing.T) {
+		r := doctor.NewReport()
+		checkRuntimeFallback(r, provider.MustGet("claude"), testutil.NewTestHome(t))
+		if out := r.String(); out != "" {
+			t.Fatalf("missing runtime fallback produced a report:\n%s", out)
+		}
+	})
+
+	t.Run("invalid state", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		path, err := activation.RuntimeStatePath(home, "claude")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := safepath.WriteFile(home, path, []byte(`{`)); err != nil {
+			t.Fatal(err)
+		}
+
+		r := doctor.NewReport()
+		checkRuntimeFallback(r, provider.MustGet("claude"), home)
+		out := r.String()
+		if !strings.Contains(out, "[WARN]") || !strings.Contains(out, "invalid:") ||
+			!strings.Contains(out, "juggernaut apply") {
+			t.Fatalf("invalid fallback report:\n%s", out)
+		}
+	})
+
+	t.Run("unreadable user config", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		if err := activation.SaveRuntimeState(home, "claude", activation.RuntimeState{
+			AuthMode: authmode.IAM,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		configPath, err := provider.MustGet("claude").ConfigPath(home, "user")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := safepath.MkdirAll(configPath); err != nil {
+			t.Fatal(err)
+		}
+
+		r := doctor.NewReport()
+		checkRuntimeFallback(r, provider.MustGet("claude"), home)
+		out := r.String()
+		if !strings.Contains(out, "[WARN]") || !strings.Contains(out, "could not be read") {
+			t.Fatalf("unreadable config report:\n%s", out)
+		}
+	})
+}
+
+func TestDoctorProjectScopeSkipsUserRuntimeFallback(t *testing.T) {
+	home := setupApplyTest(t)
+	if err := activation.SaveRuntimeState(home, "claude", activation.RuntimeState{
+		AuthMode: authmode.IAM,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		_ = ExecuteArgs([]string{"doctor", "--scope=project"})
+	})
+	if strings.Contains(out, "runtime fallback") {
+		t.Fatalf("project-only doctor reported user runtime fallback:\n%s", out)
+	}
+}
+
 func TestCliBinaryStatus_WarnWhenMissing(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	prov, err := provider.Get("opencode")

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -286,4 +287,90 @@ func TestUninstall_NothingInstalled(t *testing.T) {
 	if strings.Contains(out, "Removed juggernaut block") {
 		t.Errorf("clean home should not report a removed block, got:\n%s", out)
 	}
+}
+
+func TestRemoveRuntimeStateGuardsAndFailures(t *testing.T) {
+	originalFlags := uninstallFlags
+	t.Cleanup(func() { uninstallFlags = originalFlags })
+
+	t.Run("project scope preserves user state", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		if err := activation.SaveRuntimeState(home, "claude", activation.RuntimeState{AuthMode: "iam"}); err != nil {
+			t.Fatal(err)
+		}
+		uninstallFlags.scope = "project"
+		uninstallFlags.dryRun = false
+
+		removeRuntimeState(home, provider.MustGet("claude"))
+		if _, found, err := activation.LoadRuntimeState(home, "claude"); err != nil || !found {
+			t.Fatalf("project uninstall state = found %v, err %v", found, err)
+		}
+	})
+
+	t.Run("provider without persistence preserves state", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		if err := activation.SaveRuntimeState(home, "codex", activation.RuntimeState{AuthMode: "iam"}); err != nil {
+			t.Fatal(err)
+		}
+		uninstallFlags.scope = "user"
+		uninstallFlags.dryRun = false
+
+		removeRuntimeState(home, provider.MustGet("codex"))
+		if _, found, err := activation.LoadRuntimeState(home, "codex"); err != nil || !found {
+			t.Fatalf("non-persistent provider state = found %v, err %v", found, err)
+		}
+	})
+
+	t.Run("dry run ignores missing state", func(t *testing.T) {
+		uninstallFlags.scope = "user"
+		uninstallFlags.dryRun = true
+		out := captureStdout(t, func() {
+			removeRuntimeState(testutil.NewTestHome(t), provider.MustGet("claude"))
+		})
+		if out != "" {
+			t.Fatalf("missing fallback produced dry-run output: %q", out)
+		}
+	})
+
+	t.Run("dry run ignores invalid state", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		path, err := activation.RuntimeStatePath(home, "claude")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := safepath.WriteFile(home, path, []byte(`{`)); err != nil {
+			t.Fatal(err)
+		}
+		uninstallFlags.scope = "user"
+		uninstallFlags.dryRun = true
+		out := captureStdout(t, func() {
+			removeRuntimeState(home, provider.MustGet("claude"))
+		})
+		if out != "" {
+			t.Fatalf("invalid fallback produced dry-run output: %q", out)
+		}
+	})
+
+	t.Run("remove failure warns", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		path, err := activation.RuntimeStatePath(home, "claude")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := safepath.MkdirAll(path); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "keep"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		uninstallFlags.scope = "user"
+		uninstallFlags.dryRun = false
+
+		stderr := captureStderr(t, func() {
+			removeRuntimeState(home, provider.MustGet("claude"))
+		})
+		if !strings.Contains(stderr, "could not remove runtime fallback") {
+			t.Fatalf("missing removal warning: %q", stderr)
+		}
+	})
 }

--- a/internal/activation/activation_test.go
+++ b/internal/activation/activation_test.go
@@ -713,6 +713,12 @@ func TestEnvironmentHelpersRespectPlatformKeySemantics(t *testing.T) {
 	}
 }
 
+func TestEnvEntryHasKeyRejectsEntryWithoutSeparator(t *testing.T) {
+	if envEntryHasKey("AWS_REGION", "AWS_REGION") {
+		t.Fatal("environment entry without '=' must not match")
+	}
+}
+
 func TestLaunchWithoutSettingsDoesNotForceBedrockEnv(t *testing.T) {
 	home := testutil.NewTestHome(t)
 	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "")

--- a/internal/activation/launch_cli_test.go
+++ b/internal/activation/launch_cli_test.go
@@ -276,6 +276,7 @@ func TestReadAuthModeFromConfig(t *testing.T) {
 // token injected, no static env).
 func TestLaunchWithOptions_Codex_NoConfigFile(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "")
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
 	home := testutil.NewTestHome(t)
 
 	realDir := t.TempDir()
@@ -319,6 +320,7 @@ func TestLaunchWithOptions_Codex_NoConfigFile(t *testing.T) {
 // unmanaged behavior (no token injected).
 func TestLaunchWithOptions_Codex_BadConfigFile(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_USE_BEDROCK", "")
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
 	home := testutil.NewTestHome(t)
 
 	realDir := t.TempDir()

--- a/internal/activation/runtime_state_test.go
+++ b/internal/activation/runtime_state_test.go
@@ -139,6 +139,7 @@ func TestLoadRuntimeStateRejectsMalformedAndMismatchedFiles(t *testing.T) {
 		`{`,
 		`{"schemaVersion":99,"managedBy":"juggernaut","cli":"claude","authMode":"iam"}`,
 		`{"schemaVersion":1,"managedBy":"other","cli":"claude","authMode":"iam"}`,
+		`{"schemaVersion":1,"managedBy":"juggernaut","cli":"claude","authMode":"unknown"}`,
 	} {
 		if err := safepath.WriteFile(home, path, []byte(data)); err != nil {
 			t.Fatal(err)
@@ -146,5 +147,86 @@ func TestLoadRuntimeStateRejectsMalformedAndMismatchedFiles(t *testing.T) {
 		if _, _, err := LoadRuntimeState(home, "claude"); err == nil {
 			t.Fatalf("LoadRuntimeState should reject %s", data)
 		}
+	}
+}
+
+func TestRuntimeStateOperationsRejectInvalidCLI(t *testing.T) {
+	home := testutil.NewTestHome(t)
+
+	if _, found, err := LoadRuntimeState(home, "../claude"); err == nil || found {
+		t.Fatalf("LoadRuntimeState invalid CLI = found %v, err %v; want error", found, err)
+	}
+	if err := RemoveRuntimeState(home, "../claude"); err == nil {
+		t.Fatal("RemoveRuntimeState should reject an invalid CLI")
+	}
+}
+
+func TestSaveRuntimeStateReportsFilesystemFailures(t *testing.T) {
+	state := RuntimeState{AuthMode: authmode.IAM}
+
+	t.Run("write", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		if err := os.WriteFile(filepath.Join(home, ".juggernaut"), []byte("not a directory"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		err := SaveRuntimeState(home, "claude", state)
+		if err == nil || !strings.Contains(err.Error(), "writing runtime state") {
+			t.Fatalf("SaveRuntimeState write error = %v", err)
+		}
+	})
+
+	t.Run("rename cleans temporary file", func(t *testing.T) {
+		home := testutil.NewTestHome(t)
+		path, err := RuntimeStatePath(home, "claude")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := safepath.MkdirAll(path); err != nil {
+			t.Fatal(err)
+		}
+
+		err = SaveRuntimeState(home, "claude", state)
+		if err == nil || !strings.Contains(err.Error(), "committing runtime state") {
+			t.Fatalf("SaveRuntimeState rename error = %v", err)
+		}
+		if _, statErr := os.Stat(path + ".tmp"); !os.IsNotExist(statErr) {
+			t.Fatalf("temporary runtime state was not cleaned up: %v", statErr)
+		}
+	})
+}
+
+func TestLoadRuntimeStateReportsReadFailure(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	path, err := RuntimeStatePath(home, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := safepath.MkdirAll(path); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, found, err := LoadRuntimeState(home, "claude"); err == nil || found ||
+		!strings.Contains(err.Error(), "reading runtime state") {
+		t.Fatalf("LoadRuntimeState directory = found %v, err %v", found, err)
+	}
+}
+
+func TestRemoveRuntimeStateReportsFilesystemFailure(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	path, err := RuntimeStatePath(home, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := safepath.MkdirAll(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err = RemoveRuntimeState(home, "claude")
+	if err == nil || !strings.Contains(err.Error(), "removing runtime state") {
+		t.Fatalf("RemoveRuntimeState error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Adds the missing edge-case coverage for the Claude runtime fallback introduced in #357. This exercises malformed state, filesystem failures, doctor diagnostics, persistence cleanup, uninstall guards, and platform environment handling.

## Changes
- Cover runtime-state validation, read/write/rename/remove failures, and temporary-file cleanup
- Cover every doctor, persistence, and uninstall fallback branch
- Make unmanaged Codex launch tests independent of ambient bearer-token environment

## Coverage
- `checkRuntimeFallback`: 64.3% -> 100%
- `persistRuntimeState`: 83.3% -> 100%
- `removeRuntimeState`: 87.5% -> 100%
- `LoadRuntimeState`: 83.3% -> 100%
- `RemoveRuntimeState`: 66.7% -> 100%
- `SaveRuntimeState`: 73.3% -> 93.3% (the only remaining branch is the unreachable `json.MarshalIndent` error for a fixed string-only schema)
- Linux project coverage: 87.2%

## Testing
- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] `go vet ./...` passes
- [x] `cd npm && npm test` passes
- [ ] `make ci` passes when local tools are available (golangci-lint is not installed locally; GitHub CI runs it)
- [x] Tested on: Linux; GitHub CI covers macOS and Windows

## Documentation
- [x] No documentation changes required; this is a test-only follow-up

## Related Issues
Follow-up to #357