### PR TITLE
fix(discovery): invalidate model catalog cache on SSO account switches

### DIFF
--- a/docs/ci-suppressions.md
+++ b/docs/ci-suppressions.md
@@ -26,6 +26,7 @@ adding or removing suppressions.
 | --- | --- | --- | --- |
 | `internal/activation/artifact.go:59,97` | `#nosec G703,G501` + `nosemgrep go_filesystem_rule-fileread` | file-read of a variable path | Reads candidate v4.2.6 shim paths resolved from `binDir` + fixed name lists; read-only, errors handled. |
 | `internal/activation/launch.go:212,224` | `#nosec G703` | os.Stat on variable path | Candidates come from PATH/known config paths; both Stat errors are handled. |
+| `internal/discovery/identity.go` (`hashSSOCache`) | `#nosec G304` | os.ReadFile on variable path | Path is produced by `filepath.WalkDir` under the fixed `~/.aws/sso/cache` root (not user input); read errors fold into the fingerprint instead of failing. |
 | `internal/activation/launch.go:297` | `nosemgrep dangerous-exec-command` | exec with a variable command | Executes the real CLI binary resolved by `resolveBinaryFrom`, which skips the Juggernaut binary itself and known v4.2.6 artifacts; a fixed name would break the launch contract. |
 | `internal/activation/powershell_discovery.go:52` | `nosemgrep dangerous-exec-command` | exec with a variable command | `exe` comes from a fixed candidate list (`pwsh.exe`/`powershell.exe`) with fixed script args; the selection loop requires a variable. |
 | `internal/keychain/crypter_windows.go:53,67,77` | `#nosec G115,G103` + `nosemgrep use-of-unsafe-block` | integer conversion / unsafe | DPAPI `DATA_BLOB` marshalling requires `unsafe`; sizes are bounded by the keychain limit well under 4GB. |

--- a/docs/ci-suppressions.md
+++ b/docs/ci-suppressions.md
@@ -26,7 +26,6 @@ adding or removing suppressions.
 | --- | --- | --- | --- |
 | `internal/activation/artifact.go:59,97` | `#nosec G703,G501` + `nosemgrep go_filesystem_rule-fileread` | file-read of a variable path | Reads candidate v4.2.6 shim paths resolved from `binDir` + fixed name lists; read-only, errors handled. |
 | `internal/activation/launch.go:212,224` | `#nosec G703` | os.Stat on variable path | Candidates come from PATH/known config paths; both Stat errors are handled. |
-| `internal/discovery/identity.go` (`hashSSOCache`) | `#nosec G304` | os.ReadFile on variable path | Path is produced by `filepath.WalkDir` under the fixed `~/.aws/sso/cache` root (not user input); read errors fold into the fingerprint instead of failing. |
 | `internal/activation/launch.go:297` | `nosemgrep dangerous-exec-command` | exec with a variable command | Executes the real CLI binary resolved by `resolveBinaryFrom`, which skips the Juggernaut binary itself and known v4.2.6 artifacts; a fixed name would break the launch contract. |
 | `internal/activation/powershell_discovery.go:52` | `nosemgrep dangerous-exec-command` | exec with a variable command | `exe` comes from a fixed candidate list (`pwsh.exe`/`powershell.exe`) with fixed script args; the selection loop requires a variable. |
 | `internal/keychain/crypter_windows.go:53,67,77` | `#nosec G115,G103` + `nosemgrep use-of-unsafe-block` | integer conversion / unsafe | DPAPI `DATA_BLOB` marshalling requires `unsafe`; sizes are bounded by the keychain limit well under 4GB. |

