### PR TITLE
fix(activation): accept PS profiles under redirected Documents instead of reporting false discovery failure

### DIFF
--- a/internal/activation/path_helpers.go
+++ b/internal/activation/path_helpers.go
@@ -73,25 +73,3 @@ func validateAndCanonicalizePath(p, baseDir string) string {
 	}
 	return p
 }
-
-// validateUnderTrustedRoots canonicalizes p via validateAndCanonicalizePath
-// and accepts it when it falls under ANY of the given OS-trusted roots.
-// PowerShell profiles legitimately live under $HOME or under the Documents
-// Known Folder (which domain redirection may place outside $HOME), while
-// hostile PowerShell output escaping both is rejected.
-func validateUnderTrustedRoots(p string, roots ...string) string {
-	hasRoot := false
-	for _, root := range roots {
-		if root == "" {
-			continue
-		}
-		hasRoot = true
-		if v := validateAndCanonicalizePath(p, root); v != "" {
-			return v
-		}
-	}
-	if !hasRoot {
-		return validateAndCanonicalizePath(p, "")
-	}
-	return ""
-}

--- a/internal/activation/path_helpers.go
+++ b/internal/activation/path_helpers.go
@@ -73,3 +73,25 @@ func validateAndCanonicalizePath(p, baseDir string) string {
 	}
 	return p
 }
+
+// validateUnderTrustedRoots canonicalizes p via validateAndCanonicalizePath
+// and accepts it when it falls under ANY of the given OS-trusted roots.
+// PowerShell profiles legitimately live under $HOME or under the Documents
+// Known Folder (which domain redirection may place outside $HOME), while
+// hostile PowerShell output escaping both is rejected.
+func validateUnderTrustedRoots(p string, roots ...string) string {
+	hasRoot := false
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		hasRoot = true
+		if v := validateAndCanonicalizePath(p, root); v != "" {
+			return v
+		}
+	}
+	if !hasRoot {
+		return validateAndCanonicalizePath(p, "")
+	}
+	return ""
+}

--- a/internal/activation/powershell_discovery.go
+++ b/internal/activation/powershell_discovery.go
@@ -99,27 +99,16 @@ func discoverPowerShellProfilesScoped(home string) ProfileResolverResult {
 	}
 	result := ProfileResolverResult{}
 
-	// Resolve the base directory for path containment validation.
-	// This prevents PowerShell from returning paths that escape the
-	// user's home directory (e.g. UNC paths, symlink escapes).
-	// Use the Known Documents folder when available (it may be under
-	// OneDrive or another redirected location); fall back to $HOME.
-	baseDir := home
-	docs, err := resolveDocumentsFolder()
-	if err == nil {
-		// Ensure the Documents folder is under $HOME; if it is, use it
-		// as the tighter containment boundary.
-		rel, relErr := filepath.Rel(home, docs)
-		if relErr == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			baseDir = docs
-		}
-	}
-
-	// Primary Documents tree (Known Folder, or $HOME/Documents). Used for
-	// install fallback so we never write activation into every alternate
-	// Documents layout — only the one Windows currently points at.
+	// Resolve the trusted containment roots for path validation.
+	// This prevents PowerShell from returning paths that escape the user's
+	// profile tree (e.g. UNC paths, symlink escapes). Two roots are trusted:
+	// $HOME and the OS-resolved Documents Known Folder, which domain folder
+	// redirection may place outside $HOME entirely. Fall back to $HOME-only
+	// when the Known Folder API is unavailable.
+	docsRoot := ""
 	primaryDocs := filepath.Join(home, "Documents")
 	if docs, err := resolveDocumentsFolder(); err == nil && docs != "" {
+		docsRoot = docs
 		primaryDocs = docs
 	}
 	primaryHistorical := resolveHistoricalTargets(primaryDocs)
