### PR TITLE
fix(activation): corrupt Claude settings degrade launches instead of blocking them

### DIFF
--- a/internal/activation/auth_modes_degrade_test.go
+++ b/internal/activation/auth_modes_degrade_test.go
@@ -1,0 +1,94 @@
+package activation
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCorruptClaudeSettings(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte("<<<<<<< merge conflict"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Given a corrupt (but present) .claude/settings.json,
+// When the launch pipeline probes auth modes,
+// Then the probe degrades to a warning naming the file instead of a fatal
+// error — the wrapped CLI must never be hard-blocked by advisory config.
+func TestAuthModes_CorruptConfigDegradesToWarning(t *testing.T) {
+	home := t.TempDir()
+	writeCorruptClaudeSettings(t, home)
+
+	var warns []string
+	modes := authModes(home, func(msg string) { warns = append(warns, msg) })
+
+	if len(modes) != 0 {
+		t.Errorf("modes = %v, want empty on unreadable config", modes)
+	}
+	if len(warns) == 0 {
+		t.Fatal("expected a degradation warning for the corrupt settings file")
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "settings.json") {
+			return
+		}
+	}
+	t.Errorf("warning should name the offending file, got: %v", warns)
+}
+
+// Given a corrupt user settings.json but valid saved runtime state,
+// When the wrapper launches claude,
+// Then it falls back to the runtime configuration with a warning and still
+// execs the real binary.
+func TestLaunchWithOptions_CorruptSettingsFallsBackToRuntimeState(t *testing.T) {
+	home := t.TempDir()
+	writeCorruptClaudeSettings(t, home)
+	if err := SaveRuntimeState(home, "claude", RuntimeState{AuthMode: "iam"}); err != nil {
+		t.Fatalf("seeding runtime state: %v", err)
+	}
+
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stub := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- stub must be executable
+		t.Fatal(err)
+	}
+
+	var launched [][]string
+	var warns []string
+	err := LaunchWithOptions(LaunchOptions{
+		Home:        home,
+		Args:        []string{"--version"},
+		Path:        binDir,
+		TokenGetter: func() (string, error) { return "", nil },
+		Runner: func(path string, args []string, _ []string) error {
+			launched = append(launched, append([]string{path}, args...))
+			return nil
+		},
+		Warner: func(msg string) { warns = append(warns, msg) },
+	})
+	if err != nil {
+		t.Fatalf("launch should degrade past corrupt settings, got: %v", err)
+	}
+	if len(launched) == 0 {
+		t.Error("wrapped binary was never exec'd")
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "settings.json") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about the corrupt settings file, got: %v", warns)
+	}
+}

--- a/internal/activation/auth_modes_degrade_test.go
+++ b/internal/activation/auth_modes_degrade_test.go
@@ -3,6 +3,7 @@ package activation
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -58,7 +59,11 @@ func TestLaunchWithOptions_CorruptSettingsFallsBackToRuntimeState(t *testing.T) 
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	stub := filepath.Join(binDir, "claude")
+	stubName := "claude"
+	if runtime.GOOS == "windows" {
+		stubName = "claude.cmd"
+	}
+	stub := filepath.Join(binDir, stubName)
 	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- stub must be executable
 		t.Fatal(err)
 	}

