### PR TITLE
test: OpenCode provider-parity hardening

### DIFF
--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -354,6 +354,9 @@ func TestApply_OpenCode_ForeignConfig_Refuses(t *testing.T) {
 	if !strings.Contains(err.Error(), "model") {
 		t.Errorf("error should name the colliding path, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force, got: %v", err)
+	}
 
 	got, err := safepath.ReadFile(opencodeDir, configPath)
 	if err != nil {
@@ -361,6 +364,52 @@ func TestApply_OpenCode_ForeignConfig_Refuses(t *testing.T) {
 	}
 	if string(got) != foreign {
 		t.Errorf("foreign opencode config must be untouched on refusal, got: %s", got)
+	}
+}
+
+// TestApply_OpenCode_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting:
+// --dry-run must surface the same refusal information for OpenCode without
+// writing anything or creating a backup — the Claude dry-run contract applied
+// to OpenCode.
+func TestApply_OpenCode_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting(t *testing.T) {
+	home := setupApplyTest(t)
+
+	opencodeDir := filepath.Join(home, ".config", "opencode")
+	if err := safepath.MkdirAll(opencodeDir); err != nil {
+		t.Fatalf("mkdir opencode config dir: %v", err)
+	}
+	configPath := filepath.Join(opencodeDir, "opencode.json")
+	foreign := `{"model": "their-own-provider/their-own-model"}`
+	if err := safepath.WriteFile(opencodeDir, configPath, []byte(foreign)); err != nil {
+		t.Fatalf("write foreign opencode config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		err := ExecuteArgs([]string{
+			"apply", "--cli=opencode", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-west-2", "--dry-run", "--skip-preflight",
+		})
+		if err != nil {
+			t.Fatalf("dry-run should not error, it should report: %v", err)
+		}
+	})
+	if !strings.Contains(out, "model") {
+		t.Errorf("dry-run should report the colliding key, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--force") {
+		t.Errorf("dry-run should mention --force, got:\n%s", out)
+	}
+
+	got, err := safepath.ReadFile(opencodeDir, configPath)
+	if err != nil {
+		t.Fatalf("reading opencode.json: %v", err)
+	}
+	if string(got) != foreign {
+		t.Error("dry-run must not modify the foreign file")
+	}
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) != 0 {
+		t.Error("dry-run must not create a backup")
 	}
 }
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -402,6 +402,48 @@ func TestDoctor_Codex_HealthyAfterApply(t *testing.T) {
 	}
 }
 
+// TestDoctor_OpenCode_MissingConfig_FailsWithGuidance: doctor --cli=opencode
+// on a fresh home fails the config check with actionable apply guidance.
+func TestDoctor_OpenCode_MissingConfig_FailsWithGuidance(t *testing.T) {
+	_ = setupApplyTest(t)
+
+	out := captureStdout(t, func() {
+		err := ExecuteArgs([]string{"doctor", "--cli=opencode"})
+		if err == nil {
+			t.Fatal("expected doctor to fail when opencode is not configured")
+		}
+	})
+	if !strings.Contains(out, "opencode.json (user)") {
+		t.Errorf("expected the opencode config check line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "run `juggernaut apply --cli=opencode`") {
+		t.Errorf("expected apply --cli=opencode guidance, got:\n%s", out)
+	}
+}
+
+// TestDoctor_OpenCode_HealthyAfterApply: after a real opencode apply, doctor
+// --cli=opencode reports the user config as juggernaut-managed and finds no
+// failures.
+func TestDoctor_OpenCode_HealthyAfterApply(t *testing.T) {
+	_ = setupApplyTest(t)
+	setupIsolatedKeychain(t) // stores a real credential; skip if keychain backend hangs (macOS CI)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=opencode", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply --cli=opencode: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"doctor", "--cli=opencode"}); err != nil {
+			t.Fatalf("doctor --cli=opencode should find no failures after apply: %v", err)
+		}
+	})
+	if !strings.Contains(out, "juggernaut-managed Bedrock config present") {
+		t.Errorf("expected managed-config OK check, got:\n%s", out)
+	}
+}
+
 func TestCheckRuntimeFallback_ReportsConfigDrift(t *testing.T) {
 	home := testutil.NewTestHome(t)
 	prov := provider.MustGet("claude")

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -292,6 +292,63 @@ func TestUninstall_Codex_PreservesUserSiblingKeys(t *testing.T) {
 	}
 }
 
