### PR TITLE
test: suppress bogus Codacy permission finding in doctor test

### DIFF
--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -781,7 +781,7 @@ func TestCheckConnectivity_MissingJuggernautBlock(t *testing.T) {
 	home := setupApplyTest(t)
 	// Ensure the .claude directory exists.
 	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil { // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- directory
 		t.Fatal(err)
 	}
 	// Write a settings.json with no juggernaut block.


### PR DESCRIPTION
Suppresses the High-severity Semgrep finding \go.lang.correctness.permissions.file_permission.incorrect-default-permission\ at \cmd/doctor_test.go:784\ with the repo-standard \
osemgrep\ comment (0o700 is correct for directories in a test home). No behavior change.