### PR TITLE
fix(uninstall): --scope=project no longer deletes the shared bearer token

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -57,9 +57,11 @@ func runUninstall(_ *cobra.Command, _ []string) error {
 	removeRuntimeState(home, prov)
 	// The Bedrock bearer token is SHARED across all CLIs, so removing it on a
 	// per-CLI uninstall would break any other CLI still configured. Only remove
-	// it when uninstalling Claude (the primary). `--full` broadens shell-block
-	// removal, NOT shared-credential removal.
-	if !uninstallFlags.dryRun && prov.Name() == "claude" {
+	// it when uninstalling Claude (the primary) — and never on a scoped
+	// partial removal: --scope=project must leave the credential that
+	// user-scope Claude and non-Claude providers still reference. `--full`
+	// broadens shell-block removal, NOT shared-credential removal.
+	if !uninstallFlags.dryRun && prov.Name() == "claude" && uninstallFlags.scope != "project" {
 		removeKeychainToken(home)
 	}
 	if uninstallFlags.full {

--- a/cmd/uninstall_token_test.go
+++ b/cmd/uninstall_token_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// Given a Bedrock bearer token shared by every configured provider,
+// When the user removes ONLY Claude's project-scope block,
+// Then the shared token must survive: user-scope Claude and any non-Claude
+// provider configs still reference it.
+func TestUninstall_ProjectScope_KeepsSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("shared-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--scope=project", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after project-scope uninstall: %v", err)
+	}
+	if got != "shared-token" {
+		t.Errorf("project-scope uninstall deleted the shared bearer token (got %q)\noutput:\n%s", got, out)
+	}
+}
+
+// Given Claude is uninstalled outright (no scope restriction),
+// When the uninstall completes,
+// Then the primary's bearer token is removed as before.
+func TestUninstall_FullClaude_RemovesToken(t *testing.T) {
+	home := setupApplyTest(t)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("doomed-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after full uninstall: %v", err)
+	}
+	if got != "" {
+		t.Errorf("full Claude uninstall should remove the bearer token, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

`juggernaut uninstall --cli=claude --scope=project -f` — a deliberately narrow operation removing only the project-scope block — deleted the Bedrock bearer token from the keychain, breaking user-scope Claude and every non-Claude provider still configured. `removeRuntimeState` already guards partial removals with an early return for `scope == "project"`; the keychain deletion six lines later had no such guard, contradicting its own comment about shared credentials.

The deletion now skips project-scoped removals. Full Claude uninstalls still remove the token (pinned by test).

- test: reproduce #394 — scoped uninstall preserves a seeded token; full uninstall removes it.
- fix: add the scope guard to the token-deletion condition.

Fixes #394
