### PR TITLE
fix(npm): surface spawn failures and signal deaths with diagnostics

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -166,6 +166,43 @@ function readPkgVersion(pkgJsonPath) {
     return void 0;
   }
 }
+var SIGNAL_NUMBERS = {
+  SIGHUP: 1,
+  SIGINT: 2,
+  SIGQUIT: 3,
+  SIGKILL: 9,
+  SIGTERM: 15
+};
+
+/**
+ * Describes a spawnSync outcome for the launcher's exit path.
+ * - result.error: the binary could not be launched (AV lock, EACCES, racing
+ *   upgrade). Without this branch the launcher would exit 1 printing nothing,
+ *   indistinguishable from a normal CLI failure.
+ * - result.signal: the child died from a signal; reported via the POSIX
+ *   convention 128+signum so scripts can distinguish it from a normal exit.
+ * @param {{status:number|null, signal:string|null, error:Error|null}} result
+ * @returns {{exitCode:number, message:string}} message is "" when the child
+ * ran and exited normally (no extra output).
+ */
+function describeSpawnOutcome(result) {
+  if (result.error) {
+    var code = result.error.code ? result.error.code + " " : "";
+    return {
+      exitCode: 1,
+      message: "juggernaut-bedrock: failed to launch binary: " + code + result.error.message
+    };
+  }
+  if (result.signal) {
+    var signum = SIGNAL_NUMBERS[result.signal];
+    return {
+      exitCode: signum ? 128 + signum : 1,
+      message: "juggernaut-bedrock: binary terminated by signal " + result.signal
+    };
+  }
+  return {exitCode: result.status !== null && result.status !== undefined ? result.status : 1, message: ""};
+}
+
 if (require.main === module) {
   var pkg = getPlatformPackage(process.platform, process.arch);
   if (!pkg) {
@@ -238,7 +275,11 @@ if (require.main === module) {
       }
     }
   }
-  process.exit(result.status !== null ? result.status : 1);
+  var outcome = describeSpawnOutcome(result);
+  if (outcome.message) {
+    process.stderr.write(outcome.message + "\n");
+  }
+  process.exit(outcome.exitCode);
 }
 
 module.exports = {
@@ -249,5 +290,6 @@ module.exports = {
   isLongRunningLaunch: isLongRunningLaunch,
   stageLaunchBinary: stageLaunchBinary,
   versionsMatch: versionsMatch,
-  safeResolveBin: safeResolveBin
+  safeResolveBin: safeResolveBin,
+  describeSpawnOutcome: describeSpawnOutcome
 };

--- a/npm/index.test.js
+++ b/npm/index.test.js
@@ -277,3 +277,46 @@ describe("safeResolveBin", function() {
   });
   return void 0;
 });
+
+describe("describeSpawnOutcome", function() {
+  var describeSpawnOutcome = index.describeSpawnOutcome;
+
+  // Given the wrapped binary cannot be spawned (AV lock, EACCES, racing
+  // upgrade), When the launcher inspects the spawnSync result,
+  // Then it must produce exit code 1 and a diagnostic naming the failure.
+  it("surfaces spawn errors with a diagnostic", function() {
+    var err = new Error("spawn juggernaut EACCES");
+    err.code = "EACCES";
+    var outcome = describeSpawnOutcome({status: null, signal: null, error: err});
+    assert.strictEqual(outcome.exitCode, 1);
+    assert.ok(outcome.message.indexOf("EACCES") !== -1, "message should name the error code");
+    return void 0;
+  });
+
+  // Given the child was killed by a signal, When the outcome is described,
+  // Then it maps to the POSIX convention 128+signum with a note on stderr.
+  it("maps signal deaths to 128+signum", function() {
+    var outcome = describeSpawnOutcome({status: null, signal: "SIGTERM", error: null});
+    assert.strictEqual(outcome.exitCode, 143);
+    assert.ok(outcome.message.indexOf("SIGTERM") !== -1);
+    return void 0;
+  });
+
+  // Given the child ran and exited normally, When the outcome is described,
+  // Then the child's status passes through untouched with no extra output.
+  it("passes normal statuses through untouched", function() {
+    var outcome = describeSpawnOutcome({status: 7, signal: null, error: null});
+    assert.strictEqual(outcome.exitCode, 7);
+    assert.strictEqual(outcome.message, "");
+    return void 0;
+  });
+
+  // Given a degenerate result with no status, signal, or error,
+  // When the outcome is described, Then the launcher exits 1 safely.
+  it("exits 1 for a degenerate result", function() {
+    var outcome = describeSpawnOutcome({status: null, signal: null, error: null});
+    assert.strictEqual(outcome.exitCode, 1);
+    return void 0;
+  });
+  return void 0;
+});


### PR DESCRIPTION
## Summary

The launcher read only `spawnSync`'s `status` field. When the binary could not be spawned at all — AV quarantine/lock between the `existsSync` check and spawn, EACCES from a racing `npm install -g`, exec-bit loss — the result carried `{status: null, error: <EACCES|EBUSY|...>}` and the launcher exited 1 printing **nothing**. Children killed by signals (`{status: null, signal: ...}`) also lost the information.

A new exported pure helper `describeSpawnOutcome(result)` now owns exit-code interpretation:

- `result.error` → exit 1 + stderr diagnostic naming the error code
- `result.signal` → POSIX convention `128+signum` (SIGTERM→143, SIGINT→130, ...) + stderr note
- normal completion → status passthrough, zero extra output

- test: reproduce #401 — four outcome paths pinned (error diagnostic, signal mapping, passthrough, degenerate null).
- fix: helper + wired into the launcher exit path.

Fixes #401
