### PR TITLE
test: Codex provider-parity hardening

### DIFF
--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -266,6 +266,65 @@ func TestApply_Codex_ForeignConfig_DottedLeafCollision_Refuses(t *testing.T) {
 	if !strings.Contains(err.Error(), "model_providers.amazon-bedrock.aws.region") {
 		t.Errorf("error should name the colliding dotted path, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force, got: %v", err)
+	}
+
+	// The foreign file must be untouched — refusal happens before any write.
+	got, err := safepath.ReadFile(codexDir, configPath)
+	if err != nil {
+		t.Fatalf("reading config.toml: %v", err)
+	}
+	if string(got) != foreign {
+		t.Errorf("foreign codex config must be untouched on refusal, got: %s", got)
+	}
+}
+
+// TestApply_Codex_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting:
+// --dry-run must surface the same refusal information for Codex (the exact
+// colliding dotted path, plus the --force hint) without writing anything or
+// creating a backup. This is the same contract Claude's dry-run test locks
+// in — provider-agnostic behavior that only Claude was pinning down.
+func TestApply_Codex_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting(t *testing.T) {
+	home := setupApplyTest(t)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := safepath.MkdirAll(codexDir); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	configPath := filepath.Join(codexDir, "config.toml")
+	foreign := "model = \"their-model\"\n\n[model_providers.amazon-bedrock.aws]\nregion = \"eu-west-1\"\n"
+	if err := safepath.WriteFile(codexDir, configPath, []byte(foreign)); err != nil {
+		t.Fatalf("write foreign codex config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		err := ExecuteArgs([]string{
+			"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-east-1", "--dry-run", "--skip-preflight",
+		})
+		if err != nil {
+			t.Fatalf("dry-run should not error, it should report: %v", err)
+		}
+	})
+	if !strings.Contains(out, "model_providers.amazon-bedrock.aws.region") {
+		t.Errorf("dry-run should report the colliding dotted path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--force") {
+		t.Errorf("dry-run should mention --force, got:\n%s", out)
+	}
+
+	got, err := safepath.ReadFile(codexDir, configPath)
+	if err != nil {
+		t.Fatalf("reading config.toml: %v", err)
+	}
+	if string(got) != foreign {
+		t.Error("dry-run must not modify the foreign file")
+	}
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) != 0 {
+		t.Error("dry-run must not create a backup")
+	}
 }
 
 // TestApply_OpenCode_ForeignConfig_Refuses: OpenCode's whole-value "model" key

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -358,6 +358,50 @@ func TestCheckProviderConfigScope_CodexOwnedOK(t *testing.T) {
 	}
 }
 
+// TestDoctor_Codex_MissingConfig_FailsWithGuidance: doctor --cli=codex on a
+// fresh home fails the config check with actionable apply guidance — the
+// end-to-end wiring of checkProviderConfigScope into runDoctor for a
+// non-Claude CLI.
+func TestDoctor_Codex_MissingConfig_FailsWithGuidance(t *testing.T) {
+	_ = setupApplyTest(t)
+
+	out := captureStdout(t, func() {
+		err := ExecuteArgs([]string{"doctor", "--cli=codex"})
+		if err == nil {
+			t.Fatal("expected doctor to fail when codex is not configured")
+		}
+	})
+	if !strings.Contains(out, "config.toml (user)") {
+		t.Errorf("expected the codex config check line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "run `juggernaut apply --cli=codex`") {
+		t.Errorf("expected apply --cli=codex guidance, got:\n%s", out)
+	}
+}
+
+// TestDoctor_Codex_HealthyAfterApply: after a real codex apply, doctor
+// --cli=codex reports the user config as juggernaut-managed and finds no
+// failures — the mirror image of the missing-config case.
+func TestDoctor_Codex_HealthyAfterApply(t *testing.T) {
+	_ = setupApplyTest(t)
+	setupIsolatedKeychain(t) // stores a real credential; skip if keychain backend hangs (macOS CI)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply --cli=codex: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"doctor", "--cli=codex"}); err != nil {
+			t.Fatalf("doctor --cli=codex should find no failures after apply: %v", err)
+		}
+	})
+	if !strings.Contains(out, "juggernaut-managed Bedrock config present") {
+		t.Errorf("expected managed-config OK check, got:\n%s", out)
+	}
+}
+
 func TestCheckRuntimeFallback_ReportsConfigDrift(t *testing.T) {
 	home := testutil.NewTestHome(t)
 	prov := provider.MustGet("claude")

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -225,6 +225,73 @@ func TestUninstall_Codex_ActuallyRemoves(t *testing.T) {
 	}
 }
 
