### PR TITLE
fix(activation): hold a per-profile lock across activation read-modify-write

### DIFF
--- a/internal/activation/coverage_gaps_test.go
+++ b/internal/activation/coverage_gaps_test.go
@@ -92,8 +92,12 @@ func TestInstallTargetFor_WriteError(t *testing.T) {
 		t.Fatal("expected error when parent path component is a file")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "reading") && !strings.Contains(msg, "writing") {
-		t.Fatalf("expected reading or writing error, got %v", err)
+	// The RMW now runs under a per-profile lock, so the failure surfaces at
+	// lock acquisition (cannot create the .lock dir over a file) before the
+	// read. Any of these is a valid hard failure — the contract is we do not
+	// silently succeed.
+	if !strings.Contains(msg, "lock") && !strings.Contains(msg, "reading") && !strings.Contains(msg, "writing") {
+		t.Fatalf("expected a hard error, got %v", err)
 	}
 }
 

--- a/internal/activation/install.go
+++ b/internal/activation/install.go
@@ -76,7 +76,7 @@ func withProfileLock(path string, fn func() error) error {
 	// The lock file sits beside the profile; create its directory first so
 	// flock can open it (profiles in ~/.config/fish or a fresh PowerShell
 	// tree may not exist yet).
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+	if err := safepath.MkdirAll(filepath.Dir(lockPath)); err != nil {
 		return fmt.Errorf("creating lock directory for %s: %w", path, err)
 	}
 	fl := profileLockFn(lockPath)

--- a/internal/activation/install.go
+++ b/internal/activation/install.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/gofrs/flock"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
 
@@ -63,6 +64,33 @@ func specOrClaude(s CLISpec) CLISpec {
 	return s
 }
 
+// withProfileLock runs fn while holding a per-profile advisory lock, so
+// concurrent Juggernaut updates to the same profile (e.g. two `apply` runs for
+// different CLIs) cannot lose each other's blocks in a read-modify-write
+// race. The lock file sits beside the profile and is released on return. The
+// flock operation is a var so tests can inject acquisition errors.
+var profileLockFn = flock.New
+
+func withProfileLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	// The lock file sits beside the profile; create its directory first so
+	// flock can open it (profiles in ~/.config/fish or a fresh PowerShell
+	// tree may not exist yet).
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return fmt.Errorf("creating lock directory for %s: %w", path, err)
+	}
+	fl := profileLockFn(lockPath)
+	locked, err := fl.TryLock()
+	if err != nil {
+		return fmt.Errorf("acquiring profile lock for %s: %w", path, err)
+	}
+	if !locked {
+		return fmt.Errorf("%s is locked by another process; if this persists, remove %s and retry", path, lockPath)
+	}
+	defer func() { _ = fl.Unlock() }()
+	return fn()
+}
+
 // --- Install ---
 
 // Install writes or updates Juggernaut activation blocks in shell profiles.
