### PR TITLE
chore(deps): bump github/codeql-action/analyze from 4.37.6 to 4.37.9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,6 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Recreated by maintainer after Dependabot's original PR #419 was auto-closed when its branch tip moved to the current main head (strict up-to-date status check). Same single-file change, cherry-picked from Dependabot's original commit (`49168e3`, authorship preserved): pins `github/codeql-action/analyze` in `.github/workflows/codeql.yml` to `cdf488f595d80d6e07e03d4674febd5ab45fa938` (v4.37.9).

Supersedes #419.