### PR TITLE
test: annotate Semgrep false positives in coverage batch 1

### DIFF
--- a/cmd/coverage_batch1_test.go
+++ b/cmd/coverage_batch1_test.go
@@ -272,7 +272,7 @@ func TestRunModelsCheck_WritePersistsAndRecomputes(t *testing.T) {
 		t.Errorf("expected updated message, got:\n%s", out)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(dir, "bedrock-config.json"))
+	raw, err := os.ReadFile(filepath.Join(dir, "bedrock-config.json")) // nosemgrep: go_filesystem_rule-fileread — path under t.TempDir()
 	if err != nil {
 		t.Fatalf("reading rewritten config: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestWriteBedrockConfigFile_CreatesMissingModelsKey(t *testing.T) {
 		t.Fatalf("writeBedrockConfigFile: %v", err)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(dir, "bedrock-config.json"))
+	raw, err := os.ReadFile(filepath.Join(dir, "bedrock-config.json")) // nosemgrep: go_filesystem_rule-fileread — path under t.TempDir()
 	if err != nil {
 		t.Fatalf("reading config: %v", err)
 	}
@@ -645,7 +645,7 @@ func TestReportLegacyRecovery_ErrorWarns(t *testing.T) {
 	if err := os.Chmod(binDir, 0o555); err != nil {
 		t.Fatalf("chmod binDir: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(binDir, 0o700) })
+	t.Cleanup(func() { _ = os.Chmod(binDir, 0o700) }) // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission, go_file-permissions_rule-fileperm -- restore dir perms for cleanup
 
 	out := captureStderr(t, func() { reportLegacyRecovery(home) })
 	if !strings.Contains(out, "could not recover legacy artifacts") {


### PR DESCRIPTION
Codacy flagged three new findings in `cmd/coverage_batch1_test.go`, all Semgrep false positives on paths/permission-restores under `t.TempDir()`:

- `go_filesystem_rule-fileread` (Error) — `os.ReadFile(filepath.Join(dir, "bedrock-config.json"))`
- `go_file-permissions-rule-fileperm` (High) + `incorrect-default-permission` (High) — `t.Cleanup` chmod restoring `0o700` on the bin dir

Fix: `// nosemgrep` annotations matching the repo's established convention (`cmd/doctor_test.go:526`, `cmd/apply_test.go:829`), plus the same annotation on the duplicate `ReadFile` at line 275 so the rule can't re-fire next analysis.

Verification: `gofmt` clean, `go vet ./cmd/` clean, `go test ./cmd/` passes, `git diff --check` clean. Local `golangci-lint` unavailable (Go 1.25 binary vs repo target 1.26.5); CI is the real gate.

Touch quality: skipped — comment-only diff, no behavior or complexity change.