--- a/internal/discovery/identity.go
+++ b/internal/discovery/identity.go
@@ -82,8 +82,11 @@ func CredentialScope(home string) (string, error) {
 // credential fingerprint. Switching accounts in the SSO portal refreshes that
 // cache while leaving ~/.aws/config and credentials untouched, so without it
 // the scope cannot distinguish accounts and apply/doctor would serve another
-// account's cached model inventory. Contents are hashed with sorted relative
-// paths for determinism; a missing directory hashes as an explicit marker.
+// account's cached model inventory. Relative paths are collected first, then
+// read outside the walk (no filesystem operations inside the WalkDir
+// callback), and sorted for deterministic hashing. Read errors fold into the
+// fingerprint instead of failing; a missing directory hashes as an explicit
+// marker.
 func hashSSOCache(hash hashWriter, home string) {
 	dir := filepath.Join(home, ".aws", "sso", "cache")
 	info, err := os.Stat(dir)
@@ -92,11 +95,14 @@ func hashSSOCache(hash hashWriter, home string) {
 		return
 	}
 
-	type cachedFile struct{ rel, body string }
-	var files []cachedFile
+	type ssoCacheEntry struct {
+		rel     string
+		walkErr string
+	}
+	var entries []ssoCacheEntry
 	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			files = append(files, cachedFile{rel: path, body: "<walk-error: " + err.Error() + ">"})
+			entries = append(entries, ssoCacheEntry{rel: path, walkErr: err.Error()})
 			return nil
 		}
 		if d.IsDir() {
@@ -106,21 +112,27 @@ func hashSSOCache(hash hashWriter, home string) {
 		if relErr != nil {
 			rel = path
 		}
-		data, readErr := os.ReadFile(path) // #nosec G304 -- path is walked from a fixed root, not user input
-		if readErr != nil {
-			files = append(files, cachedFile{rel: rel, body: "<read-error: " + readErr.Error() + ">"})
-			return nil
-		}
-		files = append(files, cachedFile{rel: rel, body: string(data)})
+		entries = append(entries, ssoCacheEntry{rel: rel})
 		return nil
 	})
 	if walkErr != nil {
 		writeHashField(hash, "sso-cache-walk-error", walkErr.Error())
 		return
 	}
-	sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
-	for _, f := range files {
-		writeHashField(hash, "sso-cache:"+f.rel, f.body)
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+	for _, entry := range entries {
+		switch {
+		case entry.walkErr != "":
+			writeHashField(hash, "sso-cache:"+entry.rel, "<walk-error: "+entry.walkErr+">")
+		default:
+			data, readErr := os.ReadFile(filepath.Join(dir, entry.rel))
+			if readErr != nil {
+				writeHashField(hash, "sso-cache:"+entry.rel, "<read-error: "+readErr.Error()+">")
+				continue
+			}
+			writeHashField(hash, "sso-cache:"+entry.rel, string(data))
+		}
 	}
 }
 

--- a/internal/discovery/identity.go
+++ b/internal/discovery/identity.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -72,8 +73,55 @@ func CredentialScope(home string) (string, error) {
 			}
 			writeHashField(hash, "contents", string(data))
 		}
+		hashSSOCache(hash, home)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// hashSSOCache folds the aws-cli SSO token cache (~/.aws/sso/cache) into the
+// credential fingerprint. Switching accounts in the SSO portal refreshes that
+// cache while leaving ~/.aws/config and credentials untouched, so without it
+// the scope cannot distinguish accounts and apply/doctor would serve another
+// account's cached model inventory. Contents are hashed with sorted relative
+// paths for determinism; a missing directory hashes as an explicit marker.
+func hashSSOCache(hash hashWriter, home string) {
+	dir := filepath.Join(home, ".aws", "sso", "cache")
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		writeHashField(hash, "sso-cache", "<absent>")
+		return
+	}
+
+	type cachedFile struct{ rel, body string }
+	var files []cachedFile
+	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			files = append(files, cachedFile{rel: path, body: "<walk-error: " + err.Error() + ">"})
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			rel = path
+		}
+		data, readErr := os.ReadFile(path) // #nosec G304 -- path is walked from a fixed root, not user input
+		if readErr != nil {
+			files = append(files, cachedFile{rel: rel, body: "<read-error: " + readErr.Error() + ">"})
+			return nil
+		}
+		files = append(files, cachedFile{rel: rel, body: string(data)})
+		return nil
+	})
+	if walkErr != nil {
+		writeHashField(hash, "sso-cache-walk-error", walkErr.Error())
+		return
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
+	for _, f := range files {
+		writeHashField(hash, "sso-cache:"+f.rel, f.body)
+	}
 }
 
 type hashWriter interface {

--- a/internal/discovery/identity.go
+++ b/internal/discovery/identity.go
@@ -100,7 +100,9 @@ func hashSSOCache(hash hashWriter, home string) {
 		walkErr string
 	}
 	var entries []ssoCacheEntry
-	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+	// Walk errors surface through the callback (including a failed root
+	// listing) and fold into the fingerprint like any other entry.
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			entries = append(entries, ssoCacheEntry{rel: path, walkErr: err.Error()})
 			return nil
@@ -108,17 +110,11 @@ func hashSSOCache(hash hashWriter, home string) {
 		if d.IsDir() {
 			return nil
 		}
-		rel, relErr := filepath.Rel(dir, path)
-		if relErr != nil {
-			rel = path
-		}
+		// path is walked beneath dir, so Rel always succeeds.
+		rel, _ := filepath.Rel(dir, path)
 		entries = append(entries, ssoCacheEntry{rel: rel})
 		return nil
 	})
