### PR TITLE
fix(npm): accept flat-install layouts in safeResolveBin

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -72,15 +72,19 @@ function getBinaryPath(pkgName, platform) {
 
 /**
  * Resolves bin to a real absolute path and asserts it stays within
- * __dirname, preventing any tainted or traversed path from executing.
+ * allowedBase — the directory of the allowlisted platform package that owns
+ * the binary. Callers pass resolvePkgDir(pkg), where pkgName is validated
+ * against VALID_PACKAGES, so only a binary belonging to that known package
+ * can execute.
  * @param {string} binPath
+ * @param {string} allowedBase owning platform package directory
  * @returns {string}
  */
-function safeResolveBin(binPath) {
+function safeResolveBin(binPath, allowedBase) {
   var real = fs.realpathSync(binPath); // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename
-  var base = fs.realpathSync(__dirname); // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename
+  var base = fs.realpathSync(allowedBase); // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename
   if (!real.startsWith(base + path.sep) && real !== base) {
-    throw new Error("binary path escapes package directory: " + real);
+    throw new Error("binary path escapes " + allowedBase + ": " + real);
   }
   return real;
 }
@@ -106,7 +110,8 @@ function isLongRunningLaunch(args) {
  * long-running Windows launch. Windows locks a running .exe; running this copy
  * leaves npm free to replace or remove the installed package during a session.
  *
- * Safety: `bin` is validated by safeResolveBin (realpath'd + under __dirname).
+ * Safety: `bin` is validated by safeResolveBin (realpath'd + under the owning
+ * platform package dir).
  * The temp dir is OS-generated via mkdtempSync (unique, unpredictable suffix).
  * The staged filename is a fixed constant. No user input reaches any path.
  *
@@ -181,14 +186,14 @@ if (require.main === module) {
     process.exit(1);
   }
 
-  var bin = safeResolveBin(binRaw);
+  var bin = safeResolveBin(binRaw, resolvePkgDir(pkg));
   var rootVersion = readPkgVersion(path.join(__dirname, "package.json"));
   // Read the version from the package that owns the binary we just validated,
   // not by re-resolving `pkg` independently — so the skew check compares the
   // version of the exact binary we are about to execute. `bin` was realpath'd
-  // and asserted to be contained under __dirname by safeResolveBin above, so
-  // binPkgDir is derived from an already-validated path (the path-join finding
-  // below is a false positive on that basis).
+  // and asserted to be contained under the owning platform package directory
+  // by safeResolveBin above, so binPkgDir is derived from an already-validated
+  // path.
   var binPkgDir = path.dirname(path.dirname(bin));
   var binVersion = readPkgVersion(path.join(binPkgDir, "package.json")); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   if (!versionsMatch(rootVersion, binVersion)) {
@@ -243,5 +248,6 @@ module.exports = {
   safeForwardArgs: safeForwardArgs,
   isLongRunningLaunch: isLongRunningLaunch,
   stageLaunchBinary: stageLaunchBinary,
-  versionsMatch: versionsMatch
+  versionsMatch: versionsMatch,
+  safeResolveBin: safeResolveBin
 };

--- a/npm/index.test.js
+++ b/npm/index.test.js
@@ -210,3 +210,70 @@ describe("versionsMatch", function() {
   });
   return void 0;
 });
+
+describe("safeResolveBin", function() {
+  var safeResolveBin = index.safeResolveBin;
+
+  function makeLayout(root, pkgName) {
+    // Flat node_modules layout produced by local installs, npx cache runs,
+    // pnpm, and yarn: platform package is a SIBLING of the launcher dir.
+    var launcherDir = path.join(root, "node_modules", "juggernaut-bedrock");
+    var platformDir = path.join(root, "node_modules", pkgName);
+    fs.mkdirSync(path.join(platformDir, "bin"), {recursive: true});
+    fs.writeFileSync(path.join(platformDir, "bin", "juggernaut"), "#stub\n");
+    return {launcherDir: launcherDir, platformDir: platformDir,
+      bin: path.join(platformDir, "bin", "juggernaut")};
+  }
+
+  // Given the documented non-global install flows (npx, project-local, pnpm),
+  // When the resolved binary lives in the sibling platform package,
+  // Then safeResolveBin must accept it when containment is checked against
+  // that owning platform package directory.
+  it("accepts sibling-layout binary under its own platform package", function() {
+    var root = fs.mkdtempSync(path.join(os.tmpdir(), "jug-sibling-"));
+    try {
+      var layout = makeLayout(root, "juggernaut-bedrock-win32-x64");
+      var resolved = safeResolveBin(layout.bin, layout.platformDir);
+      assert.strictEqual(resolved, fs.realpathSync(layout.bin));
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  // Given a global install where optionals nest inside the launcher tree,
+  // When the binary resolves within the platform package there,
+  // Then it must be accepted.
+  it("accepts nested-layout binary under its own platform package", function() {
+    var root = fs.mkdtempSync(path.join(os.tmpdir(), "jug-nested-"));
+    try {
+      var layout = makeLayout(root, "juggernaut-bedrock-darwin-arm64");
+      var nested = path.join(layout.launcherDir, "node_modules",
+        "juggernaut-bedrock-darwin-arm64");
+      fs.mkdirSync(path.join(nested, "bin"), {recursive: true});
+      fs.copyFileSync(layout.bin, path.join(nested, "bin", "juggernaut"));
+      var bin = path.join(nested, "bin", "juggernaut");
+      var resolved = safeResolveBin(bin, nested);
+      assert.strictEqual(resolved, fs.realpathSync(bin));
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  // Given any layout, When the binary resolves OUTSIDE the allowlisted
+  // owning package directory, Then it must still be rejected.
+  it("rejects binary outside the owning platform package", function() {
+    var root = fs.mkdtempSync(path.join(os.tmpdir(), "jug-escape-"));
+    try {
+      var layout = makeLayout(root, "juggernaut-bedrock-win32-x64");
+      var rogueDir = path.join(root, "rogue");
+      fs.mkdirSync(rogueDir, {recursive: true});
+      fs.copyFileSync(layout.bin, path.join(rogueDir, "juggernaut"));
+      assert.throws(function() {
+        safeResolveBin(path.join(rogueDir, "juggernaut"), layout.platformDir);
+      }, /escapes|outside/i);
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+  return void 0;
+});


### PR DESCRIPTION
## Summary

`safeResolveBin` asserted the resolved binary realpath lives under the launcher's `__dirname`. That invariant only holds for `npm install -g` (arborist nests optional deps) and dev checkouts. In every flat layout — **npx cache, project-local installs, pnpm, yarn** — the platform binary package is a sibling of the launcher, so the check threw `binary path escapes package directory` on every invocation, including the README-documented `npx juggernaut-bedrock version` flow.

The containment base is now the owning platform package directory (`resolvePkgDir(pkg)`), whose name is allowlist-validated before any path is built. The security property is preserved: only a binary belonging to a known platform package can execute. Symlinked layouts (pnpm virtual store) work because both sides are realpath'd.

- test: reproduce #391 — failing tests for sibling/nested/escape layouts
- fix: contain resolved binary under its owning platform package

Fixes #391
