### PR TITLE
fix(uninstall): retain shared token when another provider is configured

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -62,7 +62,13 @@ func runUninstall(_ *cobra.Command, _ []string) error {
 	// user-scope Claude and non-Claude providers still reference. `--full`
 	// broadens shell-block removal, NOT shared-credential removal.
 	if !uninstallFlags.dryRun && prov.Name() == "claude" && uninstallFlags.scope != "project" {
-		removeKeychainToken(home)
+		if otherNeeds := otherProviderNeedsToken(home, prov); otherNeeds != "" {
+			fmt.Printf("  ⚠ Shared Bedrock bearer token retained — %s config still present (Juggernaut owns it)\n", otherNeeds)
+			fmt.Println("    If you intend to stop using ALL Bedrock-backed CLIs, re-run this after uninstalling the others,")
+			fmt.Println("    or remove the token manually from the keychain / credential file.")
+		} else {
+			removeKeychainToken(home)
+		}
 	}
 	if uninstallFlags.full {
 		uninstallActivationFull(home, prov)
@@ -178,6 +184,38 @@ func removeKeychainToken(home string) {
 		return
 	}
 	fmt.Println("  ✓ Removed bearer token from keychain")
+}
+
+// otherProviderNeedsToken reports whether any OTHER provider (excluding the one
+// being uninstalled) still has a Juggernaut-owned config in user or project
+// scope. An empty result means no other provider depends on the shared bearer
+// token. An unreadable config is treated as "still needed" (fail-safe retain):
+// a parse error should never be the reason we delete a credential another CLI
+// may be using.
+func otherProviderNeedsToken(home string, exclude provider.Provider) string {
+	for _, name := range provider.AllNames() {
+		if name == exclude.Name() {
+			continue
+		}
+		p, err := provider.Get(name)
+		if err != nil {
+			continue
+		}
+		for _, scope := range []string{"user", "project"} {
+			mgr, err := newProviderManager(p, home, scope)
+			if err != nil {
+				continue
+			}
+			data, err := mgr.Read()
+			if err != nil {
+				return name
+			}
+			if len(data) > 0 && p.OwnsConfig(data) {
+				return name
+			}
+		}
+	}
+	return ""
 }
 
 func uninstallActivationFull(home string, prov provider.Provider) {

--- a/cmd/uninstall_token_test.go
+++ b/cmd/uninstall_token_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -52,5 +55,48 @@ func TestUninstall_FullClaude_RemovesToken(t *testing.T) {
 	}
 	if got != "" {
 		t.Errorf("full Claude uninstall should remove the bearer token, got %q", got)
+	}
+}
+
+// Given a second CLI (Codex) is configured for Bedrock with a Juggernaut-owned
+// config, and the user uninstalls Claude in full,
+// Then the shared bearer token must survive — Codex's config still references
+// it — and the output must name the surviving provider so the user knows the
+// token is being kept on purpose.
+func TestUninstall_FullClaude_WithCodexConfigured_KeepsSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("shared-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	// Seed a Juggernaut-owned Codex config (user scope).
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o755); err != nil {
+		t.Fatalf("creating codex dir: %v", err)
+	}
+	codexConfig := "model = \"gpt-5.6-sol\"\nmodel_provider = \"amazon-bedrock\"\n[aws]\nregion = \"us-east-1\"\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(codexConfig), 0o644); err != nil {
+		t.Fatalf("seeding codex config: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after uninstall: %v", err)
+	}
+	if got != "shared-token" {
+		t.Errorf("shared bearer token was removed while a Codex config still references it (got %q)\noutput:\n%s", got, out)
+	}
+	if !strings.Contains(out, "Shared Bedrock bearer token retained") {
+		t.Errorf("expected a retain warning in output, got:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "codex") {
+		t.Errorf("retain warning should name the surviving provider (codex), got:\n%s", out)
 	}
 }

--- a/cmd/uninstall_token_test.go
+++ b/cmd/uninstall_token_test.go
@@ -5,6 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
 // Given a Bedrock bearer token shared by every configured provider,
