### PR TITLE
chore: bump Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/juggernaut/v5
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

The informational `vuln` (govulncheck) job has been failing on every recent PR — GO-2026-6218 (`net/url` quadratic complexity) and friends are fixed in **go1.26.6**, but `go.mod` pinned the toolchain to 1.26.5, which every workflow provisions via `go-version-file`.

Single-line bump. Local full suite + vet green on 1.26.6; CI should provision 1.26.6 and turn `vuln` green again, restoring a clean signal for future PRs (no more per-PR infrastructure-failure comments).