@@ -138,8 +127,8 @@ func discoverPowerShellProfilesScoped(home string) ProfileResolverResult {
 
 		if dr.DiscoveryOK {
 			result.EditionsDiscovered = append(result.EditionsDiscovered, ed.Name)
-			allHosts := validateAndCanonicalizePath(dr.AllHosts, baseDir)
-			currentHost := validateAndCanonicalizePath(dr.CurrentHost, baseDir)
+			allHosts := validateUnderTrustedRoots(dr.AllHosts, home, docsRoot)
+			currentHost := validateUnderTrustedRoots(dr.CurrentHost, home, docsRoot)
 
 			if allHosts != "" && !containsTargetPathCI(result.ActiveTargets, allHosts) {
 				result.ActiveTargets = append(result.ActiveTargets,

--- a/internal/activation/powershell_discovery.go
+++ b/internal/activation/powershell_discovery.go
@@ -196,6 +196,28 @@ func discoverPowerShellProfilesScoped(home string) ProfileResolverResult {
 	return result
 }
 
+// validateUnderTrustedRoots canonicalizes p via validateAndCanonicalizePath
+// and accepts it when it falls under ANY of the given OS-trusted roots.
+// PowerShell profiles legitimately live under $HOME or under the Documents
+// Known Folder (which domain redirection may place outside $HOME), while
+// hostile PowerShell output escaping both is rejected.
+func validateUnderTrustedRoots(p string, roots ...string) string {
+	hasRoot := false
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		hasRoot = true
+		if v := validateAndCanonicalizePath(p, root); v != "" {
+			return v
+		}
+	}
+	if !hasRoot {
+		return validateAndCanonicalizePath(p, "")
+	}
+	return ""
+}
+
 func discoverEdition(ed psEdition, runner discoveryCommandRunner) psDiscoveryResult {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/internal/activation/ps_docs_containment_test.go
+++ b/internal/activation/ps_docs_containment_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package activation
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
+)
+
+// Given Documents is redirected outside the user profile (enterprise folder
+// redirection, another volume) and PowerShell discovery succeeds,
+// When profiles are resolved,
+// Then the discovered paths must be accepted — the OS-resolved Known Folder
+// root is the containment boundary — instead of being silently dropped,
+// which forces the false "discovery failed" fallback on every run.
+func TestDiscoverPowerShellProfiles_DocumentsOutsideHome(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	docs := t.TempDir() // sibling of home — NOT under it
+
+	psProfile := filepath.Join(docs, "PowerShell", "profile.ps1")
+	SetPSRunnerForTesting(&mockCommandRunner{
+		output: map[string][]byte{
+			"pwsh.exe":       makePSOutput(psProfile, psProfile),
+			"powershell.exe": makePSOutput(psProfile, psProfile),
+		},
+	})
+	t.Cleanup(ResetPSRunnerForTesting)
+	SetResolveDocumentsFolderForTesting(func() (string, error) { return docs, nil })
+	t.Cleanup(ResetResolveDocumentsFolderForTesting)
+
+	res := discoverPowerShellProfilesScoped(home)
+
+	if res.UsedFallback {
+		t.Errorf("discovery reported failure despite successful PS queries; warnings=%v", res.DiscoveryWarnings)
+	}
+	if len(res.ActiveTargets) == 0 {
+		t.Fatalf("no active targets discovered; warnings=%v", res.DiscoveryWarnings)
+	}
+	found := false
+	for _, tgt := range res.ActiveTargets {
+		if !strings.HasPrefix(strings.ToLower(tgt.Path), strings.ToLower(docs)) {
+			t.Errorf("target %s escapes the Documents boundary %s", tgt.Path, docs)
+		}
+		if strings.EqualFold(tgt.Path, psProfile) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("discovered profile %s missing from active targets: %+v", psProfile, res.ActiveTargets)
+	}
+}


### PR DESCRIPTION
## Summary

When the Documents Known Folder is redirected outside `$HOME` (enterprise folder redirection, another volume, UNC homes), `filepath.Rel($HOME, docs)` cannot relate the paths — so `baseDir` stayed at `$HOME` and `validateAndCanonicalizePath` silently dropped **every** discovered PowerShell profile. Discovery then reported permanent failure ("using Known Documents fallback") on every run while doctor/status showed a failure state that does not exist.

Discovery now validates against **two OS-trusted roots**: `$HOME` and the resolved Documents Known Folder (falling back to `$HOME`-only when the Known Folder API is unavailable). Hostile PowerShell output escaping both roots is still rejected via Clean+Rel containment; traversal inside a root still rejected. The first PR iteration collapsed to docs-only containment, which broke `cmd` doctor tests that validate mocked paths under fake homes against `$HOME` — caught by the full suite locally and reworked before push.

- test: reproduce #402 — redirected Documents outside `$HOME`: discovery succeeds without fallback, targets land under the Documents boundary.
- fix: dual trusted-root validation wrapper; single resolver call for base + primary docs.

Fixes #402