--- a/internal/activation/coverage_gaps_extra_test.go
+++ b/internal/activation/coverage_gaps_extra_test.go
@@ -538,10 +538,7 @@ func TestSpecOrClaude_Populated(t *testing.T) {
 func TestAuthModes_ReturnsExpectedModes(t *testing.T) {
 	home := testutil.NewTestHome(t)
 	writeSettings(t, home, authmode.IAM)
-	modes, err := authModes(home)
-	if err != nil {
-		t.Fatalf("authModes error: %v", err)
-	}
+	modes := authModes(home, nil)
 	if len(modes) == 0 {
 		t.Fatal("expected at least one auth mode")
 	}

--- a/internal/activation/coverage_gaps_wrappers_test.go
+++ b/internal/activation/coverage_gaps_wrappers_test.go
@@ -352,10 +352,7 @@ func TestAuthModes_EmptyConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	modes, err := authModes(home)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	modes := authModes(home, nil)
 	if len(modes) != 0 {
 		t.Errorf("expected no auth modes from empty config, got %v", modes)
 	}

--- a/internal/activation/launch.go
+++ b/internal/activation/launch.go
@@ -65,10 +65,7 @@ func LaunchWithOptions(opts LaunchOptions) error {
 	}
 
 	env := os.Environ()
-	modes, err := authModes(opts.Home)
-	if err != nil {
-		return err
-	}
+	modes := authModes(opts.Home, opts.Warner)
 
 	// Determine whether this launch is Juggernaut-managed and whether it needs a
 	// bearer token. Claude declares its auth mode in ~/.claude/settings.json
@@ -267,7 +264,11 @@ func readAuthModeFromConfig(path string) string {
 	return ""
 }
 
-func authModes(home string) ([]string, error) {
+// authModes probes Claude settings files for persisted auth modes. The read
+// is advisory: a corrupt-but-present file must never hard-block the wrapped
+// CLI, so failures degrade to a warning naming the offending path (missing
+// files are silently skipped).
+func authModes(home string, warnf func(string)) []string {
 	paths := []string{
 		filepath.Join(".", ".claude", "settings.json"),
 		filepath.Join(home, ".claude", "settings.json"),
@@ -277,13 +278,17 @@ func authModes(home string) ([]string, error) {
 		mgr := config.NewManager(path)
 		data, err := mgr.Read()
 		if err != nil {
-			return nil, fmt.Errorf("reading %s: %w", path, err)
+			if warnf != nil {
+				warnf("Warning: could not read " + path +
+					" (" + err.Error() + "); ignoring it for launch decisions")
+			}
+			continue
 		}
 		if jb, ok := config.ParseJuggernautBlock(data); ok && jb.AuthMode != "" {
 			modes = append(modes, jb.AuthMode)
 		}
 	}
-	return modes, nil
+	return modes
 }
 
 // --- Environment helpers ---

--- a/internal/activation/resolve_authmodes_test.go
+++ b/internal/activation/resolve_authmodes_test.go
@@ -164,10 +164,7 @@ func TestAuthModes_SkipsMalformedSettings(t *testing.T) {
 		}
 	}`)
 
-	modes, err := authModes(home)
-	if err != nil {
-		t.Fatalf("authModes: %v", err)
-	}
+	modes := authModes(home, nil)
 	if len(modes) != 0 {
 		t.Errorf("a block without managedBy==juggernaut must be ignored, got %v", modes)
 	}
@@ -186,10 +183,7 @@ func TestAuthModes_ReadsManagedMode(t *testing.T) {
 		}
 	}`)
 
-	modes, err := authModes(home)
-	if err != nil {
-		t.Fatalf("authModes: %v", err)
-	}
+	modes := authModes(home, nil)
 	if len(modes) != 1 || modes[0] != "iam" {
 		t.Errorf("expected [iam], got %v", modes)
 	}


### PR DESCRIPTION
## Summary

A corrupt-but-present `.claude/settings.json` (merge-conflict markers, truncated hand-edit) hard-aborted every wrapped `claude` launch with a parse error — before binary resolution — and bypassed the runtime-state recovery path. Self-repair via `apply` dead-ended on the same parse error, leaving the user with a broken CLI and no obvious fix.

`authModes` now treats the settings probe as what it always was — advisory: unreadable files degrade to a stderr warning naming the path, missing files stay silent, and the launch proceeds through the normal managed/runtime-fallback/unmanaged flow. This matches the existing policy in `readAuthModeFromConfig`. Per maintainer decision on the issue.

- test: reproduce #408 — unit: corrupt config yields empty modes + warning naming the file; end-to-end: corrupt user settings + valid runtime state still execs the wrapped binary with the warning emitted.
- fix: drop the error return from `authModes`, delete the fatal branch at the launch call site.

Fixes #408
