### PR TITLE
fix(apply): auto-migrate v5 (Mantle-era) configs on plain apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Juggernaut will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **v5 (Mantle-era) configs now auto-migrate on plain `apply`.** Upgrading
+  from v5 and running `juggernaut apply` no longer requires `--force` when the
+  existing `~/.codex/config.toml` or `~/.grok/config.toml` was written by
+  Juggernaut v5 (Mantle-era). The apply detects the stale Mantle `base_url` /
+  pre-v6 model IDs, announces the migration, backs up the old config, and
+  rewrites it to route via `bedrock-runtime`. A genuinely foreign config (one
+  Juggernaut did not write) still requires `--force`.
+  - Grok: legacy `base_url` pointing at `bedrock-mantle` triggers migration.
+  - Codex: legacy `model_provider = "amazon-bedrock"` with a pre-v6 model
+    ID (`openai.gpt-5.x`, not `openai.gpt-5.6-*`) triggers migration.
+  - After applying, re-run `juggernaut models refresh --source native
+    --region <region>` to repopulate the model catalog.
+
 ## [6.0.0] - 2026-08-30
 
 **Major release — consolidated on native Bedrock. Mantle is removed.**

--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -593,3 +593,319 @@ func TestApply_Claude_ForeignConfig_MalformedJSON_ErrorsNotSilentlyIgnored(t *te
 		t.Error("a parse error must not be misreported as a collision refusal")
 	}
 }
