### PR TITLE
test: Grok provider-parity hardening

### DIFF
--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -189,6 +189,9 @@ func TestApply_Grok_ForeignConfig_Refuses(t *testing.T) {
 	if !strings.Contains(err.Error(), "models.default") {
 		t.Errorf("error should name the colliding path, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force, got: %v", err)
+	}
 
 	got, err := safepath.ReadFile(grokDir, configPath)
 	if err != nil {
@@ -235,6 +238,52 @@ func TestApply_Grok_ForeignConfig_SiblingProfileSurvivesNoForceNeeded(t *testing
 	}
 	if !strings.Contains(string(got), "bedrock-grok") {
 		t.Error("expected Juggernaut's bedrock-grok block to be written")
+	}
+}
+
+// TestApply_Grok_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting:
+// --dry-run must surface the same refusal information for Grok without writing
+// anything or creating a backup — the Claude dry-run contract applied to Grok.
+// Dry-run never resolves a credential, so no keychain is required.
+func TestApply_Grok_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting(t *testing.T) {
+	home := setupApplyTest(t)
+
+	grokDir := filepath.Join(home, ".grok")
+	if err := safepath.MkdirAll(grokDir); err != nil {
+		t.Fatalf("mkdir .grok: %v", err)
+	}
+	configPath := filepath.Join(grokDir, "config.toml")
+	foreign := "[models]\ndefault = \"their-own-default\"\n"
+	if err := safepath.WriteFile(grokDir, configPath, []byte(foreign)); err != nil {
+		t.Fatalf("write foreign grok config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		err := ExecuteArgs([]string{
+			"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-west-2", "--dry-run", "--skip-preflight",
+		})
+		if err != nil {
+			t.Fatalf("dry-run should not error, it should report: %v", err)
+		}
+	})
+	if !strings.Contains(out, "models.default") {
+		t.Errorf("dry-run should report the colliding path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--force") {
+		t.Errorf("dry-run should mention --force, got:\n%s", out)
+	}
+
+	got, err := safepath.ReadFile(grokDir, configPath)
+	if err != nil {
+		t.Fatalf("reading config.toml: %v", err)
+	}
+	if string(got) != foreign {
+		t.Error("dry-run must not modify the foreign file")
+	}
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) != 0 {
+		t.Error("dry-run must not create a backup")
 	}
 }
 

--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -241,49 +241,72 @@ func TestApply_Grok_ForeignConfig_SiblingProfileSurvivesNoForceNeeded(t *testing
 	}
 }
 
