### PR TITLE
docs: sharpen README and QUICKSTART first impression

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,18 +1,30 @@
 # Quick Start Guide
 
-## New Machine Setup (5 Minutes)
+## Get Started in 60 Seconds
 
-### 1. Prerequisites Check
 ```bash
-# Install Claude Code if needed
-curl -fsSL https://claude.ai/install.sh | bash
-
-# Check AWS CLI is installed (for IAM/SSO auth)
-aws --version
+npm install -g juggernaut-bedrock
+juggernaut apply --auth=iam   # or --auth=bedrock-api-key
+# restart shell, then:
+claude
 ```
 
-### 2. AWS Setup (IAM/SSO only — skip for Bedrock API key)
+Claude Code from Anthropic is a prerequisite:
+
 ```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Run `juggernaut apply` without flags for an interactive first-run prompt. Apply will not enable Bedrock routing unless a valid credential source is confirmed; if the target config already has foreign values on keys Juggernaut would write, apply refuses unless you pass `--force`.
+
+Upgrading from an older Juggernaut? Install v5 directly with npm; there is no required v3 → v4 → v5 chain. Windows v3 API-key users who need to keep an old DPAPI-stored key should use the bridge script in [README.md](README.md#windows-v3-api-key-installs).
+
+## Prerequisites (if using IAM/SSO)
+
+```bash
+# Check AWS CLI is installed
+aws --version
+
 # Method A: AWS Configure
 aws configure
 
@@ -24,39 +36,19 @@ export AWS_PROFILE=<your-profile>
 aws sts get-caller-identity
 ```
 
-### 3. Install Juggernaut
+Using `--auth=bedrock-api-key` instead? Skip AWS setup entirely — the key is stored securely in your OS keychain.
+
+## Other Coding CLIs
+
+Codex / OpenCode / Grok route through Mantle and require a Bedrock API key (not IAM):
 
 ```bash
-npm install -g juggernaut-bedrock
-```
-
-Upgrading from an older Juggernaut? Install v5 directly with npm; there is no required v3 → v4 → v5 chain. Windows v3 API-key users who need to keep an old DPAPI-stored key should use the bridge script in [README.md](README.md#windows-v3-api-key-installs).
-
-### 4. Configure
-```bash
-# IAM / SSO (recommended for organizations) — Claude Code default
-juggernaut apply --auth=iam
-
-# Bedrock API key (key stored securely in OS keychain)
-juggernaut apply --auth=bedrock-api-key
-
-# Other coding CLIs (Mantle routes require a Bedrock API key, not IAM)
 juggernaut apply --cli=opencode --auth=bedrock-api-key
 juggernaut apply --cli=codex --auth=bedrock-api-key
 juggernaut apply --cli=grok --auth=bedrock-api-key
 ```
 
-Run without flags for an interactive first-run prompt.
-
-`juggernaut apply` will not enable Bedrock routing unless a valid credential source is confirmed. If the target config already has foreign values on keys Juggernaut would write, apply refuses unless you pass `--force`.
-
-### 5. Launch
-```bash
-claude
-# or codex / opencode / grok after apply --cli=<name>
-```
-
-Restart your shell, or source the updated profile, then run the CLI normally. Juggernaut installs a marked shell function and never overwrites the real binary.
+Activation blocks for different CLIs coexist in one shell profile. Juggernaut installs a marked shell function and never overwrites the real binary. Restart your shell, or source the updated profile, then run the CLI normally.
 
 ## Verify Setup
 
@@ -100,7 +92,6 @@ juggernaut apply --auth=iam --dry-run
 juggernaut show
 ```
 
-
 ## Troubleshooting
 
 **403 Access Denied** — Complete the Anthropic model access request in the AWS Bedrock console.
@@ -109,6 +100,6 @@ juggernaut show
 
 **Keychain unavailable on headless Linux** — IAM auth works without a keychain. Bedrock API key auth requires a Secret Service daemon on Linux.
 
