### PR TITLE
docs: document git hook enforcement in AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,16 @@ Use conventional commit subjects when asked to commit. Release tags are `v*`
 and trigger GitHub release publishing plus npm OIDC publish; do not create or
 push a release tag unless explicitly requested.
 
+Installed git hooks (`scripts/setup-hooks.{sh,ps1}`, sourced from `.githooks/`)
+enforce more than conventional defaults and will fail your commit/push:
+
+- `commit-msg` — first line must be a **single-type** Conventional Commit:
+  `docs+test: ...` is rejected, `type(scope?): description` is required.
+- `pre-commit` — fails if `go fmt` / `go mod tidy` would change staged Go files.
+- `pre-push` — fails if a changed Go file gains a function at 0.0% coverage. An
+  early warning only — CI's Codecov patch gate is the authority. Documented
+  emergency bypass: `git push --no-verify`.
+
 `main` is protected by a GitHub **ruleset**, not classic branch protection, so
 `gh api repos/.../branches/main/protection` returns 404 — query
 `gh api repos/jpvelasco/juggernaut/rulesets` instead. The active `protect-main`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,11 @@ make codacy
 
 Hooks live in `.githooks/` (tracked) and are installed into `.git/hooks/` via `scripts/setup-hooks.sh`/`.ps1` (see Commands above) — install once per clone.
 
-- **pre-commit**: runs `gofmt -l` and `go vet` on staged Go files, then `go mod tidy` (fails if `go.mod`/`go.sum` change)
-- **commit-msg**: enforces Conventional Commits (`feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`)
-- **pre-push**: fails if any changed non-test Go file has a function at 0.0% coverage (early catch; bypass with `git push --no-verify` in emergencies)
+- **pre-commit**: runs `gofmt` and `go mod tidy` against staged Go files; fails if either would change a file (i.e. `go vet` is not run here — that's a separate `make vet`/CI step)
+- **commit-msg**: enforces a **single-type** Conventional Commit on the first line — `type(scope?): description` with `type` one of `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`; a combined type like `docs+test: ...` is rejected
+- **pre-push**: fails if any changed non-test Go file has a function at exactly 0.0% coverage (bypass with `git push --no-verify` in emergencies)
 
-The hooks are a convenience — **CI is the real gate**: Codecov's `patch` status (target 80%, in `codecov.yml`) runs on every PR and cannot be bypassed locally.
+The hooks are an early warning, not the authority — **CI is the real gate**: Codecov's `patch` status (target 80%, in `codecov.yml`) runs on every PR and cannot be bypassed locally.
 
 ## Architecture
 


### PR DESCRIPTION
## What

Adds the installed git hook enforcement to the Git and Scope section of
\AGENTS.md\ and aligns the hook docs in \CLAUDE.md\ with the actual enforced
behavior, so future sessions don't get surprised by hook failures:

- \commit-msg\ — first line must be a **single-type** Conventional Commit
  (\docs+test:\ is rejected, \	ype(scope?): description\ is required).
- \pre-commit\ — fails if \go fmt\ / \go mod tidy\ would change staged Go files;
  \go vet\ is not run here (separate \make vet\/CI step).
- \pre-push\ — fails if a changed Go file gains a function at 0.0% coverage;
  early warning only, Codecov patch gate is the authority, \--no-verify\ is the
  documented bypass.

Verified against \.githooks/\ before writing — the enforcement text matches the
hooks exactly. Docs-only change; no code affected.

## Notes

- Hooks are installed from \.githooks/\ via \scripts/setup-hooks.{sh,ps1}\.
- The \legacy/v3\ protected-branch note was already present and left unchanged.