-// TestApply_Grok_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting:
-// --dry-run must surface the same refusal information for Grok without writing
-// anything or creating a backup — the Claude dry-run contract applied to Grok.
-// Dry-run never resolves a credential, so no keychain is required.
-func TestApply_Grok_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting(t *testing.T) {
-	home := setupApplyTest(t)
-
-	grokDir := filepath.Join(home, ".grok")
-	if err := safepath.MkdirAll(grokDir); err != nil {
-		t.Fatalf("mkdir .grok: %v", err)
+// TestApply_DryRun_ForeignConfig_TOML_ReportsCollisionsWithoutWriting:
+// --dry-run must surface the same refusal information for the TOML providers
+// (Codex's exact colliding dotted path, Grok's models.default) without
+// writing anything or creating a backup. This is the same contract Claude's
+// dry-run test locks in — provider-agnostic behavior that only Claude was
+// pinning down. Dry-run never resolves a credential, so no keychain is
+// required.
+func TestApply_DryRun_ForeignConfig_TOML_ReportsCollisionsWithoutWriting(t *testing.T) {
+	cases := []struct {
+		name             string
+		cli, dir, region string
+		foreign          string
+		wantCollision    string
+	}{
+		{
+			name: "codex", cli: "codex", dir: ".codex", region: "us-east-1",
+			foreign:       "model = \"their-model\"\n\n[model_providers.amazon-bedrock.aws]\nregion = \"eu-west-1\"\n",
+			wantCollision: "model_providers.amazon-bedrock.aws.region",
+		},
+		{
+			name: "grok", cli: "grok", dir: ".grok", region: "us-west-2",
+			foreign:       "[models]\ndefault = \"their-own-default\"\n",
+			wantCollision: "models.default",
+		},
 	}
-	configPath := filepath.Join(grokDir, "config.toml")
-	foreign := "[models]\ndefault = \"their-own-default\"\n"
-	if err := safepath.WriteFile(grokDir, configPath, []byte(foreign)); err != nil {
-		t.Fatalf("write foreign grok config: %v", err)
-	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			home := setupApplyTest(t)
 
-	out := captureStdout(t, func() {
-		err := ExecuteArgs([]string{
-			"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
-			"--region=us-west-2", "--dry-run", "--skip-preflight",
+			configDir := filepath.Join(home, c.dir)
+			if err := safepath.MkdirAll(configDir); err != nil {
+				t.Fatalf("mkdir %s: %v", c.dir, err)
+			}
+			configPath := filepath.Join(configDir, "config.toml")
+			if err := safepath.WriteFile(configDir, configPath, []byte(c.foreign)); err != nil {
+				t.Fatalf("write foreign %s config: %v", c.cli, err)
+			}
+
+			out := captureStdout(t, func() {
+				err := ExecuteArgs([]string{
+					"apply", "--cli=" + c.cli, "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+					"--region=" + c.region, "--dry-run", "--skip-preflight",
+				})
+				if err != nil {
+					t.Fatalf("dry-run should not error, it should report: %v", err)
+				}
+			})
+			if !strings.Contains(out, c.wantCollision) {
+				t.Errorf("dry-run should report the colliding path, got:\n%s", out)
+			}
+			if !strings.Contains(out, "--force") {
+				t.Errorf("dry-run should mention --force, got:\n%s", out)
+			}
+
+			got, err := safepath.ReadFile(configDir, configPath)
+			if err != nil {
+				t.Fatalf("reading config.toml: %v", err)
+			}
+			if string(got) != c.foreign {
+				t.Error("dry-run must not modify the foreign file")
+			}
+			matches, _ := filepath.Glob(configPath + ".backup.*")
+			if len(matches) != 0 {
+				t.Error("dry-run must not create a backup")
+			}
 		})
-		if err != nil {
-			t.Fatalf("dry-run should not error, it should report: %v", err)
-		}
-	})
-	if !strings.Contains(out, "models.default") {
-		t.Errorf("dry-run should report the colliding path, got:\n%s", out)
-	}
-	if !strings.Contains(out, "--force") {
-		t.Errorf("dry-run should mention --force, got:\n%s", out)
-	}
-
-	got, err := safepath.ReadFile(grokDir, configPath)
-	if err != nil {
-		t.Fatalf("reading config.toml: %v", err)
-	}
-	if string(got) != foreign {
-		t.Error("dry-run must not modify the foreign file")
-	}
-	matches, _ := filepath.Glob(configPath + ".backup.*")
-	if len(matches) != 0 {
-		t.Error("dry-run must not create a backup")
 	}
 }
 
@@ -326,53 +349,6 @@ func TestApply_Codex_ForeignConfig_DottedLeafCollision_Refuses(t *testing.T) {
 	}
 	if string(got) != foreign {
 		t.Errorf("foreign codex config must be untouched on refusal, got: %s", got)
-	}
-}
-
-// TestApply_Codex_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting:
-// --dry-run must surface the same refusal information for Codex (the exact
-// colliding dotted path, plus the --force hint) without writing anything or
-// creating a backup. This is the same contract Claude's dry-run test locks
-// in — provider-agnostic behavior that only Claude was pinning down.
-func TestApply_Codex_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting(t *testing.T) {
-	home := setupApplyTest(t)
-
-	codexDir := filepath.Join(home, ".codex")
-	if err := safepath.MkdirAll(codexDir); err != nil {
-		t.Fatalf("mkdir .codex: %v", err)
-	}
-	configPath := filepath.Join(codexDir, "config.toml")
-	foreign := "model = \"their-model\"\n\n[model_providers.amazon-bedrock.aws]\nregion = \"eu-west-1\"\n"
-	if err := safepath.WriteFile(codexDir, configPath, []byte(foreign)); err != nil {
-		t.Fatalf("write foreign codex config: %v", err)
-	}
-
-	out := captureStdout(t, func() {
-		err := ExecuteArgs([]string{
-			"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
-			"--region=us-east-1", "--dry-run", "--skip-preflight",
-		})
-		if err != nil {
-			t.Fatalf("dry-run should not error, it should report: %v", err)
-		}
-	})
-	if !strings.Contains(out, "model_providers.amazon-bedrock.aws.region") {
-		t.Errorf("dry-run should report the colliding dotted path, got:\n%s", out)
-	}
-	if !strings.Contains(out, "--force") {
-		t.Errorf("dry-run should mention --force, got:\n%s", out)
-	}
-
-	got, err := safepath.ReadFile(codexDir, configPath)
-	if err != nil {
-		t.Fatalf("reading config.toml: %v", err)
-	}
-	if string(got) != foreign {
-		t.Error("dry-run must not modify the foreign file")
-	}
-	matches, _ := filepath.Glob(configPath + ".backup.*")
-	if len(matches) != 0 {
-		t.Error("dry-run must not create a backup")
 	}
 }
 

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -444,6 +444,52 @@ func TestDoctor_OpenCode_HealthyAfterApply(t *testing.T) {
 	}
 }
 
+// TestDoctor_Grok_MissingConfig_FailsWithGuidance: doctor --cli=grok on a
+// fresh home fails the config check with actionable apply guidance. Grok is
+// always user-scoped — the check line must not mention a project scope.
+func TestDoctor_Grok_MissingConfig_FailsWithGuidance(t *testing.T) {
+	_ = setupApplyTest(t)
+
+	out := captureStdout(t, func() {
+		err := ExecuteArgs([]string{"doctor", "--cli=grok"})
+		if err == nil {
+			t.Fatal("expected doctor to fail when grok is not configured")
+		}
+	})
+	if !strings.Contains(out, "config.toml (user)") {
+		t.Errorf("expected the grok config check line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "run `juggernaut apply --cli=grok`") {
+		t.Errorf("expected apply --cli=grok guidance, got:\n%s", out)
+	}
+	if strings.Contains(out, "config.toml (project)") {
+		t.Errorf("grok must never report a project-scope config check, got:\n%s", out)
+	}
+}
+
+// TestDoctor_Grok_HealthyAfterApply: after a real grok apply, doctor
+// --cli=grok reports the user config as juggernaut-managed and finds no
+// failures.
+func TestDoctor_Grok_HealthyAfterApply(t *testing.T) {
+	_ = setupApplyTest(t)
+	setupIsolatedKeychain(t) // stores a real credential; skip if keychain backend hangs (macOS CI)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply --cli=grok: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"doctor", "--cli=grok"}); err != nil {
+			t.Fatalf("doctor --cli=grok should find no failures after apply: %v", err)
+		}
+	})
+	if !strings.Contains(out, "juggernaut-managed Bedrock config present") {
+		t.Errorf("expected managed-config OK check, got:\n%s", out)
+	}
+}
+
 func TestCheckRuntimeFallback_ReportsConfigDrift(t *testing.T) {
 	home := testutil.NewTestHome(t)
 	prov := provider.MustGet("claude")

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -349,6 +349,80 @@ func TestUninstall_OpenCode_PreservesUserSiblingKeys(t *testing.T) {
 	}
 }
 