-**Claude stopped using Bedrock after an update** — Run `juggernaut doctor`, then re-run `juggernaut apply --cli=claude` if it reports missing managed config. The saved runtime fallback contains no bearer token and keeps launches routed while you repair the full config.
+**Claude stopped using Bedrock after an update** — Run `juggernaut doctor`; if it reports missing managed config, re-run `juggernaut apply --cli=claude`. The runtime fallback keeps launches routed while you repair.
 
 See [README.md](README.md) for full documentation.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,24 @@
 
 <p align="center"><strong>Safe Bedrock routing for coding agents — Claude Code, Codex, OpenCode, and Grok</strong></p>
 
-Single cross-platform binary that configures your coding CLI to route through **Amazon Bedrock** instead of vendor APIs — IAM, SSO, or Bedrock API key auth. Juggernaut is the **safe Bedrock arbiter**: it refuses to clobber foreign config, keeps credentials in the OS keychain, and installs marked shell activation that never overwrites the real CLI binary. A generated runtime fallback keeps Bedrock routing alive even if a Claude Code update replaces its own `settings.json` — no silent regression to vendor APIs or vendor billing.
+**Safe Bedrock on-ramp for coding CLIs — not a proxy, not another agent harness.**
+
+For teams already on AWS who want Claude Code, Codex, OpenCode, or Grok on Bedrock without hand-editing configs or MITMing traffic.
 
 **Install from npm:** [`juggernaut-bedrock`](https://www.npmjs.com/package/juggernaut-bedrock) — `npm install -g juggernaut-bedrock`
+
+## Why Juggernaut (not a proxy)
+
+- **Configures native CLI settings; does not sit in the request path** — Bedrock traffic flows directly from your CLI to AWS, no intermediate service.
+- **Refuses foreign config leaves (Juggernaut law)** — `apply` never clobbers keys you configured elsewhere unless you pass `--force` (a backup is still created).
+- **Keychain-only secrets; never overwrites the real CLI binary** — credentials stay in the OS keychain, and Juggernaut never installs over an unknown file matching a managed CLI name.
+- **Survives Claude Code updates** — a non-secret runtime fallback keeps Bedrock routing active if an update replaces `settings.json`; `doctor` guides the repair.
+
+## Non-goals
+
+- Not a multi-model jailbreak for Claude Code
+- Not an agent orchestrator
+- Not affiliated with Anthropic or Amazon Web Services
 
 ## Why Bedrock?
 
@@ -32,7 +47,7 @@ Single cross-platform binary that configures your coding CLI to route through **
 
 ## Install
 
-Install Claude Code from Anthropic, then install Juggernaut from npm.
+**Prerequisite:** install Claude Code from Anthropic, then install Juggernaut from npm.
 
 ```bash
 curl -fsSL https://claude.ai/install.sh | bash
@@ -41,57 +56,14 @@ npm install -g juggernaut-bedrock
 
 The old `scripts/install.sh` and `scripts/install.ps1` installers are deprecated stubs in v5. Juggernaut is published through [`juggernaut-bedrock`](https://www.npmjs.com/package/juggernaut-bedrock).
 
-### Upgrade from older Juggernaut
-
-Go straight to v5 with npm. You do not need to install an intermediate v3 or v4 release first.
+### 60-second path
 
 ```bash
-npm install -g juggernaut-bedrock@latest
-juggernaut version
+npm install -g juggernaut-bedrock
+juggernaut apply --auth=iam   # or --auth=bedrock-api-key
+# restart shell, then:
+claude
 ```
-
-Then re-run `apply` with your preferred auth mode:
-
-```bash
-juggernaut apply --auth=iam
-juggernaut apply --auth=bedrock-api-key
-```
-
-#### Windows v3 API-key installs
-
-If you are upgrading an old Windows installer-based v3 setup and want to keep a DPAPI-stored Bedrock API key, call the npm v5 binary explicitly and bridge the old key once:
-
-```powershell
-npm install -g juggernaut-bedrock@latest
-
-$NpmPrefix = (npm prefix -g).Trim()
-$Candidates = @(
-  (Join-Path $NpmPrefix "juggernaut.cmd"),
-  (Join-Path $NpmPrefix "bin\juggernaut.cmd"),
-  (Join-Path $env:APPDATA "npm\juggernaut.cmd"),
-  (Join-Path $HOME ".npm-global\juggernaut.cmd")
-)
-
-$Juggernaut = $Candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-if (-not $Juggernaut) { throw "npm Juggernaut binary not found" }
-
-& $Juggernaut version
-
-. "$HOME\.juggernaut\lib\keychain.ps1"
-$probe = Read-BearerToken
-if (-not $probe -or -not $probe.Value) { throw "Old v3 API key not found" }
-
-& $Juggernaut apply `
-  --auth=bedrock-api-key `
-  --bedrock-key $probe.Value `
-  --region=us-west-2 `
-  --mode=auto `
-  --effort=high
-
-& $Juggernaut doctor
-```
-
-Close and reopen PowerShell after `doctor` is green. This avoids the old `C:\Users\<you>\.juggernaut` launcher taking precedence during the upgrade.
 
 ## Configure
 
@@ -335,6 +307,58 @@ juggernaut uninstall --dry-run
 juggernaut uninstall --full
 ```
 
+## Migrating from v3/v4
+
+Go straight to v5 with npm. You do not need to install an intermediate v3 or v4 release first.
+
+```bash
+npm install -g juggernaut-bedrock@latest
+juggernaut version
+```
+
+Then re-run `apply` with your preferred auth mode:
+
+```bash
+juggernaut apply --auth=iam
+juggernaut apply --auth=bedrock-api-key
+```
+
+### Windows v3 API-key installs
+
+If you are upgrading an old Windows installer-based v3 setup and want to keep a DPAPI-stored Bedrock API key, call the npm v5 binary explicitly and bridge the old key once:
+
+```powershell
+npm install -g juggernaut-bedrock@latest
+
+$NpmPrefix = (npm prefix -g).Trim()
+$Candidates = @(
+  (Join-Path $NpmPrefix "juggernaut.cmd"),
+  (Join-Path $NpmPrefix "bin\juggernaut.cmd"),
+  (Join-Path $env:APPDATA "npm\juggernaut.cmd"),
+  (Join-Path $HOME ".npm-global\juggernaut.cmd")
+)
+
+$Juggernaut = $Candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $Juggernaut) { throw "npm Juggernaut binary not found" }
+
+& $Juggernaut version
+
+. "$HOME\.juggernaut\lib\keychain.ps1"
+$probe = Read-BearerToken
+if (-not $probe -or -not $probe.Value) { throw "Old v3 API key not found" }
+
+& $Juggernaut apply `
+  --auth=bedrock-api-key `
+  --bedrock-key $probe.Value `
+  --region=us-west-2 `
+  --mode=auto `
+  --effort=high
+
+& $Juggernaut doctor
+```
+
+Close and reopen PowerShell after `doctor` is green. This avoids the old `C:\Users\<you>\.juggernaut` launcher taking precedence during the upgrade.
+
 ## Troubleshooting
 
 **403 Access Denied** — Complete the Anthropic model access request in the AWS Bedrock console.
