### PR TITLE
fix(discovery): bound Mantle catalog requests to stop indefinite hangs

### DIFF
--- a/internal/discovery/mantle.go
+++ b/internal/discovery/mantle.go
@@ -24,6 +24,14 @@ type requestSigner func(context.Context, *http.Request) error
 
 var mantleHTTPClient httpDoer = http.DefaultClient
 
+// mantleRequestTimeout bounds each Mantle catalog fetch even when the caller
+// passes a context without a deadline (cmd callers pass cmd.Context()).
+// Without it, a black-holed connection — VPN drop, DROP-mode firewall,
+// stalled TLS handshake — hangs `models refresh` indefinitely. Mirrors
+// bedrock connectivity's client timeout for the same class of probe.
+// Test-visible so the bound can be tightened without real network waits.
+var mantleRequestTimeout = 15 * time.Second
+
 // ListMantleModels queries the account- and region-specific Mantle Models API.
 // A bearer token is used when supplied; otherwise the request is SigV4-signed
 // with the default AWS credential chain and service name "bedrock-mantle".
@@ -56,6 +64,8 @@ func listMantleModelsWith(
 	client httpDoer,
 	sign requestSigner,
 ) ([]DiscoveredModel, error) {
+	ctx, cancel := context.WithTimeout(ctx, mantleRequestTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating Mantle models request: %w", err)

--- a/internal/discovery/mantle_timeout_test.go
+++ b/internal/discovery/mantle_timeout_test.go
@@ -11,10 +11,16 @@ import (
 
 type stalledDoer struct{ delay time.Duration }
 
-func (d stalledDoer) Do(*http.Request) (*http.Response, error) {
-	time.Sleep(d.delay)
-	body := io.NopCloser(strings.NewReader(`{"data":[{"id":"anthropic.claude-sonnet-4-5"}]}`))
-	return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+func (d stalledDoer) Do(req *http.Request) (*http.Response, error) {
+	timer := time.NewTimer(d.delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		body := io.NopCloser(strings.NewReader(`{"data":[{"id":"anthropic.claude-sonnet-4-5"}]}`))
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	case <-req.Context().Done():
+		return nil, req.Context().Err()
+	}
 }
 
 // Given the Mantle endpoint stalls (VPN black-hole, DROP-mode firewall),

--- a/internal/discovery/mantle_timeout_test.go
+++ b/internal/discovery/mantle_timeout_test.go
@@ -1,0 +1,61 @@
+package discovery
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type stalledDoer struct{ delay time.Duration }
+
+func (d stalledDoer) Do(*http.Request) (*http.Response, error) {
+	time.Sleep(d.delay)
+	body := io.NopCloser(strings.NewReader(`{"data":[{"id":"anthropic.claude-sonnet-4-5"}]}`))
+	return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+}
+
+// Given the Mantle endpoint stalls (VPN black-hole, DROP-mode firewall),
+// When models refresh queries it with a context that has no deadline,
+// Then the request is bounded by an internal deadline (tunable via
+// mantleRequestTimeout) instead of blocking indefinitely.
+func TestListMantleModels_BoundedByInternalDeadline(t *testing.T) {
+	origClient := mantleHTTPClient
+	origTimeout := mantleRequestTimeout
+	mantleHTTPClient = stalledDoer{delay: 5 * time.Second}
+	mantleRequestTimeout = 50 * time.Millisecond
+	defer func() {
+		mantleHTTPClient = origClient
+		mantleRequestTimeout = origTimeout
+	}()
+
+	start := time.Now()
+	_, err := ListMantleModels(context.Background(), "us-west-2", "tok")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("ListMantleModels succeeded against a stalled endpoint after %s; want internal deadline error", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("deadline not applied promptly: blocked for %s", elapsed)
+	}
+}
+
+// Given the endpoint responds normally,
+// When the internal deadline is generous,
+// Then a healthy fetch still succeeds.
+func TestListMantleModels_HealthyFetchUnaffected(t *testing.T) {
+	origClient := mantleHTTPClient
+	mantleHTTPClient = stalledDoer{delay: 10 * time.Millisecond}
+	defer func() { mantleHTTPClient = origClient }()
+
+	models, err := ListMantleModels(context.Background(), "us-west-2", "tok")
+	if err != nil {
+		t.Fatalf("healthy fetch failed: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "anthropic.claude-sonnet-4-5" {
+		t.Errorf("unexpected models: %+v", models)
+	}
+}


### PR DESCRIPTION
## Summary

`models refresh` / `models list --refresh` used `http.DefaultClient` (zero timeout) with a bare `cmd.Context()` — a black-holed connection (VPN drop, DROP-mode firewall, stalled TLS) hung the command indefinitely.

Each Mantle fetch is now bounded by `mantleRequestTimeout` (15s default, mirroring bedrock connectivity's probe timeout), applied at the single choke point in `listMantleModelsWith` so every caller is covered, and tunable for tests. Callers that already pass deadlines are unaffected (shorter deadline wins).

- test: reproduce #395 — expresses the contract (internal tunable bound); red as a build failure on the missing var, then asserts prompt deadline errors against a stalled doer plus an unaffected healthy path.
- fix: derive a timeout context in `listMantleModelsWith`.

Fixes #395
