### PR TITLE
fix(launch): propagate launched CLI exit codes instead of collapsing to 1

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -17,7 +17,11 @@ var launchCmd = &cobra.Command{
 	Short:              "Launch a CLI (default: Claude Code) with Juggernaut Bedrock activation",
 	Hidden:             true,
 	DisableFlagParsing: true,
-	RunE:               runLaunch,
+	// Passthrough exec: the child's output and exit status are the result, so
+	// never print cobra's "Error:" line or usage dump around them.
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runLaunch,
 }
 
 // launchCLICmd gives non-Claude activation blocks a version-skew-safe entry
@@ -28,6 +32,8 @@ var launchCLICmd = &cobra.Command{
 	Short:              "Launch a named CLI with Juggernaut Bedrock activation",
 	Hidden:             true,
 	DisableFlagParsing: true,
+	SilenceUsage:       true,
+	SilenceErrors:      true,
 	RunE:               runLaunchCLI,
 }
 

--- a/cmd/launch_exitcode_test.go
+++ b/cmd/launch_exitcode_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("JUGGERNAUT_TEST_WRAPPER_CHILD") == "1" {
+		wrapperChildMain()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// wrapperChildMain runs inside a freshly spawned test-binary process and acts
+// as the wrapper CLI (`juggernaut launch-cli claude -- --version`).
+func wrapperChildMain() {
+	rootCmd.SetArgs([]string{"launch-cli", "claude", "--", "--version"})
+	Execute()
+}
+
+// writeClaudeStub plants a fake `claude` executable that exits with code at
+// the front of PATH, so the launch pipeline resolves and runs it.
+func writeClaudeStub(t *testing.T, dir string, code int) {
+	t.Helper()
+	var stub string
+	var body string
+	if runtime.GOOS == "windows" {
+		stub = filepath.Join(dir, "claude.cmd")
+		body = "@echo off\r\nexit /b " + strconv.Itoa(code) + "\r\n"
+	} else {
+		stub = filepath.Join(dir, "claude")
+		body = "#!/bin/sh\nexit " + strconv.Itoa(code) + "\n"
+	}
+	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil { // #nosec G306 -- stub must be executable
+		t.Fatalf("writing claude stub: %v", err)
+	}
+}
+
+// Given Juggernaut wraps a CLI whose process exits with a non-zero code,
+// When a script runs the wrapped CLI through `launch-cli` and checks $?,
+// Then the wrapper exits with the child's exact code and prints neither an
+// error line, nor a usage dump, nor internal "exit status N" noise.
+func TestExecute_PropagatesLaunchedCLIExitCode(t *testing.T) {
+	home := t.TempDir()
+	stubDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(stubDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeStub(t, stubDir, 2)
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("JUGGERNAUT_TEST_WRAPPER_CHILD", "1")
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("locating test binary: %v", err)
+	}
+	out, err := exec.Command(exe).CombinedOutput() // #nosec G204 -- spawns this test binary in wrapper-child mode
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected ExitError from wrapper child, got %v; output:\n%s", err, out)
+	}
+	if ee.ExitCode() != 2 {
+		t.Errorf("wrapper exit code = %d, want child's code 2; output:\n%s", ee.ExitCode(), out)
+	}
+	for _, noise := range []string{"exit status", "Error:", "Usage:"} {
+		if strings.Contains(string(out), noise) {
+			t.Errorf("wrapper leaked %q to output:\n%s", noise, out)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -20,6 +22,13 @@ var rootCmd = &cobra.Command{
 // Execute is the main entry point for the CLI.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		// Launched CLIs pass through this process: their exit status IS the
+		// result. Propagate it verbatim instead of collapsing every failure
+		// to 1 with "exit status N" noise — scripts key on those codes.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.ExitCode())
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

Every wrapped CLI invocation (`claude`, `codex`, `grok` shell functions funnel through `juggernaut launch`/`launch-cli`) lost the child's exit status: `RunBinary` returns the raw `*exec.ExitError`, which Cobra's `Execute()` collapsed to exit code 1 while printing `Error: exit status N`, a usage dump, and a duplicate `exit status N` line. Scripts and CI keying on exit codes broke on every non-zero CLI exit.

- `Execute()` now translates `*exec.ExitError` into `os.Exit(child code)` with no output (cmd/root.go).
- The passthrough launch commands set `SilenceUsage`/`SilenceErrors` so cobra never wraps child results in error/usage noise (cmd/launch.go). Non-exit launch failures still print exactly once via `Execute()`.

test: reproduce #392 — subprocess harness runs this test binary as the wrapper against a stub `claude` exiting 2; asserted wrong code + leaked noise before, exact code 2 + silent stderr after.

Fixes #392