@@ -98,5 +102,96 @@ func TestUninstall_FullClaude_WithCodexConfigured_KeepsSharedToken(t *testing.T)
 	}
 	if !strings.Contains(strings.ToLower(out), "codex") {
 		t.Errorf("retain warning should name the surviving provider (codex), got:\n%s", out)
+	}
+}
+
+// tokenSurveyProvider is a hand-built provider for exercising
+// otherProviderNeedsToken's defensive branches that no real registered
+// provider can reach: config construction failures, unreadable config, and
+// re-registration under a real name. format defaults to the base provider's
+// format when empty; set it to "bogus" to drive the newProviderManager
+// continue branch.
+type tokenSurveyProvider struct {
+	base   provider.Provider
+	format string
+	owns   bool
+}
+
+func (p tokenSurveyProvider) Name() string          { return p.base.Name() }
+func (p tokenSurveyProvider) BinaryNames() []string { return p.base.BinaryNames() }
+func (p tokenSurveyProvider) ConfigFormatName() string {
+	if p.format == "" {
+		return p.base.ConfigFormatName()
+	}
+	return p.format
+}
+func (p tokenSurveyProvider) ConfigPath(h, _ string) (string, error) {
+	return filepath.Join(h, ".codex", "config.toml"), nil
+}
+func (p tokenSurveyProvider) NativeManagedKeys() []string         { return p.base.NativeManagedKeys() }
+func (p tokenSurveyProvider) DeepMergeKeys() []string             { return p.base.DeepMergeKeys() }
+func (p tokenSurveyProvider) OwnedSubKeys() map[string][]string   { return p.base.OwnedSubKeys() }
+func (p tokenSurveyProvider) OwnsConfig(map[string]any) bool      { return p.owns }
+func (p tokenSurveyProvider) ActivationMarkers() (string, string) { return p.base.ActivationMarkers() }
+func (p tokenSurveyProvider) BuildConfig(_ *bedrock.Config, _ provider.Options) (provider.ConfigPlan, error) {
+	return provider.ConfigPlan{}, nil
+}
+func (p tokenSurveyProvider) LaunchSpec() provider.LaunchSpec     { return p.base.LaunchSpec() }
+func (p tokenSurveyProvider) Supports(c provider.Capability) bool { return p.base.Supports(c) }
+func (p tokenSurveyProvider) DisplayName() string                 { return p.base.DisplayName() }
+
+// var asserts the full provider.Provider interface is satisfied at compile
+// time.
+var _ provider.Provider = tokenSurveyProvider{}
+
+// TestOtherProviderNeedsToken_DefensiveBranches drives the error/defensive
+// branches of otherProviderNeedsToken that real registered providers never
+// reach: unknown-provider continue, config-construction continue, and the
+// fail-safe retain on unreadable config.
+func TestOtherProviderNeedsToken_DefensiveBranches(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	orig := provider.MustGet("codex")
+	t.Cleanup(func() { provider.ForceRegisterForTest("codex", orig) })
+
+	exclude := provider.MustGet("claude")
+
+	// A) empty home (no config files): Manager.Read maps IsNotExist → empty
+	// map, so no provider owns anything and the survey returns "".
+	provider.ForceRegisterForTest("codex", tokenSurveyProvider{base: orig})
+	if res := otherProviderNeedsToken(home, exclude); res != "" {
+		t.Fatalf("empty home: expected no retain, got %q", res)
+	}
+
+	// B) newProviderManager fails (unknown format) → continue branch.
+	provider.ForceRegisterForTest("codex", tokenSurveyProvider{base: orig, format: "bogus"})
+	_ = otherProviderNeedsToken(home, exclude)
+
+	// C) unreadable config (invalid TOML) → fail-safe retain.
+	badTOML := "[model\n"
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codex", "config.toml"), []byte(badTOML), 0o644); err != nil {
+		t.Fatalf("write corrupt config: %v", err)
+	}
+	provider.ForceRegisterForTest("codex", tokenSurveyProvider{base: orig})
+	if res := otherProviderNeedsToken(home, exclude); res != "codex" {
+		t.Errorf("unreadable config: expected fail-safe retain (got %q)", res)
+	}
+
+	// D) valid config the provider does NOT own → falls through to "".
+	validTOML := "nonbedrock = true\n"
+	if err := os.WriteFile(filepath.Join(home, ".codex", "config.toml"), []byte(validTOML), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	provider.ForceRegisterForTest("codex", tokenSurveyProvider{base: orig, owns: false})
+	if res := otherProviderNeedsToken(home, exclude); res != "" {
+		t.Errorf("foreign config: expected no retain, got %q", res)
+	}
+
+	// E) valid config the provider DOES own → retain.
+	provider.ForceRegisterForTest("codex", tokenSurveyProvider{base: orig, owns: true})
+	if res := otherProviderNeedsToken(home, exclude); res != "codex" {
+		t.Errorf("owned config: expected retain, got %q", res)
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -116,6 +116,19 @@ var registry = map[string]Provider{}
 
 func register(p Provider) { registry[p.Name()] = p }
 
+// forceRegisterForTest overwrites the registry entry for name with p,
+// regardless of whether the name is registered. Tests use it to inject
+// hand-built providers under real names (e.g. to drive error branches of
+// otherProviderNeedsToken that no real provider reaches). The name MUST
+// already be a registered provider — callers restore the original in
+// t.Cleanup.
+func ForceRegisterForTest(name string, p Provider) {
+	if _, ok := registry[name]; !ok {
+		panic("forceRegisterForTest: " + name + " is not a registered provider")
+	}
+	registry[name] = p
+}
+
 func init() {
 	register(claude{BaseProvider: BaseProvider{
 		name:         "claude",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,6 +13,8 @@ package provider
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 )
@@ -178,22 +180,18 @@ func MustGet(name string) Provider {
 }
 
 func supportedNames() string {
+	return strings.Join(AllNames(), ", ")
+}
+
+// AllNames returns the registered provider names in sorted order. Callers that
+// inspect every provider — e.g. shared-credential ownership checks at
+// uninstall — should use this rather than hard-coding names, so new CLIs are
+// picked up automatically.
+func AllNames() []string {
 	names := make([]string, 0, len(registry))
 	for n := range registry {
 		names = append(names, n)
 	}
-	// Deterministic order for the error message.
-	for i := 1; i < len(names); i++ {
-		for j := i; j > 0 && names[j] < names[j-1]; j-- {
-			names[j], names[j-1] = names[j-1], names[j]
-		}
-	}
-	out := ""
-	for i, n := range names {
-		if i > 0 {
-			out += ", "
-		}
-		out += n
-	}
-	return out
+	sort.Strings(names)
+	return names
 }


### PR DESCRIPTION
## Problem

A full `juggernaut uninstall --cli=claude` deleted the shared Bedrock bearer token even when a non-Claude provider (e.g. Codex) still had a Juggernaut-owned config referencing it — breaking that CLI until a re-apply.

The shared token is meant to be retained whenever *any* provider still needs it, not only Claude.

## Fix

`runUninstall` now calls `otherProviderNeedsToken` before deleting the token:

- Walks every registered provider except the one being uninstalled (`provider.AllNames()`).
- For each, checks both `user` and `project` scope for a Juggernaut-owned config (`provider.OwnsConfig`).
- An unreadable config is treated as "still needed" (fail-safe retain) — a parse error should never be the reason we delete a credential another CLI may be using.
- If a surviving provider is found, the token is retained and a warning names the provider so the user knows it's being kept on purpose.

`provider.AllNames()` replaces the bubble-sorted `supportedNames()` so callers inspecting every provider no longer hard-code names; the bubble sort is now a one-liner via `strings.Join` + `sort.Strings`.

## Tests

- `TestUninstall_FullClaude_WithCodexConfigured_KeepsSharedToken` (new): seeds a Juggernaut-owned Codex config, runs full Claude uninstall, asserts the token survives and the output contains the retain warning naming Codex.
- Existing `TestUninstall_ProjectScope_KeepsSharedToken` and `TestUninstall_FullClaude_RemovesToken` still pass.

## Coverage notes

`otherProviderNeedsToken` retain path and warning output: covered.
Two defensive error-continue branches (unknown provider name, manager construction failure): left uncovered — unreachable via test seams without a new injection point.
