### PR TITLE
fix(npm): annotate test fixtures to clear semgrep path-traversal rows

### DIFF
--- a/docs/ci-suppressions.md
+++ b/docs/ci-suppressions.md
@@ -30,13 +30,14 @@ adding or removing suppressions.
 | `internal/activation/powershell_discovery.go:52` | `nosemgrep dangerous-exec-command` | exec with a variable command | `exe` comes from a fixed candidate list (`pwsh.exe`/`powershell.exe`) with fixed script args; the selection loop requires a variable. |
 | `internal/keychain/crypter_windows.go:53,67,77` | `#nosec G115,G103` + `nosemgrep use-of-unsafe-block` | integer conversion / unsafe | DPAPI `DATA_BLOB` marshalling requires `unsafe`; sizes are bounded by the keychain limit well under 4GB. |
 
-### npm launcher (`npm/index.js`, 10 sites)
+### npm launcher (`npm/index.js`, `npm/index.test.js`)
 
 `nosemgrep path-traversal` / `detect-non-literal-fs-filename` on path joins and
 fs calls. All are false positives by construction: package names pass the
 `VALID_PACKAGES` allowlist before any join, `safeResolveBin` realpaths and
-asserts containment under `__dirname`, and staging uses `fs.mkdtempSync` with a
-constant prefix plus `COPYFILE_EXCL`.
+asserts containment under the owning platform package dir, staging uses
+`fs.mkdtempSync` with a constant prefix plus `COPYFILE_EXCL`, and test
+fixtures build their trees under `fs.mkdtempSync(os.tmpdir())` roots.
 
 ### Test-only Go suppressions (~45 sites)
 

--- a/npm/index.test.js
+++ b/npm/index.test.js
@@ -217,12 +217,12 @@ describe("safeResolveBin", function() {
   function makeLayout(root, pkgName) {
     // Flat node_modules layout produced by local installs, npx cache runs,
     // pnpm, and yarn: platform package is a SIBLING of the launcher dir.
-    var launcherDir = path.join(root, "node_modules", "juggernaut-bedrock");
-    var platformDir = path.join(root, "node_modules", pkgName);
-    fs.mkdirSync(path.join(platformDir, "bin"), {recursive: true});
-    fs.writeFileSync(path.join(platformDir, "bin", "juggernaut"), "#stub\n");
+    var launcherDir = path.join(root, "node_modules", "juggernaut-bedrock"); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- test fixture under mkdtemp/tmpdir roots
+    var platformDir = path.join(root, "node_modules", pkgName); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal, javascript_pathtraversal_rule-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
+    fs.mkdirSync(path.join(platformDir, "bin"), {recursive: true}); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal, javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
+    fs.writeFileSync(path.join(platformDir, "bin", "juggernaut"), "#stub\n"); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal, javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
     return {launcherDir: launcherDir, platformDir: platformDir,
-      bin: path.join(platformDir, "bin", "juggernaut")};
+      bin: path.join(platformDir, "bin", "juggernaut")}; // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal -- test fixture under mkdtemp/tmpdir roots
   }
 
   // Given the documented non-global install flows (npx, project-local, pnpm),
@@ -234,7 +234,7 @@ describe("safeResolveBin", function() {
     try {
       var layout = makeLayout(root, "juggernaut-bedrock-win32-x64");
       var resolved = safeResolveBin(layout.bin, layout.platformDir);
-      assert.strictEqual(resolved, fs.realpathSync(layout.bin));
+      assert.strictEqual(resolved, fs.realpathSync(layout.bin)); // nosemgrep: javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
     } finally {
       fs.rmSync(root, {recursive: true, force: true});
     }
@@ -249,11 +249,11 @@ describe("safeResolveBin", function() {
       var layout = makeLayout(root, "juggernaut-bedrock-darwin-arm64");
       var nested = path.join(layout.launcherDir, "node_modules",
         "juggernaut-bedrock-darwin-arm64");
-      fs.mkdirSync(path.join(nested, "bin"), {recursive: true});
+      fs.mkdirSync(path.join(nested, "bin"), {recursive: true}); // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal, javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
       fs.copyFileSync(layout.bin, path.join(nested, "bin", "juggernaut"));
       var bin = path.join(nested, "bin", "juggernaut");
       var resolved = safeResolveBin(bin, nested);
-      assert.strictEqual(resolved, fs.realpathSync(bin));
+      assert.strictEqual(resolved, fs.realpathSync(bin)); // nosemgrep: javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
     } finally {
       fs.rmSync(root, {recursive: true, force: true});
     }
@@ -266,7 +266,7 @@ describe("safeResolveBin", function() {
     try {
       var layout = makeLayout(root, "juggernaut-bedrock-win32-x64");
       var rogueDir = path.join(root, "rogue");
-      fs.mkdirSync(rogueDir, {recursive: true});
+      fs.mkdirSync(rogueDir, {recursive: true}); // nosemgrep: javascript_pathtraversal_rule-non-literal-fs-filename, javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename -- test fixture under mkdtemp/tmpdir roots
       fs.copyFileSync(layout.bin, path.join(rogueDir, "juggernaut"));
       assert.throws(function() {
         safeResolveBin(path.join(rogueDir, "juggernaut"), layout.platformDir);


### PR DESCRIPTION
## Summary

Clears the sixteen JS semgrep rows on `npm/index.test.js` (test-hygiene; the failing scanner run was the red, `npm test` stays 38/38 green):

- Fixture `path.join`/fs calls annotated with same-line `nosemggrep` rationale — all fixture trees are built under `fs.mkdtempSync(os.tmpdir())` roots with allowlist-validated package names, mirroring the documented pattern already carried by `npm/index.js`.
- docs/ci-suppressions.md npm section refreshed: covers `index.test.js`, and corrects the containment description to the owning-platform-package boundary (#396).

Verification: standalone Semgrep over `npm/**`: 16→0; suite green.

Fixes Codacy rows: index.test.js 220–269 (path-traversal / non-literal-fs-filename / detect-non-literal-fs-filename).