@@ -353,4 +377,3 @@ juggernaut uninstall --full
 
 - `/login` and `/logout` are disabled when using Bedrock
 - `AWS_REGION` is set explicitly by Juggernaut (Claude Code does not read it from `~/.aws/config`)
-- Juggernaut is an independent tool, not affiliated with Anthropic or Amazon Web Services


### PR DESCRIPTION
## Summary

Landing-surface polish for first-time visitors — README + QUICKSTART only, no code.

## Changes

- **README above the fold:** one-line product positioning ('not a proxy, not another agent harness') + who it's for; long opening paragraph replaced
- **Why Juggernaut (not a proxy):** new section before the Why Bedrock table — native config (no request-path proxy), Juggernaut law, keychain-only secrets / no binary overwrite, runtime fallback + doctor
- **Non-goals:** jailbreak / orchestrator / affiliation disclaimers (deduped from Notes)
- **60-second path:** under Install, before any upgrade narrative
- **Migrating from v3/v4:** full Windows v3 DPAPI bridge + upgrade content moved below Uninstall, content unchanged
- **QUICKSTART:** leads with the 60-second path; IAM/SSO as 'if using IAM' prereqs; multi-CLI as a separate short block; troubleshooting stays short and links README

## Verification

- Diff is docs-only (README.md, QUICKSTART.md)
- Anchor \#windows-v3-api-key-installs\ preserved (still referenced by QUICKSTART and npm/README)
- \git diff --check\ clean
- No invented product claims — bullets mirror the existing Safety model language

## Testing

Docs-only change; no tests required. No Go/npm files touched.