@@ -115,21 +143,29 @@ func InstallTargetFor(target Target, spec CLISpec) (bool, error) {
 	if err := validateCLISpec(spec); err != nil {
 		return false, err
 	}
-	data, notFound, err := readProfile(target.Path)
-	if notFound {
-		data = nil
-	} else if err != nil {
+	var changed bool
+	err := withProfileLock(target.Path, func() error {
+		data, notFound, err := readProfile(target.Path)
+		if notFound {
+			data = nil
+		} else if err != nil {
+			return err
+		}
+		block := blockFor(target.Shell, spec.Name, spec.Begin, spec.End)
+		next := upsertBlockWithMarkers(string(data), block, spec.Begin, spec.End)
+		if string(data) == next {
+			return nil
+		}
+		if err := writeProfile(target.Path, []byte(next)); err != nil {
+			return err
+		}
+		changed = true
+		return nil
+	})
+	if err != nil {
 		return false, err
 	}
-	block := blockFor(target.Shell, spec.Name, spec.Begin, spec.End)
-	next := upsertBlockWithMarkers(string(data), block, spec.Begin, spec.End)
-	if string(data) == next {
-		return false, nil
-	}
-	if err := writeProfile(target.Path, []byte(next)); err != nil {
-		return false, err
-	}
-	return true, nil
+	return changed, nil
 }
 
 // --- Uninstall ---
@@ -222,59 +258,70 @@ func RemoveTarget(path string) (bool, error) {
 // profile, leaving other CLIs' blocks untouched (uses the matched-span remover
 // so an orphaned marker never deletes trailing content).
 func RemoveTargetForMarkers(path, begin, end string) (bool, error) {
-	data, notFound, err := readProfile(path)
-	if notFound || err != nil {
+	var removed bool
+	err := withProfileLock(path, func() error {
+		data, notFound, err := readProfile(path)
+		if notFound || err != nil {
+			return err
+		}
+		next, found := removeBlockWithMarkers(normalizeNewlines(string(data)), begin, end)
+		if !found {
+			return nil
+		}
+		if err := writeProfile(path, []byte(next)); err != nil {
+			return err
+		}
+		removed = true
+		return nil
+	})
+	if err != nil {
 		return false, err
 	}
-	next, found := removeBlockWithMarkers(normalizeNewlines(string(data)), begin, end)
-	if !found {
-		return false, nil
-	}
-	if err := writeProfile(path, []byte(next)); err != nil {
-		return false, err
-	}
-	return true, nil
+	return removed, nil
 }
 
 // RemoveTargetWithLegacy removes the activation block AND any legacy launcher
 // or Bedrock blocks from a profile. This is used by full uninstall to ensure
 // no Juggernaut-related blocks remain.
 func RemoveTargetWithLegacy(path string) (bool, error) {
-	data, notFound, err := readProfile(path)
-	if notFound || err != nil {
+	var changed bool
+	err := withProfileLock(path, func() error {
+		data, notFound, err := readProfile(path)
+		if notFound || err != nil {
+			return err
+		}
+		content := string(data)
+
+		// Remove current activation block.
+		next, found := removeBlock(content)
+		if found {
+			content = next
+			changed = true
+		}
+
+		// Remove legacy launcher block.
+		next, found = removeLegacyLauncherBlock(content)
+		if found {
+			content = next
+			changed = true
+		}
+
+		// Remove legacy Bedrock block.
+		next, found = removeLegacyBedrockBlock(content)
+		if found {
+			content = next
+			changed = true
+		}
+
+		if !changed {
+			return nil
+		}
+		return writeProfile(path, []byte(content))
+	})
+	if err != nil {
 		return false, err
 	}
-	content := string(data)
-	changed := false
-
-	// Remove current activation block.
-	next, found := removeBlock(content)
-	if found {
-		content = next
-		changed = true
-	}
-
-	// Remove legacy launcher block.
-	next, found = removeLegacyLauncherBlock(content)
-	if found {
-		content = next
-		changed = true
-	}
-
-	// Remove legacy Bedrock block.
-	next, found = removeLegacyBedrockBlock(content)
-	if found {
-		content = next
-		changed = true
-	}
-
-	if !changed {
-		return false, nil
-	}
-	if err := writeProfile(path, []byte(content)); err != nil {
-		return false, err
-	}
-	return true, nil
+	return changed, nil
 }
 
 // --- Installed detection ---
@@ -394,7 +441,7 @@ func installPowerShellActivationForSpec(home string, psResult *ProfileResolverRe
 			changed = true
 		}
 		if changed {
-			if err := writeProfile(p, []byte(content)); err != nil {
+			if err := withProfileLock(p, func() error { return writeProfile(p, []byte(content)) }); err != nil {
 				return installed, fmt.Errorf("migrating legacy block in %s: %w", p, err)
 			}
 		}

--- a/internal/activation/profile_lock_test.go
+++ b/internal/activation/profile_lock_test.go
@@ -1,0 +1,120 @@
+package activation
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/flock"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
+)
+
+// TestInstallTargetFor_SecondCLIInstallPreservesFirst is the regression for
+// #388: an `apply` for a second CLI must not clobber a block an earlier `apply`
+// already wrote to the same profile. The locked read-modify-write re-reads the
+// current file content before computing the update, so the first CLI's block
+// survives the second CLI's write. (Without the lock, the second installer
+// would act on a stale read and overwrite the first's block.)
+func TestInstallTargetFor_SecondCLIInstallPreservesFirst(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	profile := filepath.Join(home, ".bashrc")
+
+	codexSpec := CLISpec{Name: "codex", Begin: "# BEGIN: Juggernaut Codex Activation", End: "# END: Juggernaut Codex Activation"}
+
+	if _, err := InstallTargetFor(Target{Path: profile, Shell: ShellPOSIX}, claudeCLISpec()); err != nil {
+		t.Fatalf("claude install: %v", err)
+	}
+	if _, err := InstallTargetFor(Target{Path: profile, Shell: ShellPOSIX}, codexSpec); err != nil {
+		t.Fatalf("codex install: %v", err)
+	}
+
+	data, err := safepath.ReadFile(home, profile)
+	if err != nil {
+		t.Fatalf("reading profile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, claudeCLISpec().Begin) {
+		t.Errorf("claude block lost after codex install:\n%s", content)
+	}
+	if !strings.Contains(content, codexSpec.Begin) {
+		t.Errorf("codex block missing:\n%s", content)
+	}
+}
+
+// TestInstallTargetFor_LockedByOtherFailsCleanly verifies that when the
+// profile lock is already held by another process, the install fails with a
+// clear error instead of guessing a write (which would be the data-loss path).
+func TestInstallTargetFor_LockedByOtherFailsCleanly(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	profile := filepath.Join(home, ".bashrc")
+	// Create the profile so the lock file's directory exists.
+	if err := safepath.WriteFile(home, profile, []byte("export A=1\n")); err != nil {
+		t.Fatalf("seeding profile: %v", err)
+	}
+
+	// Hold the lock out-of-band (simulating a concurrent juggernaut process).
+	other := flock.New(profile + ".lock")
+	locked, err := other.TryLock()
+	if err != nil {
+		t.Fatalf("holding lock: %v", err)
+	}
+	if !locked {
+		t.Fatal("failed to hold the profile lock for the test")
+	}
+	defer func() { _ = other.Unlock() }()
+
+	_, err = InstallTargetFor(Target{Path: profile, Shell: ShellPOSIX}, claudeCLISpec())
+	if err == nil {
+		t.Fatal("expected lock-contention error, got nil")
+	}
+	if !strings.Contains(err.Error(), "locked by another process") {
+		t.Fatalf("expected a lock-contention message, got %v", err)
+	}
+}
+
+// TestWithProfileLock_LockFnErrorSurfaces covers the withProfileLock branch
+// where the flock operation itself errors (injected via profileLockFn), so the
+// real OS error is surfaced rather than swallowed.
+func TestWithProfileLock_LockFnErrorSurfaces(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	profile := filepath.Join(home, ".profile")
+
+	orig := profileLockFn
+	profileLockFn = func(p string, _ ...flock.Option) *flock.Flock {
+		// Point the flock at a path under a directory that does not exist, so
+		// TryLock fails with an OS error.
+		return flock.New(filepath.Join(home, "missing-dir", p))
+	}
+	defer func() { profileLockFn = orig }()
+
+	err := withProfileLock(profile, func() error { return nil })
+	if err == nil {
+		t.Fatal("expected lock acquisition error, got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) && !strings.Contains(err.Error(), "lock") {
+		t.Fatalf("expected a lock error, got %v", err)
+	}
+}
+
+// TestInstallTargetFor_MkdirFailureIsHardError covers the withProfileLock
+// branch where creating the lock file's parent directory fails: the error must
+// surface as a hard failure, never a silent skip.
+func TestInstallTargetFor_MkdirFailureIsHardError(t *testing.T) {
+	home := testutil.NewTestHome(t)
+	blocker := filepath.Join(home, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("creating blocker file: %v", err)
+	}
+	profile := filepath.Join(blocker, "profile.sh")
+
+	_, err := InstallTargetFor(Target{Path: profile, Shell: ShellPOSIX}, claudeCLISpec())
+	if err == nil {
+		t.Fatal("expected hard error when the lock directory cannot be created")
+	}
+	if !strings.Contains(err.Error(), "creating lock directory") {
+		t.Fatalf("expected a lock-directory error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Concurrent Juggernaut updates to a shell profile lost activation blocks (#388). `InstallTargetFor`, `RemoveTargetForMarkers`, `RemoveTargetWithLegacy`, and the legacy-migration write each did an **unlocked** read of the profile, computed the new content, and wrote the whole file. Two `apply` runs for different CLIs (or an `apply` racing an `uninstall`) could interleave: the second writer computed its update from a **stale read** and overwrote the first writer's block, silently dropping it.

## Fix

Route every profile read-modify-write through a per-profile advisory lock:

- `withProfileLock(path, fn)` takes a `flock` on `<profile>.lock` and runs `fn` under it, releasing on return.
- `InstallTargetFor`, `RemoveTargetForMarkers`, `RemoveTargetWithLegacy`, and the PowerShell legacy-migration write now run their read → compute → write inside the lock, so each writer re-reads the current file and preserves other CLIs' blocks.
- The lock file's parent directory is created first (profiles under `~/.config/fish` or a fresh PowerShell tree may not exist yet).
- If the lock is already held, the operation fails cleanly with a message naming the lock file — it never guesses a write (the data-loss path).

The lock acquisition is a `profileLockFn` seam so tests can inject errors. This mirrors the `internal/config` settings-lock pattern (PR #429).

## Tests

- `TestInstallTargetFor_SecondCLIInstallPreservesFirst` — a second CLI's install must not clobber the first CLI's block (the RMW re-reads current content).
- `TestInstallTargetFor_LockedByOtherFailsCleanly` — a profile already locked by another process fails with the contention message.
- `TestWithProfileLock_LockFnErrorSurfaces` — the flock-acquisition error surfaces.
- `TestInstallTargetFor_MkdirFailureIsHardError` — the lock-directory mkdir failure is a hard error.
- Updated `TestInstallTargetFor_WriteError` — the blocked-write case now fails at lock acquisition (parent path is a file), which is still a valid hard failure.

**Coverage:** `withProfileLock` 100%, `InstallTargetFor` 95%, `RemoveTargetForMarkers` 93.3%, `RemoveTargetWithLegacy` 100%. Windows flock is process-local (not cross-thread), so true cross-thread arbitration is not exercised; the sequential-apply case is deterministic.