+
+// TestApply_Grok_LegacyJuggernautConfig_PlainApplyMigrates: a plain apply
+// (no --force) over a v5 Grok config (base_url pointing at Mantle) must
+// migrate to the v6 bedrock-runtime config with a backup — not refuse.
+func TestApply_Grok_LegacyJuggernautConfig_PlainApplyMigrates(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t) // apply stores a real credential; skip if backend hangs (macOS CI)
+
+	grokDir := filepath.Join(home, ".grok")
+	if err := safepath.MkdirAll(grokDir); err != nil {
+		t.Fatalf("mkdir .grok: %v", err)
+	}
+	configPath := filepath.Join(grokDir, "config.toml")
+	legacy := `[models]
+default = "bedrock-grok"
+
+[model.bedrock-grok]
+model = "xai.grok-4.3"
+base_url = "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+name = "Amazon Bedrock (Mantle)"
+
+[auth]
+auth_provider_command = "juggernaut auth-token"
+`
+	if err := safepath.WriteFile(grokDir, configPath, []byte(legacy)); err != nil {
+		t.Fatalf("write legacy grok config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-west-2", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("plain apply over legacy grok config should migrate, not refuse: %v", err)
+		}
+	})
+	if !strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("apply should announce the v5→v6 migration, got:\n%s", out)
+	}
+	if !strings.Contains(out, "models refresh") {
+		t.Errorf("apply should mention models refresh, got:\n%s", out)
+	}
+
+	// Verify the written config has the v6 bedrock-runtime URL, not Mantle.
+	content, err := safepath.ReadFile(grokDir, configPath)
+	if err != nil {
+		t.Fatalf("read config after apply: %v", err)
+	}
+	written := string(content)
+	if !strings.Contains(written, "bedrock-runtime") {
+		t.Errorf("migrated config should contain bedrock-runtime base_url, got:\n%s", written)
+	}
+	if strings.Contains(written, "bedrock-mantle") {
+		t.Errorf("migrated config must NOT contain bedrock-mantle URL, got:\n%s", written)
+	}
+	if !strings.Contains(written, "xai.grok-4.6") {
+		t.Errorf("migrated config should have v6 default model xai.grok-4.6, got:\n%s", written)
+	}
+
+	// A backup of the legacy config should have been created.
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) == 0 {
+		t.Error("expected a backup of the legacy grok config to be created")
+	}
+}
+
+// TestApply_Codex_LegacyJuggernautConfig_PlainApplyMigrates: a plain apply
+// (no --force) over a v5 Codex config (amazon-bedrock provider with old
+// GPT-5.5 model ID) must migrate to the v6 model ID with a backup.
+func TestApply_Codex_LegacyJuggernautConfig_PlainApplyMigrates(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := safepath.MkdirAll(codexDir); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	configPath := filepath.Join(codexDir, "config.toml")
+	legacy := `model = "openai.gpt-5.5"
+model_provider = "amazon-bedrock"
+
+[model_providers.amazon-bedrock.aws]
+region = "us-east-1"
+`
+	if err := safepath.WriteFile(codexDir, configPath, []byte(legacy)); err != nil {
+		t.Fatalf("write legacy codex config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-west-2", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("plain apply over legacy codex config should migrate, not refuse: %v", err)
+		}
+	})
+	if !strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("apply should announce the v5→v6 migration for codex, got:\n%s", out)
+	}
+	if !strings.Contains(out, "models refresh") {
+		t.Errorf("apply should mention models refresh, got:\n%s", out)
+	}
+
+	content, err := safepath.ReadFile(codexDir, configPath)
+	if err != nil {
+		t.Fatalf("read config after apply: %v", err)
+	}
+	written := string(content)
+	if !strings.Contains(written, "openai.gpt-5.6-sol") {
+		t.Errorf("migrated config should have v6 default model openai.gpt-5.6-sol, got:\n%s", written)
+	}
+	if strings.Contains(written, "openai.gpt-5.5") {
+		t.Errorf("migrated config must NOT contain old v5 model openai.gpt-5.5, got:\n%s", written)
+	}
+
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) == 0 {
+		t.Error("expected a backup of the legacy codex config to be created")
+	}
+}
+
+// TestApply_DryRun_LegacyJuggernautConfig_PreviewsMigration: a plain dry-run
+// over a legacy v5 Grok config must preview the migration (announce + the
+// standard "would write" output) without writing or creating a backup.
+func TestApply_DryRun_LegacyJuggernautConfig_PreviewsMigration(t *testing.T) {
+	home := setupApplyTest(t)
+
+	grokDir := filepath.Join(home, ".grok")
+	if err := safepath.MkdirAll(grokDir); err != nil {
+		t.Fatalf("mkdir .grok: %v", err)
+	}
+	configPath := filepath.Join(grokDir, "config.toml")
+	legacy := `[models]
+default = "bedrock-grok"
+
+[model.bedrock-grok]
+model = "xai.grok-4.3"
+base_url = "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+name = "Amazon Bedrock (Mantle)"
+
+[auth]
+auth_provider_command = "juggernaut auth-token"
+`
+	if err := safepath.WriteFile(grokDir, configPath, []byte(legacy)); err != nil {
+		t.Fatalf("write legacy grok config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-west-2", "--dry-run", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("dry-run should not error: %v", err)
+		}
+	})
+	if !strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("dry-run should preview the v5→v6 migration, got:\n%s", out)
+	}
+	if !strings.Contains(out, "models refresh") {
+		t.Errorf("dry-run should mention models refresh, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Would write juggernaut config") {
+		t.Errorf("dry-run should still show what would be written, got:\n%s", out)
+	}
+
+	got, err := safepath.ReadFile(grokDir, configPath)
+	if err != nil {
+		t.Fatalf("reading config.toml: %v", err)
+	}
+	if string(got) != legacy {
+		t.Error("dry-run must not modify the legacy file")
+	}
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) != 0 {
+		t.Error("dry-run must not create a backup")
+	}
+}
+
+// TestApply_ForeignConfig_NotLegacy_NoMigrationHint: a foreign config that
+// does NOT look like a Juggernaut v5 config must NOT trigger the migration
+// hint — it still requires --force.
+func TestApply_ForeignConfig_NotLegacy_NoMigrationHint(t *testing.T) {
+	home := setupApplyTest(t)
+
+	grokDir := filepath.Join(home, ".grok")
+	if err := safepath.MkdirAll(grokDir); err != nil {
+		t.Fatalf("mkdir .grok: %v", err)
+	}
+	configPath := filepath.Join(grokDir, "config.toml")
+	foreign := `[models]
+default = "their-own-model"
+`
+	if err := safepath.WriteFile(grokDir, configPath, []byte(foreign)); err != nil {
+		t.Fatalf("write foreign grok config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{
+			"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+			"--region=us-west-2", "--dry-run", "--skip-preflight",
+		}); err != nil {
+			t.Fatalf("dry-run should not error: %v", err)
+		}
+	})
+	if strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("non-legacy foreign config must NOT trigger migration hint, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--force") {
+		t.Errorf("non-legacy foreign config must still mention --force, got:\n%s", out)
+	}
+}
+
+// TestApply_Grok_LegacyJuggernautConfig_Force_MigratesToV6: --force over a
+// legacy v5 Grok config must succeed, write the v6 bedrock-runtime base_url,
+// and drop the Mantle URL. This is the actual migration path — the user
+// doesn't have to hand-edit their config.
+func TestApply_Grok_LegacyJuggernautConfig_Force_MigratesToV6(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+
+	grokDir := filepath.Join(home, ".grok")
+	if err := safepath.MkdirAll(grokDir); err != nil {
+		t.Fatalf("mkdir .grok: %v", err)
+	}
+	configPath := filepath.Join(grokDir, "config.toml")
+	legacy := `[models]
+default = "bedrock-grok"
+
+[model.bedrock-grok]
+model = "xai.grok-4.3"
+base_url = "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+name = "Amazon Bedrock (Mantle)"
+
+[auth]
+auth_provider_command = "juggernaut auth-token"
+`
+	if err := safepath.WriteFile(grokDir, configPath, []byte(legacy)); err != nil {
+		t.Fatalf("write legacy grok config: %v", err)
+	}
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=grok", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+		"--region=us-west-2", "--skip-preflight", "--force",
+	}); err != nil {
+		t.Fatalf("apply --force over legacy grok config should succeed: %v", err)
+	}
+
+	// Verify the written config has the v6 bedrock-runtime URL, not Mantle.
+	content, err := safepath.ReadFile(grokDir, configPath)
+	if err != nil {
+		t.Fatalf("read config after apply: %v", err)
+	}
+	written := string(content)
+	if !strings.Contains(written, "bedrock-runtime") {
+		t.Errorf("migrated config should contain bedrock-runtime base_url, got:\n%s", written)
+	}
+	if strings.Contains(written, "bedrock-mantle") {
+		t.Errorf("migrated config must NOT contain bedrock-mantle URL, got:\n%s", written)
+	}
+	if !strings.Contains(written, "xai.grok-4.6") {
+		t.Errorf("migrated config should have v6 default model xai.grok-4.6, got:\n%s", written)
+	}
+
+	// A backup of the legacy config should have been created.
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) == 0 {
+		t.Error("expected a backup of the legacy grok config to be created with --force")
+	}
+}
+
+// TestApply_Codex_LegacyJuggernautConfig_Force_MigratesToV6: --force over a
+// legacy v5 Codex config must succeed, write the v6 model ID (gpt-5.6-sol),
+// and drop the old GPT-5.5 model.
+func TestApply_Codex_LegacyJuggernautConfig_Force_MigratesToV6(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := safepath.MkdirAll(codexDir); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	configPath := filepath.Join(codexDir, "config.toml")
+	legacy := `model = "openai.gpt-5.5"
+model_provider = "amazon-bedrock"
+
+[model_providers.amazon-bedrock.aws]
+region = "us-east-1"
+`
+	if err := safepath.WriteFile(codexDir, configPath, []byte(legacy)); err != nil {
+		t.Fatalf("write legacy codex config: %v", err)
+	}
+
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=codex", "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+		"--region=us-west-2", "--skip-preflight", "--force",
+	}); err != nil {
+		t.Fatalf("apply --force over legacy codex config should succeed: %v", err)
+	}
+
+	content, err := safepath.ReadFile(codexDir, configPath)
+	if err != nil {
+		t.Fatalf("read config after apply: %v", err)
+	}
+	written := string(content)
+	if !strings.Contains(written, "openai.gpt-5.6-sol") {
+		t.Errorf("migrated config should have v6 default model openai.gpt-5.6-sol, got:\n%s", written)
+	}
+	if strings.Contains(written, "openai.gpt-5.5") {
+		t.Errorf("migrated config must NOT contain old v5 model openai.gpt-5.5, got:\n%s", written)
+	}
+
+	matches, _ := filepath.Glob(configPath + ".backup.*")
+	if len(matches) == 0 {
+		t.Error("expected a backup of the legacy codex config to be created with --force")
+	}
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -334,15 +334,21 @@ func printApplyDryRun(home string, block *schema.Block, prov provider.Provider, 
 	if err != nil {
 		return err
 	}
+
 	collisions, err := detectForeignCollisions(home, applyFlags.scope, prov, plan)
 	if err != nil {
 		return err
 	}
 	if len(collisions) > 0 && !applyFlags.force {
-		fmt.Printf("Would refuse to apply: %s isn't managed by Juggernaut and already has:\n%s\n"+
-			"Would require --force to overwrite anyway (a backup would still be made before writing)\n",
-			path, formatCollisions(collisions))
-		return nil
+		if migrateLegacyJuggernautConfig(prov, home, applyFlags.scope) {
+			announceMigration(prov)
+		} else {
+			// Dry-run never errors — it prints the same refusal the commit
+			// path would return, so the user can preview what a real apply
+			// would do.
+			fmt.Print(refuseForeignConfig(prov, home, applyFlags.scope, plan, path).Error() + "\n")
+			return nil
+		}
 	}
 
 	title := prov.DisplayName()
@@ -366,10 +372,41 @@ func detectForeignCollisions(home, scope string, prov provider.Provider, plan pr
 	if err != nil {
 		return nil, fmt.Errorf("checking existing configuration: %w", err)
 	}
-	if prov.OwnsConfig(existing) || len(existing) == 0 {
+	if len(existing) == 0 {
+		return nil, nil
+	}
+	// A legacy v5 config (Mantle-era) must be migrated even if it passes
+	// OwnsConfig — the old base_url / model IDs are wrong for v6.
+	if prov.OwnsConfig(existing) && !isJuggernautLegacy(existing) {
 		return nil, nil
 	}
 	return config.DetectCollisions(existing, plan.Keys, prov.DeepMergeKeys(), prov.OwnedSubKeys()), nil
+}
+
+// isJuggernautLegacy reports whether the existing config was written by a
+// pre-v6 Juggernaut (Mantle-era) and is stale for v6's bedrock-runtime
+// routing. Returns false for configs that don't look like Juggernaut's own
+// (foreign user configs, non-Juggernaut tooling) — those still require
+// --force. Legacy Juggernaut configs are migrated by a plain apply: the
+// write clobbers the file and the backup preserves the old content.
+func isJuggernautLegacy(existing map[string]any) bool {
+	// Grok: [model.bedrock-grok] base_url pointed at Mantle.
+	if model, ok := existing["model"].(map[string]any); ok {
+		if grokModel, ok := model["bedrock-grok"].(map[string]any); ok {
+			if bu, ok := grokModel["base_url"].(string); ok && strings.Contains(bu, "mantle") {
+				return true
+			}
+		}
+	}
+	// Codex: a Juggernaut-owned config (amazon-bedrock provider) with a
+	// pre-v6 model ID (openai.gpt-5.x, not the v6 openai.gpt-5.6-* family)
+	// is a Mantle-era config.
+	if mp, ok := existing["model_provider"]; ok && mp == "amazon-bedrock" {
+		if m, ok := existing["model"].(string); ok && strings.HasPrefix(m, "openai.gpt-5.") && !strings.HasPrefix(m, "openai.gpt-5.6") {
+			return true
+		}
+	}
+	return false
 }
 
 // formatCollisions renders one line per collision for the refusal error/dry-run
@@ -380,6 +417,43 @@ func formatCollisions(collisions []config.Collision) string {
 		lines[i] = fmt.Sprintf("  %s: %#v (foreign value)", c.Path, c.Existing)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func readExistingForLegacy(prov provider.Provider, home, scope string) map[string]any {
+	existing, err := readProviderConfig(prov, home, scope)
+	if err != nil || existing == nil {
+		return nil
+	}
+	return existing
+}
+
+// migrateLegacyJuggernautConfig reports whether the existing config is a
+// pre-v6 (Mantle-era) Juggernaut config that a plain apply migrates — rather
+// than refuses — to the v6 bedrock-runtime config. Only Juggernaut's own
+// legacy configs qualify; a genuinely foreign config is never treated as
+// legacy and still requires --force.
+func migrateLegacyJuggernautConfig(prov provider.Provider, home, scope string) bool {
+	return isJuggernautLegacy(readExistingForLegacy(prov, home, scope))
+}
+
+// announceMigration prints the v5→v6 migration notice for a legacy
+// Juggernaut config. Both the dry-run and commit paths call this before
+// writing, so the user sees the migration is happening, not a refusal.
+func announceMigration(prov provider.Provider) {
+	fmt.Printf("Migrating %s: the existing config was written by Juggernaut v5 (Mantle era).\n", prov.DisplayName())
+	fmt.Println("Mantle endpoints are removed in v6; the config will be rewritten to route via bedrock-runtime.")
+	fmt.Println("A backup of the old config is saved before writing.")
+	fmt.Println("After applying, re-run: juggernaut models refresh --source native --region <region>")
+}
+
+// refuseForeignConfig returns the refusal error for a config Juggernaut does
+// not own and is not a legacy migration target. Both the dry-run (printed) and
+// commit (returned) paths use the same wording so the two views never diverge.
+func refuseForeignConfig(prov provider.Provider, home, scope string, plan provider.ConfigPlan, path string) error {
+	collisions, _ := detectForeignCollisions(home, scope, prov, plan)
+	return fmt.Errorf("refusing to modify %s — it isn't managed by Juggernaut and already has:\n%s\n"+
+		"run with --force to overwrite anyway (a backup is still made before writing)",
+		path, formatCollisions(collisions))
 }
 
 func commitApply(home, authMode, token string, block *schema.Block, prov provider.Provider, bCfg *bedrock.Config, provOpts provider.Options) error {
@@ -403,9 +477,11 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 		return err
 	}
 	if len(collisions) > 0 && !applyFlags.force {
-		return fmt.Errorf("refusing to modify %s — it isn't managed by Juggernaut and already has:\n%s\n"+
-			"run with --force to overwrite anyway (a backup is still made before writing)",
-			path, formatCollisions(collisions))
+		if migrateLegacyJuggernautConfig(prov, home, applyFlags.scope) {
+			announceMigration(prov)
+		} else {
+			return refuseForeignConfig(prov, home, applyFlags.scope, plan, path)
+		}
 	}
 
 	if authmode.IsBedrockAPIKey(authMode) && token != "" {

--- a/cmd/helpers_test_phases_test.go
+++ b/cmd/helpers_test_phases_test.go
@@ -879,7 +879,7 @@ func TestPrintApplyDryRun_CollisionsNoForce(t *testing.T) {
 	if !strings.Contains(out, "Dry run — no changes written.") {
 		t.Fatalf("expected dry run header, got:\n%s", out)
 	}
-	if !strings.Contains(out, "Would refuse to apply") {
+	if !strings.Contains(out, "refusing to modify") {
 		t.Fatalf("expected collision refusal in dry run, got:\n%s", out)
 	}
 	if !strings.Contains(out, "AWS_REGION") {


### PR DESCRIPTION
## Summary

A plain `juggernaut apply` over a pre-v6 (Mantle-era) Juggernaut config no longer refuses with a `--force` prompt. Instead it detects the stale Mantle `base_url` (Grok) or pre-v6 model IDs (Codex), announces the migration, backs up the old config, and rewrites it to route via `bedrock-runtime`.

`--force` is now only required for genuinely foreign configs (ones Juggernaut did not write). Genuinely owned v6 configs re-apply with zero friction, as before.

## Detection

- **Grok**: `[model.bedrock-grok]` `base_url` contains `mantle`
- **Codex**: `model_provider = "amazon-bedrock"` AND `model` matches `openai.gpt-5.*` but NOT `openai.gpt-5.6-*`

## Tests

- `TestApply_Grok_LegacyJuggernautConfig_PlainApplyMigrates` — plain apply over legacy Grok config migrates (no `--force`), writes v6 content, creates backup
- `TestApply_Codex_LegacyJuggernautConfig_PlainApplyMigrates` — same for Codex
- `TestApply_DryRun_LegacyJuggernautConfig_PreviewsMigration` — dry-run previews the migration without writing
- `TestApply_ForeignConfig_NotLegacy_NoMigrationHint` — negative case: foreign config does NOT trigger migration
- `TestApply_Grok_LegacyJuggernautConfig_Force_MigratesToV6` — existing, still passes
- `TestApply_Codex_LegacyJuggernautConfig_Force_MigratesToV6` — existing, still passes

## Quality Pass

- **Dedup:** `migrateLegacyJuggernautConfig` + `announceMigration` + `refuseForeignConfig` extracted to eliminate duplicated refusal/migration logic between dry-run and commit paths
- **Simplify:** `commitApply` refusal block reduced from 12 lines to 6; `printApplyDryRun` refusal block reduced from 10 lines to 8
- **Tests:** 4 new tests covering plain-apply migration (Grok + Codex), dry-run preview, and negative case
- **Skip:** N/A