### PR TITLE
fix(apply): reject unknown --auth modes instead of writing a broken config

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -117,6 +117,12 @@ func runApply(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Fail fast on a typo'd mode before reading or writing any state, so an
+	// invalid value can never produce a "successful" broken config.
+	if err := validateAuthFlag(); err != nil {
+		return err
+	}
+
 	prov, err := provider.Get(applyFlags.cli)
 	if err != nil {
 		return err

--- a/cmd/apply_authmode_test.go
+++ b/cmd/apply_authmode_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+)
+
+// Given the only valid auth modes are `iam` and `bedrock-api-key`,
+// When the user runs apply with a misspelled mode plus --bedrock-key,
+// Then apply must fail with an error naming the valid modes instead of
+// writing a config that can never authenticate while silently discarding
+// the provided key.
+func TestApply_RejectsUnknownAuthMode(t *testing.T) {
+	home := setupApplyTestWithReset(t)
+
+	err := ExecuteArgs([]string{
+		"apply", "--cli=claude", "--scope=user", "--region=us-west-2",
+		"--skip-preflight", "--auth=bogus-mode", bedrockKeyFlag(),
+	})
+
+	if err == nil {
+		t.Fatal("apply accepted unknown --auth=bogus-mode; want explicit rejection")
+	}
+	if !strings.Contains(err.Error(), authmode.IAM) ||
+		!strings.Contains(err.Error(), authmode.BedrockAPIKey) {
+		t.Errorf("error should name the valid modes, got: %v", err)
+	}
+	if _, readErr := safepath.ReadFile(home, filepath.Join(home, ".claude", "settings.json")); readErr == nil {
+		t.Error("a rejected apply must not write settings.json")
+	}
+}
+
+// Given both supported modes are accepted,
+// When apply runs with each exact value,
+// Then validation passes them through untouched.
+func TestApply_AcceptsExactAuthModes(t *testing.T) {
+	for _, mode := range []string{authmode.IAM, authmode.BedrockAPIKey} {
+		t.Run(mode, func(t *testing.T) {
+			home := setupApplyTestWithReset(t)
+			args := []string{
+				"apply", "--cli=claude", "--scope=user", "--region=us-west-2",
+				"--skip-preflight", "--auth=" + mode,
+			}
+			if mode == authmode.BedrockAPIKey {
+				args = append(args, bedrockKeyFlag())
+			}
+			if err := ExecuteArgs(args); err != nil {
+				t.Fatalf("apply with --auth=%s should succeed, got: %v", mode, err)
+			}
+			if got := readJuggernautAuthMode(t, home); got != mode {
+				t.Errorf("persisted auth.mode = %q, want %q", got, mode)
+			}
+		})
+	}
+}

--- a/cmd/apply_authmode_test.go
+++ b/cmd/apply_authmode_test.go
@@ -41,6 +41,11 @@ func TestApply_AcceptsExactAuthModes(t *testing.T) {
 	for _, mode := range []string{authmode.IAM, authmode.BedrockAPIKey} {
 		t.Run(mode, func(t *testing.T) {
 			home := setupApplyTestWithReset(t)
+			if mode == authmode.BedrockAPIKey {
+				// The api-key apply persists a credential; isolate the
+				// keychain so CI never touches (or hangs on) a live backend.
+				setupIsolatedKeychain(t)
+			}
 			args := []string{
 				"apply", "--cli=claude", "--scope=user", "--region=us-west-2",
 				"--skip-preflight", "--auth=" + mode,

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -142,6 +142,20 @@ func resolveMantle() (bool, error) {
 	return applyFlags.mantle || applyFlags.mantleURL != "", nil
 }
 
+// validateAuthFlag rejects unknown --auth values up front. Every downstream
+// consumer compares the mode by exact string, so a typo would otherwise fall
+// into the IAM path, silently drop --bedrock-key, and still write a config
+// reporting success.
+func validateAuthFlag() error {
+	if applyFlags.auth == "" ||
+		applyFlags.auth == authmode.IAM ||
+		authmode.IsBedrockAPIKey(applyFlags.auth) {
+		return nil
+	}
+	return fmt.Errorf("unknown --auth mode %q; valid modes are %q and %q",
+		applyFlags.auth, authmode.IAM, authmode.BedrockAPIKey)
+}
+
 // validateMantleAuth ensures that Mantle-only CLIs (Codex, OpenCode, Grok)
 // use a Bedrock API key — IAM/SSO (SigV4) does not reach Mantle. Rejects
 // non-bearer auth modes so we never write a config that can't authenticate.


### PR DESCRIPTION
## Summary

`--auth` was never validated: `resolveAuthMode` returned the flag verbatim, `resolveCredential` silently discarded `--bedrock-key` for any non-exact match, and `commitApply` hardcoded `AuthValidated: true`. A one-character typo (`--auth=bedrock-apikey`) therefore produced a guaranteed-broken config **and** printed "Configuration written successfully."

Apply now fails fast with an error naming the two valid modes (`iam`, `bedrock-api-key`) before reading or writing any state.

- test: reproduce #393 — rejected typo'd mode names valid modes and writes no settings.json; exact modes still pass through and persist unchanged.
- fix: validate the flag at the top of `runApply`.

Fixes #393