+// TestUninstall_Grok_PreservesUserSiblingKeys: uninstall --cli=grok removes
+// ONLY Juggernaut's owned leaves — the bedrock-grok model profile, the
+// models.default pointer, and the two auth keys — across three deep-merge
+// tables. A user's own model profiles, models settings, and auth settings
+// must all survive.
+func TestUninstall_Grok_PreservesUserSiblingKeys(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t) // apply stores a real credential; skip if keychain backend hangs (macOS CI)
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, "--bedrock-key=test-key-value", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Inject user-owned sibling content into all three tables Juggernaut writes.
+	configPath := filepath.Join(home, ".grok", "config.toml")
+	tomlFmt, _ := config.FormatByName("toml")
+	mgr := config.NewManagerWithFormat(configPath, tomlFmt)
+	got, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse config.toml: %v", err)
+	}
+	got["model"].(map[string]any)["batwing-coder"] = map[string]any{"base_url": "http://192.168.0.1/v1"}
+	got["models"].(map[string]any)["web_search"] = "batwing-coder"
+	got["auth"].(map[string]any)["extra_user_setting"] = "keep-me"
+	if err := mgr.Write(got); err != nil {
+		t.Fatalf("writing config.toml: %v", err)
+	}
+
+	if err := ExecuteArgs([]string{
+		"uninstall", "--cli=grok", "--force",
+	}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	after, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse config.toml after uninstall: %v", err)
+	}
+	modelTbl, ok := after["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("model table vanished — user profiles must survive, got: %v", after["model"])
+	}
+	if _, ok := modelTbl["bedrock-grok"]; ok {
+		t.Error("Juggernaut's bedrock-grok profile should be removed")
+	}
+	if _, ok := modelTbl["batwing-coder"]; !ok {
+		t.Error("user's own model profile lost on uninstall — data loss!")
+	}
+	modelsTbl, ok := after["models"].(map[string]any)
+	if !ok {
+		t.Fatalf("models table vanished — user settings must survive, got: %v", after["models"])
+	}
+	if _, ok := modelsTbl["default"]; ok {
+		t.Error("Juggernaut's models.default pointer should be removed")
+	}
+	if modelsTbl["web_search"] != "batwing-coder" {
+		t.Error("user's models.web_search setting lost on uninstall — data loss!")
+	}
+	authTbl, ok := after["auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("auth table vanished — user settings must survive, got: %v", after["auth"])
+	}
+	for _, key := range []string{"auth_provider_command", "auth_provider_label"} {
+		if _, ok := authTbl[key]; ok {
+			t.Errorf("Juggernaut's auth.%s should be removed", key)
+		}
+	}
+	if authTbl["extra_user_setting"] != "keep-me" {
+		t.Error("user's own auth setting lost on uninstall — data loss!")
+	}
+}
+
 // TestApply_Codex_IAM_Allowed: Codex now supports IAM via the AWS SDK credential
 // chain, so apply --cli=codex --auth=iam must succeed (not rejected).
 func TestApply_Codex_IAM_Allowed(t *testing.T) {


### PR DESCRIPTION
## Summary

Provider-parity hardening, PR 3 of 4: bring Grok's safety-critical test density in line with Claude (the gold standard). Test-only — no feature work, no architecture changes. Grok is user-scope-only, so this PR also pins that uniqueness.

## What's covered

- **Collision refusal (strengthened)** — `TestApply_Grok_ForeignConfig_Refuses` now also asserts the error mentions `--force` (it already asserted the exact colliding path, file-untouched, and no keychain side effects).
- **Dry-run collision report (new)** — `TestApply_Grok_DryRun_ForeignConfig_ReportsCollisionsWithoutWriting`: `--dry-run` surfaces the colliding `models.default` path + `--force` hint, writes nothing, creates no backup. Mirrors the Claude dry-run contract, which only Claude was pinning down.
- **Uninstall leaf-prune (new)** — `TestUninstall_Grok_PreservesUserSiblingKeys`: end-to-end `uninstall --cli=grok` removes the `bedrock-grok` model profile, the `models.default` pointer, and the two `auth` keys across all three deep-merge tables while preserving the user's own model profiles, `models.web_search`, and auth settings.
- **doctor --cli=grok end-to-end (new)** — `TestDoctor_Grok_MissingConfig_FailsWithGuidance` (FAIL + `apply --cli=grok` guidance on fresh home; asserts no project-scope check line is ever emitted, since Grok is user-scope-only) and `TestDoctor_Grok_HealthyAfterApply` (juggernaut-managed OK after real apply). The existing `TestRunDoctor_GrokProjectScope_Errors` already covers the `--scope=project` rejection branch, so that is not duplicated.

Every test exercises a real branch/error path (Irreducible Coverage Floor rule) and reuses existing fixtures (`setupApplyTest`, `setupIsolatedKeychain`, `bedrockKeyFlag`, `captureStdout`, `safepath`, `config.Manager`).

## Verification

- `go test ./...` — green (all packages)
- `go vet ./...` — clean
- `gofmt -l` — clean
- `git diff --check` — clean
- Touch quality: clean — tests reuse existing helpers; no new structural duplication

## Coverage impact

New assertions pin down the grok dry-run report, the three-table leaf-prune on uninstall, and non-Claude `doctor` runDoctor wiring (with the user-scope-only guarantee asserted in the report output).