-	if walkErr != nil {
-		writeHashField(hash, "sso-cache-walk-error", walkErr.Error())
-		return
-	}
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
 	for _, entry := range entries {

--- a/internal/discovery/identity_sso_test.go
+++ b/internal/discovery/identity_sso_test.go
@@ -79,3 +79,38 @@ func TestCredentialScope_IncludesSSOCacheContents(t *testing.T) {
 		t.Fatal("scope drifted without any input change")
 	}
 }
+
+// Given a cache entry that cannot be read (broken symlink),
+// When the fingerprint is computed,
+// Then the unreadable entry folds in deterministically instead of failing.
+func TestCredentialScope_SSOCacheUnreadableEntryFoldsIn(t *testing.T) {
+	home := testhome.NewTestHome(t)
+	clearSSORelevantEnv(t)
+	ssoCacheFile(t, home, "good.json", `{"accountId":"111122223333"}`)
+
+	broken := filepath.Join(home, ".aws", "sso", "cache", "broken.json")
+	if err := os.Symlink(filepath.Join(home, ".aws", "sso", "cache", "missing"), broken); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+
+	first, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("scope with unreadable cache entry: %v", err)
+	}
+	second, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("stable rescope with unreadable entry: %v", err)
+	}
+	if first != second {
+		t.Fatal("scope drifted while the unreadable entry stayed constant")
+	}
+
+	ssoCacheFile(t, home, "another.json", `{}`)
+	third, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("rescope after cache change: %v", err)
+	}
+	if third == first {
+		t.Fatal("readable-entry change did not alter the scope alongside an unreadable one")
+	}
+}

--- a/internal/discovery/identity_sso_test.go
+++ b/internal/discovery/identity_sso_test.go
@@ -1,0 +1,81 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/testhome"
+)
+
+// clearSSORelevantEnv isolates the credential-selection env vars so the
+// shared-config branch of CredentialScope is exercised.
+func clearSSORelevantEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AWS_DEFAULT_PROFILE",
+		"AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE",
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_CONTAINER_CREDENTIALS_FULL_URI",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func ssoCacheFile(t *testing.T, home, name, body string) {
+	t.Helper()
+	dir := filepath.Join(home, ".aws", "sso", "cache")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Given an SSO user who logs in and selects account A (writing the aws-cli
+// token cache), When the credential fingerprint is computed before and after,
+// Then the cache write must change the scope — otherwise apply/doctor would
+// serve another account's cached model inventory after an account switch.
+func TestCredentialScope_IncludesSSOCacheContents(t *testing.T) {
+	home := testhome.NewTestHome(t)
+	clearSSORelevantEnv(t)
+
+	beforeLogin, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("scope without sso cache: %v", err)
+	}
+
+	ssoCacheFile(t, home, "account-a.json", `{"accountId":"111122223333"}`)
+
+	afterLoginA, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("scope with account A: %v", err)
+	}
+	if afterLoginA == beforeLogin {
+		t.Fatal("scope unchanged after first SSO login wrote its token cache")
+	}
+
+	// Given the user switches accounts in the SSO portal,
+	// When aws-cli refreshes the cache for account B,
+	// Then the scope must change so stale account-A caches are not served.
+	ssoCacheFile(t, home, "account-b.json", `{"accountId":"444455556666"}`)
+	afterSwitchB, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("scope with account B: %v", err)
+	}
+	if afterSwitchB == afterLoginA {
+		t.Fatal("scope unchanged after switching SSO accounts")
+	}
+
+	// Given nothing about the selection changes,
+	// When the scope is recomputed,
+	// Then it must stay stable.
+	stable, err := CredentialScope(home)
+	if err != nil {
+		t.Fatalf("stable rescope: %v", err)
+	}
+	if stable != afterSwitchB {
+		t.Fatal("scope drifted without any input change")
+	}
+}


### PR DESCRIPTION
## Summary

`CredentialScope` fingerprinted profile names, env selectors, and the static `~/.aws/config`/`credentials` files — none of which change when an SSO user picks a different account in the portal. The recomputed scope was identical across account switches, so `apply`/`doctor` loaded the previous account's cached model inventory and evaluated availability against the wrong entitlements.

The aws-cli SSO token cache (`~/.aws/sso/cache`) is now folded into the hash: files are walked under the fixed root, read errors fold into the fingerprint (matching the existing offline-tolerance policy), relative paths are sorted for determinism, and a missing directory hashes as an explicit marker so first login also invalidates. Per maintainer decision on the issue; the accepted tradeoff is coupling to aws-cli's on-disk cache layout.

- test: reproduce #409 — behavioral red: first login's cache write changed nothing pre-fix; post-fix asserts first-login change, account-switch change, and stability with no input change.
- fix: `hashSSOCache` in the shared-config branch; suppression documented in docs/ci-suppressions.md.

Fixes #409
