### PR TITLE
feat(codex): default to global inference-profile IDs for GPT-5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Juggernaut will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Codex default models now use global inference-profile IDs.** The GPT-5.6
+  family (sol/terra/luna) is INFERENCE_PROFILE-only on native Bedrock — the
+  base foundation ID (`openai.gpt-5.6-sol`) is listed and ACTIVE but returns
+  `400 on-demand throughput isn't supported` when invoked. Juggernaut now
+  writes the callable `global.openai.gpt-5.6-*` profile ID as the default
+  (verified 2026-08-30). `--model=sol|terra|luna` and raw ID forms
+  (`openai.gpt-5.6-sol`, `gpt-5.6-sol`) all normalize to the global profile ID.
+  Existing v6 Codex configs with the base ID are still recognized as current
+  (not legacy) by the v5→v6 migration detector.
+
 ### Fixed
 
 - **v5 (Mantle-era) configs now auto-migrate on plain `apply`.** Upgrading

--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -701,8 +701,8 @@ region = "us-east-1"
 		t.Fatalf("read config after apply: %v", err)
 	}
 	written := string(content)
-	if !strings.Contains(written, "openai.gpt-5.6-sol") {
-		t.Errorf("migrated config should have v6 default model openai.gpt-5.6-sol, got:\n%s", written)
+	if !strings.Contains(written, "global.openai.gpt-5.6-sol") {
+		t.Errorf("migrated config should have v6 default model global.openai.gpt-5.6-sol, got:\n%s", written)
 	}
 	if strings.Contains(written, "openai.gpt-5.5") {
 		t.Errorf("migrated config must NOT contain old v5 model openai.gpt-5.5, got:\n%s", written)
@@ -897,8 +897,8 @@ region = "us-east-1"
 		t.Fatalf("read config after apply: %v", err)
 	}
 	written := string(content)
-	if !strings.Contains(written, "openai.gpt-5.6-sol") {
-		t.Errorf("migrated config should have v6 default model openai.gpt-5.6-sol, got:\n%s", written)
+	if !strings.Contains(written, "global.openai.gpt-5.6-sol") {
+		t.Errorf("migrated config should have v6 default model global.openai.gpt-5.6-sol, got:\n%s", written)
 	}
 	if strings.Contains(written, "openai.gpt-5.5") {
 		t.Errorf("migrated config must NOT contain old v5 model openai.gpt-5.5, got:\n%s", written)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -399,10 +399,12 @@ func isJuggernautLegacy(existing map[string]any) bool {
 		}
 	}
 	// Codex: a Juggernaut-owned config (amazon-bedrock provider) with a
-	// pre-v6 model ID (openai.gpt-5.x, not the v6 openai.gpt-5.6-* family)
-	// is a Mantle-era config.
+	// pre-v6 model ID (openai.gpt-5.x, not the v6 GPT-5.6 family) is a
+	// Mantle-era config. The v6 GPT-5.6 family may appear as either the base
+	// foundation ID (openai.gpt-5.6-*) or the inference-profile ID
+	// (global.openai.gpt-5.6-* / us.openai.gpt-5.6-*); both are current.
 	if mp, ok := existing["model_provider"]; ok && mp == "amazon-bedrock" {
-		if m, ok := existing["model"].(string); ok && strings.HasPrefix(m, "openai.gpt-5.") && !strings.HasPrefix(m, "openai.gpt-5.6") {
+		if m, ok := existing["model"].(string); ok && strings.HasPrefix(m, "openai.gpt-5.") && !strings.Contains(m, "gpt-5.6") {
 			return true
 		}
 	}

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -70,8 +70,8 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse config.toml: %v", err)
 	}
-	if got["model"] != "openai.gpt-5.6-sol" {
-		t.Errorf("model = %v, want openai.gpt-5.6-sol", got["model"])
+	if got["model"] != "global.openai.gpt-5.6-sol" {
+		t.Errorf("model = %v, want global.openai.gpt-5.6-sol", got["model"])
 	}
 	if got["model_provider"] != "amazon-bedrock" {
 		t.Errorf("model_provider = %v, want amazon-bedrock", got["model_provider"])
@@ -108,10 +108,10 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 		t.Fatalf("apply: %v", err)
 	}
 	data := readFileForTest(t, filepath.Join(home, ".codex", "config.toml"))
-	if !containsStr(data, "openai.gpt-5.6-terra") {
+	if !containsStr(data, "global.openai.gpt-5.6-terra") {
 		t.Errorf("expected gpt-5.6-terra model, got:\n%s", data)
 	}
-	if containsStr(data, "openai.gpt-5.6-sol") {
+	if containsStr(data, "gpt-5.6-sol") {
 		t.Errorf("must not fall back to sol when --model=terra given:\n%s", data)
 	}
 	if !containsStr(data, `model_provider = "amazon-bedrock"`) {

--- a/cmd/model_catalog_coverage_test.go
+++ b/cmd/model_catalog_coverage_test.go
@@ -297,14 +297,15 @@ func TestModelsList_FiltersByProvider(t *testing.T) {
 		},
 		{
 			name:          "codex",
-			source:        "foundation",
+			source:        "native",
 			cli:           "codex",
-			cachedSources: []discovery.Source{discovery.SourceFoundation},
+			cachedSources: []discovery.Source{discovery.SourceFoundation, discovery.SourceProfile},
 			models: []discovery.DiscoveredModel{
 				{ID: "openai.gpt-5.6-sol", Source: discovery.SourceFoundation, Status: "ACTIVE", Availability: "AVAILABLE"},
+				{ID: "global.openai.gpt-5.6-sol", Source: discovery.SourceProfile, Status: "ACTIVE", Availability: "AVAILABLE"},
 				{ID: "xai.grok-4.3", Source: discovery.SourceFoundation, Status: "ACTIVE", Availability: "AVAILABLE"},
 			},
-			wantPresent: []string{"openai.gpt-5.6-sol"},
+			wantPresent: []string{"global.openai.gpt-5.6-sol"},
 			wantAbsent:  []string{"xai.grok-4.3"},
 		},
 		{
@@ -453,6 +454,7 @@ func TestProviderSupportsCatalogModel_UsesProviderCheck(t *testing.T) {
 		{"claude", "anthropic.claude-opus-4-8", "foundation", true},
 		{"claude", "openai.gpt-5.5", "foundation", false},
 		{"codex", "openai.gpt-5.6-sol", "foundation", true},
+		{"codex", "global.openai.gpt-5.6-sol", "profile", true},
 		{"codex", "anthropic.claude-opus-4-8", "foundation", false},
 		{"grok", "xai.grok-4.6", "foundation", true},
 		{"grok", "moonshotai.kimi-k2.5", "foundation", false},

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -207,8 +207,8 @@ func TestCodex_BuildConfig_AmazonBedrockProvider(t *testing.T) {
 	if plan.Keys["model_provider"] != "amazon-bedrock" {
 		t.Errorf("model_provider = %v, want amazon-bedrock", plan.Keys["model_provider"])
 	}
-	if plan.Keys["model"] != "openai.gpt-5.6-sol" {
-		t.Errorf("model = %v, want openai.gpt-5.6-sol", plan.Keys["model"])
+	if plan.Keys["model"] != "global.openai.gpt-5.6-sol" {
+		t.Errorf("model = %v, want global.openai.gpt-5.6-sol", plan.Keys["model"])
 	}
 	// baseOpts uses the default region us-west-2 (non-explicit). sol is available
 	// in us-west-2, so no auto-switch.

--- a/internal/provider/catalog_test.go
+++ b/internal/provider/catalog_test.go
@@ -21,6 +21,8 @@ func TestProviders_ClassifyDiscoveredModels(t *testing.T) {
 		{"claude", catalogModel("global.anthropic.claude-opus-4-8", "profile"), true},
 		{"claude", catalogModel("amazon.nova-pro", "foundation"), false},
 		{"codex", catalogModel("openai.gpt-5.6-sol", "foundation"), true},
+		{"codex", catalogModel("global.openai.gpt-5.6-sol", "foundation"), true},
+		{"codex", catalogModel("us.openai.gpt-5.6-sol", "foundation"), true},
 		{"codex", catalogModel("openai.gpt-oss-120b-1:0", "foundation"), false},
 		{"opencode", catalogModel("moonshotai.kimi-k2.5", "foundation"), true},
 		{"opencode", catalogModel("zai.glm-5", "foundation"), true},
@@ -68,9 +70,21 @@ func TestProviders_CatalogSources(t *testing.T) {
 }
 
 func TestCodexModel_AcceptsRawDiscoveredID(t *testing.T) {
-	model, ok := codexModel("openai.gpt-5.6-sol")
-	if !ok || model.ModelID != "openai.gpt-5.6-sol" {
-		t.Fatalf("codexModel(raw ID) = %+v, %v", model, ok)
+	// The GPT-5.6 family is INFERENCE_PROFILE-only; codexModel normalizes any
+	// non-global form to the global. profile ID.
+	cases := []struct {
+		key, want string
+	}{
+		{"openai.gpt-5.6-sol", "global.openai.gpt-5.6-sol"},
+		{"gpt-5.6-sol", "global.openai.gpt-5.6-sol"},
+		{"global.openai.gpt-5.6-sol", "global.openai.gpt-5.6-sol"},
+		{"sol", "global.openai.gpt-5.6-sol"},
+	}
+	for _, c := range cases {
+		model, ok := codexModel(c.key)
+		if !ok || model.ModelID != c.want {
+			t.Fatalf("codexModel(%q) = %+v, %v; want ModelID %q", c.key, model, ok, c.want)
+		}
 	}
 }
 
@@ -225,7 +239,7 @@ func TestDynamicModelSelectionAndCatalogWarnings(t *testing.T) {
 		model string
 		id    string
 	}{
-		{"codex", "sol", "openai.gpt-5.6-sol"},
+		{"codex", "sol", "global.openai.gpt-5.6-sol"},
 		{"grok", "grok-4.6", "xai.grok-4.6"},
 	}
 	for _, tt := range tests {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -64,24 +64,31 @@ func (c codex) OwnedSubKeys() map[string][]string {
 }
 
 // codexBedrockModel describes one OpenAI-family model reachable through native
-// Bedrock from Codex. Sourced from foundation model verification (2026-08-29).
+// Bedrock from Codex. Sourced from live foundation + inference-profile
+// verification (2026-08-30).
+//
+// The GPT-5.6 family is INFERENCE_PROFILE-only on native Bedrock: the base
+// foundation ID (openai.gpt-5.6-sol) is listed and ACTIVE but returns 400
+// "on-demand throughput isn't supported" when invoked. Only the inference
+// profile IDs (global.openai.gpt-5.6-sol, us.openai.gpt-5.6-sol) are callable.
+// Juggernaut therefore writes the global. profile ID as the default.
 type codexBedrockModel struct {
-	ModelID string   // Bedrock foundation model ID, e.g. "openai.gpt-5.6-sol"
+	ModelID string   // Bedrock inference-profile model ID, e.g. "global.openai.gpt-5.6-sol"
 	Regions []string // regions where available (informational)
 }
 
 // codexModels maps a friendly key to its verified native facts.
 var codexModels = map[string]codexBedrockModel{
 	"sol": {
-		ModelID: "openai.gpt-5.6-sol",
+		ModelID: "global.openai.gpt-5.6-sol",
 		Regions: []string{"us-east-1", "us-east-2", "us-west-2"},
 	},
 	"terra": {
-		ModelID: "openai.gpt-5.6-terra",
+		ModelID: "global.openai.gpt-5.6-terra",
 		Regions: []string{"us-east-1", "us-east-2", "us-west-2"},
 	},
 	"luna": {
-		ModelID: "openai.gpt-5.6-luna",
+		ModelID: "global.openai.gpt-5.6-luna",
 		Regions: []string{"us-east-1", "us-east-2", "us-west-2"},
 	},
 	// NOTE: gpt-oss is intentionally absent. Current Codex is Responses-API-only
@@ -90,17 +97,27 @@ var codexModels = map[string]codexBedrockModel{
 	// gpt-oss remains available via OpenCode (which speaks Chat Completions).
 }
 
+// codexModel resolves a friendly key (sol/terra/luna) or a raw Bedrock model ID
+// (global.openai.gpt-5.6-sol, openai.gpt-5.6-sol, or gpt-5.6-sol) to a
+// codexBedrockModel. Unknown families return the zero value with ok=false.
 func codexModel(key string) (codexBedrockModel, bool) {
 	m, ok := codexModels[key]
 	if ok {
 		return m, true
 	}
-	// Handle full IDs like "openai.gpt-5.6-sol" and short "gpt-5.6-sol"
-	if strings.HasPrefix(key, "gpt-5.6-") {
-		return codexBedrockModel{ModelID: "openai." + key}, true
-	}
-	if strings.HasPrefix(key, "openai.gpt-5.6-") {
+	// Accept the raw forms the user may pass:
+	//   "gpt-5.6-sol"            → canonical global profile ID
+	//   "openai.gpt-5.6-sol"     → same (base ID form, auto-upgraded to global.)
+	//   "global.openai.gpt-5.6-sol" → already canonical
+	// The GPT-5.6 family is INFERENCE_PROFILE-only, so any non-global form is
+	// normalized to the global. profile ID.
+	switch {
+	case strings.HasPrefix(key, "global.openai.gpt-5.6-"):
 		return codexBedrockModel{ModelID: key}, true
+	case strings.HasPrefix(key, "openai.gpt-5.6-"):
+		return codexBedrockModel{ModelID: "global." + key}, true
+	case strings.HasPrefix(key, "gpt-5.6-"):
+		return codexBedrockModel{ModelID: "global.openai." + key}, true
 	}
 	return m, ok
 }
@@ -109,9 +126,14 @@ func codexModel(key string) (codexBedrockModel, bool) {
 func codexDefaultModel() string { return "sol" }
 
 // BuildConfig writes Codex's config.toml using the built-in amazon-bedrock
-// provider. This provider ships a model catalog with native Bedrock foundation
-// IDs (openai.gpt-5.6-sol etc.), eliminating the "Model metadata not found"
-// warning.
+// provider. This provider ships a model catalog with native Bedrock inference
+// profile IDs (global.openai.gpt-5.6-sol etc.), eliminating the "Model
+// metadata not found" warning.
+//
+// The GPT-5.6 family is INFERENCE_PROFILE-only on native Bedrock: the base
+// foundation ID (openai.gpt-5.6-sol) returns 400 "on-demand throughput isn't
+// supported" when invoked. Juggernaut writes the global. profile ID so the
+// config is actually callable.
 //
 // The built-in provider uses the standard AWS credential chain:
 // AWS_BEARER_TOKEN_BEDROCK env var (injected by Juggernaut's launch wrapper) or
@@ -119,7 +141,7 @@ func codexDefaultModel() string { return "sol" }
 //
 // Config shape:
 //
-//	model = "openai.gpt-5.6-sol"
+//	model = "global.openai.gpt-5.6-sol"
 //	model_provider = "amazon-bedrock"
 //	[model_providers.amazon-bedrock.aws]
 //	  region = "us-west-2"
@@ -179,7 +201,11 @@ func (c codex) SupportsModel(model CatalogModel) ModelSupport {
 		if m.Source == "mantle" {
 			return ModelSupport{Reason: "Codex no longer uses Mantle (native only)"}
 		}
-		if !strings.HasPrefix(m.ID, "openai.gpt-5.6") {
+		// The GPT-5.6 family may appear in the catalog as either the base
+		// foundation ID (openai.gpt-5.6-*) or an inference-profile ID
+		// (global.openai.gpt-5.6-* / us.openai.gpt-5.6-*). Accept both; only
+		// the profile IDs are actually callable on-demand.
+		if !strings.Contains(m.ID, "gpt-5.6") {
 			return ModelSupport{Reason: "Codex's built-in Bedrock provider supports OpenAI GPT-5.6 models (sol, terra, luna)"}
 		}
 		return ModelSupport{Supported: true, Reason: "Codex Responses model"}

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -63,8 +63,8 @@ func TestCodexModel_GPT55(t *testing.T) {
 	if !ok {
 		t.Fatal("sol not in Codex model table")
 	}
-	if m.ModelID != "openai.gpt-5.6-sol" {
-		t.Errorf("ModelID = %q, want openai.gpt-5.6-sol", m.ModelID)
+	if m.ModelID != "global.openai.gpt-5.6-sol" {
+		t.Errorf("ModelID = %q, want global.openai.gpt-5.6-sol", m.ModelID)
 	}
 	if len(m.Regions) == 0 {
 		t.Error("sol should have non-empty regions")

--- a/internal/provider/task4_codex_verify_test.go
+++ b/internal/provider/task4_codex_verify_test.go
@@ -9,8 +9,8 @@ func TestTask4_Codex_SolDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildConfig: %v", err)
 	}
-	if m, _ := plan.Keys["model"].(string); m != "openai.gpt-5.6-sol" {
-		t.Errorf("default model = %q, want openai.gpt-5.6-sol", m)
+	if m, _ := plan.Keys["model"].(string); m != "global.openai.gpt-5.6-sol" {
+		t.Errorf("default model = %q, want global.openai.gpt-5.6-sol", m)
 	}
 }
 
@@ -29,10 +29,15 @@ func TestTask4_Codex_SupportsNative(t *testing.T) {
 }
 
 func TestTask4_Codex_Aliases(t *testing.T) {
+	// The GPT-5.6 family is INFERENCE_PROFILE-only; codexModel normalizes all
+	// alias and raw-ID forms to the global. profile ID.
 	cases := map[string]string{
-		"sol":   "openai.gpt-5.6-sol",
-		"terra": "openai.gpt-5.6-terra",
-		"luna":  "openai.gpt-5.6-luna",
+		"sol":                       "global.openai.gpt-5.6-sol",
+		"terra":                     "global.openai.gpt-5.6-terra",
+		"luna":                      "global.openai.gpt-5.6-luna",
+		"gpt-5.6-sol":               "global.openai.gpt-5.6-sol",
+		"openai.gpt-5.6-sol":        "global.openai.gpt-5.6-sol",
+		"global.openai.gpt-5.6-sol": "global.openai.gpt-5.6-sol",
 	}
 	for alias, wantID := range cases {
 		m, ok := codexModel(alias)


### PR DESCRIPTION
## Summary

The GPT-5.6 family (sol/terra/luna) is **INFERENCE_PROFILE-only** on native Bedrock. The base foundation ID (`openai.gpt-5.6-sol`) is listed and ACTIVE but returns `400 on-demand throughput isn't supported` when invoked. Only the inference-profile IDs (`global.openai.gpt-5.6-*`) are actually callable.

Juggernaut now writes the `global.` profile ID as the Codex default so the config is callable out of the box.

## Changes

- `internal/provider/codex.go` — `codexModels` map defaults to `global.openai.gpt-5.6-*`; `codexModel()` normalizes all raw ID forms (`openai.gpt-5.6-*`, `gpt-5.6-*`, `global.openai.gpt-5.6-*`) to the global profile ID; `SupportsModel` accepts both base and profile ID forms
- `cmd/helpers.go` — `isJuggernautLegacy` recognizes `global.openai.gpt-5.6-*` as current (not legacy) via `strings.Contains(m, "gpt-5.6")`
- `CHANGELOG.md` — Unreleased/Changed entry documenting the switch
- Tests — updated all fixtures/assertions to the global IDs; added normalization cases for the raw-ID forms

## Verification

- `go test ./...` — all packages pass
- `go vet ./...` — clean
- Live probe (2026-08-30, boto3, us-west-2): `global.openai.gpt-5.6-sol/luna/terra` return 200 with valid `chat.completion` responses; `us.openai.gpt-5.6-terra` also 200
- Grok 4.6 probe: INFERENCE_PROFILE-only, profile IDs (`global.xai.grok-4.6` / `us.xai.grok-4.6`) time out on every invoke — model is listed/ACTIVE (life-cycle start 2026-08-19) but not callable yet. Grok default remains `xai.grok-4.6` pending AWS enabling the profile.

## Testing notes

- The earlier `aws` CLI 2.36.14 `Errno 22 Invalid argument` on `invoke-model --body` with the `max_completion_tokens` body was a local CLI quirk (Python 3.14 `os.open` on the outfile path), not an AWS-side failure. boto3 bypasses it cleanly.

## Scope

Codex only. Grok default intentionally unchanged (`xai.grok-4.6`) — the model is not callable yet. OpenCode model inventories come from live native discovery, so no static ID change needed there.