+// TestUninstall_OpenCode_PreservesUserSiblingKeys: uninstall --cli=opencode
+// removes ONLY Juggernaut's owned leaves — the top-level "model" key and the
+// bedrock-mantle provider block. A user's own provider entries and their own
+// top-level keys must survive.
+func TestUninstall_OpenCode_PreservesUserSiblingKeys(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t) // apply stores a real credential; skip if keychain backend hangs (macOS CI)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=opencode", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Inject user-owned sibling content: a top-level key and a provider of
+	// their own next to the bedrock-mantle block Juggernaut wrote.
+	configPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	mgr := config.NewManager(configPath)
+	got, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse opencode.json: %v", err)
+	}
+	got["theme"] = "dark"
+	prov := got["provider"].(map[string]any)
+	prov["anthropic"] = map[string]any{"npm": "@ai-sdk/anthropic", "options": map[string]any{"apiKey": "sk-ant-own-key"}}
+	if err := mgr.Write(got); err != nil {
+		t.Fatalf("writing opencode.json: %v", err)
+	}
+
+	if err := ExecuteArgs([]string{
+		"uninstall", "--cli=opencode", "--force",
+	}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	after, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse opencode.json after uninstall: %v", err)
+	}
+	if _, ok := after["model"]; ok {
+		t.Error("managed 'model' key should be removed")
+	}
+	if after["theme"] != "dark" {
+		t.Errorf("user's top-level 'theme' key must survive, got: %v", after["theme"])
+	}
+	provAfter, ok := after["provider"].(map[string]any)
+	if !ok {
+		t.Fatalf("provider table vanished — user providers must survive, got: %v", after["provider"])
+	}
+	if _, ok := provAfter["bedrock-mantle"]; ok {
+		t.Error("Juggernaut's bedrock-mantle provider should be removed")
+	}
+	if _, ok := provAfter["anthropic"]; !ok {
+		t.Error("user's own provider entry lost on uninstall — data loss!")
+	}
+}
+
 // TestApply_Codex_IAM_Allowed: Codex now supports IAM via the AWS SDK credential
 // chain, so apply --cli=codex --auth=iam must succeed (not rejected).
 func TestApply_Codex_IAM_Allowed(t *testing.T) {


### PR DESCRIPTION
## Summary

Provider-parity hardening, PR 2 of 4: bring OpenCode's safety-critical test density in line with Claude (the gold standard). Test-only — no feature work, no architecture changes.

## What's covered

- **Collision refusal (strengthened)** — `TestApply_OpenCode_ForeignConfig_Refuses` now also asserts the error mentions `--force`.
- **Dry-run collision report (new)** — `TestApply_OpenCode_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting`: `--dry-run` surfaces the colliding `model` key + `--force` hint, writes nothing, creates no backup. Mirrors the Claude dry-run contract, which only Claude was pinning down.
- **Uninstall leaf-prune (new)** — `TestUninstall_OpenCode_PreservesUserSiblingKeys`: end-to-end `uninstall --cli=opencode` removes `model` and the `provider.bedrock-mantle` block while preserving the user's top-level keys and their own provider entries next to bedrock-mantle.
- **doctor --cli=opencode end-to-end (new)** — `TestDoctor_OpenCode_MissingConfig_FailsWithGuidance` (FAIL + `apply --cli=opencode` guidance on fresh home) and `TestDoctor_OpenCode_HealthyAfterApply` (juggernaut-managed OK after real apply).

Every test exercises a real branch/error path (Irreducible Coverage Floor rule) and reuses existing fixtures (`setupApplyTest`, `setupIsolatedKeychain`, `bedrockKeyFlag`, `captureStdout`, `safepath`, `config.Manager`).

## Verification

- `go test ./...` — green (all packages)
- `go vet ./...` — clean
- `gofmt -l` — clean
- `git diff --check` — clean
- Touch quality: clean — tests reuse existing helpers; no new structural duplication

## Coverage impact

New assertions pin down non-Claude `doctor` runDoctor wiring and the opencode dry-run / uninstall leaf-prune paths end-to-end.