+// TestUninstall_Codex_PreservesUserSiblingKeys: uninstall removes ONLY the
+// leaves Juggernaut owns. A user's own top-level keys, their own
+// model_providers entries, and sibling settings inside the
+// model_providers.amazon-bedrock.aws table must survive — uninstall is a
+// leaf-prune, not a data wipe.
+func TestUninstall_Codex_PreservesUserSiblingKeys(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t) // apply stores a real credential; skip if keychain backend hangs (macOS CI)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Inject user-owned sibling content: a top-level key, a provider entry of
+	// their own, and a sibling inside the same aws table Juggernaut writes into.
+	cfgPath := filepath.Join(home, ".codex", "config.toml")
+	tomlFmt, _ := config.FormatByName("toml")
+	mgr := config.NewManagerWithFormat(cfgPath, tomlFmt)
+	got, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse config.toml: %v", err)
+	}
+	got["telemetry"] = false
+	mp := got["model_providers"].(map[string]any)
+	mp["my-own"] = map[string]any{"base_url": "http://192.168.0.1/v1", "env_key": "MY_OWN_KEY"}
+	aws := mp["amazon-bedrock"].(map[string]any)["aws"].(map[string]any)
+	aws["profile"] = "bedrock-ops"
+	if err := mgr.Write(got); err != nil {
+		t.Fatalf("writing config.toml: %v", err)
+	}
+
+	if err := ExecuteArgs([]string{
+		"uninstall", "--cli=codex", "--force",
+	}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	after, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse config.toml after uninstall: %v", err)
+	}
+	for _, key := range []string{"model", "model_provider", "juggernaut"} {
+		if _, ok := after[key]; ok {
+			t.Errorf("managed key %q should be removed, got: %v", key, after[key])
+		}
+	}
+	if after["telemetry"] != false {
+		t.Errorf("user's top-level 'telemetry' key must survive, got: %v", after["telemetry"])
+	}
+	mpAfter, ok := after["model_providers"].(map[string]any)
+	if !ok {
+		t.Fatalf("model_providers table vanished — user providers must survive, got: %v", after["model_providers"])
+	}
+	if _, ok := mpAfter["my-own"]; !ok {
+		t.Error("user's own provider entry lost on uninstall — data loss!")
+	}
+	awsAfter := mpAfter["amazon-bedrock"].(map[string]any)["aws"].(map[string]any)
+	if _, ok := awsAfter["region"]; ok {
+		t.Error("Juggernaut's region leaf should be removed")
+	}
+	if awsAfter["profile"] != "bedrock-ops" {
+		t.Error("user's aws.profile sibling must survive uninstall")
+	}
+}
+
 // TestApply_Codex_IAM_Allowed: Codex now supports IAM via the AWS SDK credential
 // chain, so apply --cli=codex --auth=iam must succeed (not rejected).
 func TestApply_Codex_IAM_Allowed(t *testing.T) {


### PR DESCRIPTION
## Summary

Provider-parity hardening, PR 1 of 4: bring Codex's safety-critical test density in line with Claude (the gold standard). Test-only — no feature work, no architecture changes.

## What's covered

- **Collision refusal (strengthened)** — `TestApply_Codex_ForeignConfig_DottedLeafCollision_Refuses` now also asserts the error mentions `--force` and the foreign file is byte-for-byte untouched (refusal happens before any write).
- **Dry-run collision report (new)** — `TestApply_Codex_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting`: `--dry-run` surfaces the exact colliding dotted path + `--force` hint, writes nothing, creates no backup. Mirrors Claude's existing dry-run contract, which only Claude was pinning down.
- **Uninstall leaf-prune (new)** — `TestUninstall_Codex_PreservesUserSiblingKeys`: end-to-end `uninstall --cli=codex` removes `model`, `model_provider`, `juggernaut`, and the `model_providers.amazon-bedrock.aws.region` leaf while preserving the user's top-level keys, their own provider entries, and siblings inside the same `aws` table.
- **doctor --cli=codex end-to-end (new)** — `TestDoctor_Codex_MissingConfig_FailsWithGuidance` (FAIL + `apply --cli=codex` guidance on fresh home) and `TestDoctor_Codex_HealthyAfterApply` (juggernaut-managed OK after real apply). Helper-level coverage existed; the runDoctor wiring for non-Claude CLIs did not.

Every test exercises a real branch/error path (Irreducible Coverage Floor rule) and reuses existing fixtures (`setupApplyTest`, `setupIsolatedKeychain`, `bedrockKeyFlag`, `captureStdout`, `safepath`, `config.Manager`).

## Verification

- `go test ./...` — green (all packages)
- `go vet ./...` — clean
- `gofmt -l` — clean
- `git diff --check` — clean
- Touch quality: clean — tests reuse existing helpers; no new structural duplication

## Coverage impact

New assertions target previously untested branch wiring: codex dry-run collision report, codex uninstall leaf-prune through the cmd layer, and non-Claude `doctor` runDoctor paths (`checkProviderConfigScope` fail/OK branches end-to-end).
