### PR TITLE
fix(tests): least-privilege fixture perms and documented semgrep annotations

### DIFF
--- a/cmd/helpers_test_phases_test.go
+++ b/cmd/helpers_test_phases_test.go
@@ -1492,7 +1492,7 @@ func TestReportLegacyRecovery_ErrorPath(t *testing.T) {
 	if err := os.Chmod(binDir, 0o000); err != nil {
 		t.Skipf("cannot chmod (not root): %v", err)
 	}
-	defer func() { _ = os.Chmod(binDir, 0o700) }() // restore for cleanup
+	defer func() { _ = os.Chmod(binDir, 0o700) }() // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission,go_file-permissions_rule-fileperm -- restore dir perms for cleanup
 
 	// reportLegacyRecovery prints to stderr on error; stdout should be empty.
 	out := captureStdout(t, func() {

--- a/cmd/launch_exitcode_test.go
+++ b/cmd/launch_exitcode_test.go
@@ -39,6 +39,7 @@ func writeClaudeStub(t *testing.T, dir string, code int) {
 		stub = filepath.Join(dir, "claude")
 		body = "#!/bin/sh\nexit " + strconv.Itoa(code) + "\n"
 	}
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission,go_file-permissions_rule-fileperm -- executable stub needs 0o755
 	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil { // #nosec G306 -- stub must be executable
 		t.Fatalf("writing claude stub: %v", err)
 	}
@@ -51,7 +52,7 @@ func writeClaudeStub(t *testing.T, dir string, code int) {
 func TestExecute_PropagatesLaunchedCLIExitCode(t *testing.T) {
 	home := t.TempDir()
 	stubDir := filepath.Join(home, "bin")
-	if err := os.MkdirAll(stubDir, 0o755); err != nil {
+	if err := os.MkdirAll(stubDir, 0o700); err != nil { // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- owner-only temp dir
 		t.Fatal(err)
 	}
 	writeClaudeStub(t, stubDir, 2)
@@ -65,6 +66,7 @@ func TestExecute_PropagatesLaunchedCLIExitCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("locating test binary: %v", err)
 	}
+	// nosemgrep: go_subproc_rule-subproc,go.lang.security.audit.dangerous-exec-command.dangerous-exec-command -- fixed os.Executable() target
 	out, err := exec.Command(exe).CombinedOutput() // #nosec G204 -- spawns this test binary in wrapper-child mode
 	var ee *exec.ExitError
 	if !errors.As(err, &ee) {

--- a/docs/ci-suppressions.md
+++ b/docs/ci-suppressions.md
@@ -54,3 +54,6 @@ constant prefix plus `COPYFILE_EXCL`.
 - `internal/activation/artifact.go:92` `//nolint:unused` — `isLegacyClaudeShim`
   is retained for future v4.2.6 artifact recovery; covered by tests, not yet
   called from production code.
+- `cmd/launch_exitcode_test.go` - `#nosec G204` + `nosemgrep go_subproc_rule-subproc,dangerous-exec-command` on the wrapper-child harness spawning `os.Executable()` (the test binary itself) so exit-code propagation through `Execute()` can be asserted.
+- Executable test stubs written `0o755` (`cmd/launch_exitcode_test.go`, `internal/activation/auth_modes_degrade_test.go`) - `#nosec G306` + `nosemgrep fileperm/incorrect-default-permission`; POSIX shell stubs must be executable for the launch pipeline to resolve and run them.
+- `internal/config/write_test.go` and `cmd/helpers_test_phases_test.go` - `nosemgrep mkdir/fileperm/incorrect-default-permission` alongside the existing `//nolint:gosec` on the intentional read-only dir and its cleanup chmod restore.

--- a/internal/activation/auth_modes_degrade_test.go
+++ b/internal/activation/auth_modes_degrade_test.go
@@ -11,7 +11,7 @@ import (
 func writeCorruptClaudeSettings(t *testing.T, home string) {
 	t.Helper()
 	dir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil { // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- owner-only temp fixture dir
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte("<<<<<<< merge conflict"), 0o600); err != nil {
@@ -56,7 +56,7 @@ func TestLaunchWithOptions_CorruptSettingsFallsBackToRuntimeState(t *testing.T) 
 	}
 
 	binDir := filepath.Join(home, "bin")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
+	if err := os.MkdirAll(binDir, 0o700); err != nil { // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- owner-only temp dir
 		t.Fatal(err)
 	}
 	stubName := "claude"
@@ -64,6 +64,7 @@ func TestLaunchWithOptions_CorruptSettingsFallsBackToRuntimeState(t *testing.T) 
 		stubName = "claude.cmd"
 	}
 	stub := filepath.Join(binDir, stubName)
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission,go_file-permissions_rule-fileperm -- executable stub needs 0o755
 	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- stub must be executable
 		t.Fatal(err)
 	}

--- a/internal/config/write_test.go
+++ b/internal/config/write_test.go
@@ -63,8 +63,9 @@ func TestWrite_RenameFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("JoinUnder: %v", err)
 	}
-	_ = os.MkdirAll(readonlyDir, 0o555) //nolint:gosec // test-only — intentionally read-only dir to test write-failure path
-	defer func() { _ = os.Chmod(readonlyDir, 0o700) }()
+	// nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission,go_file-permissions_rule-mkdir -- test-only, intentionally read-only dir to test write-failure path
+	_ = os.MkdirAll(readonlyDir, 0o555)                 //nolint:gosec // test-only — intentionally read-only dir to test write-failure path
+	defer func() { _ = os.Chmod(readonlyDir, 0o700) }() // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- restore perms for cleanup
 
 	path, err := safepath.JoinUnder(readonlyDir, "settings.json")
 	if err != nil {


### PR DESCRIPTION
## Summary

Clears the eight Go semgrep rows from the local/dashboard scan (test-hygiene class; no behavior change — the failing scanner run was the red):

- Fixture directories tightened to `0o700` (`cmd/launch_exitcode_test.go`, `internal/activation/auth_modes_degrade_test.go`) with repo-standard nosemgrep rationale.
- Executable stubs keep `0o755` (required for POSIX resolution) — annotated `#nosec G306` + nosemgrep fileperm, documented in docs/ci-suppressions.md.
- Wrapper-child harness `exec.Command(os.Executable())` annotated subproc/dangerous-exec with rationale (same class as launch.go's documented site).
- Pre-existing neighbors that predate this session but lacked annotations: `internal/config/write_test.go` read-only dir + cleanup chmod, `cmd/helpers_test_phases_test.go` chmod restore.

Verification: standalone Semgrep over cmd/activation/config: 8→0; full suite, vet green. Suppression additions documented per policy.

Fixes Codacy rows: launch_exitcode_test.go ×3, auth_modes_degrade_test.go ×2 (+2 latent), helpers_test_phases_test.go, write_test.go.
