### PR TITLE
fix(apply): migrate leftover Codex/OpenCode Mantle providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Juggernaut will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Leftover Codex/OpenCode Mantle providers now migrate on plain `apply`.**
+  v6.1.0 only treated Codex `model_provider = "amazon-bedrock"` plus a
+  pre-5.6 model ID as legacy. Real v5 configs used
+  `model_provider = "bedrock-mantle"` (and OpenCode
+  `provider.bedrock-mantle`); those looked foreign, so plain apply refused
+  without `--force` and Codex kept POSTing to `bedrock-mantle.*.api.aws`
+  (404 on `gpt-5.6-sol` / `gpt-5.5`). Apply now detects Mantle `base_url` /
+  `bedrock-mantle` tables — including hybrid v6 model IDs still aimed at
+  Mantle — announces the rewrite, writes `amazon-bedrock`, and strips the
+  leftover Mantle provider block.
+
 ## [6.1.0] - 2026-08-31
 
 ### Changed

--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -909,3 +909,159 @@ region = "us-east-1"
 		t.Error("expected a backup of the legacy codex config to be created with --force")
 	}
 }
+
+const legacyCodexMantleProvider = `model = "openai.gpt-5.5"
+model_provider = "bedrock-mantle"
+
+[model_providers.bedrock-mantle]
+name = "Amazon Bedrock (Mantle)"
+base_url = "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+wire_api = "responses"
+`
+
+const legacyCodexHybridMantle = `model = "global.openai.gpt-5.6-sol"
+model_provider = "amazon-bedrock"
+
+[model_providers.amazon-bedrock.aws]
+region = "us-west-2"
+
+[model_providers.bedrock-mantle]
+base_url = "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+`
+
+const legacyOpenCodeMantle = `{
+  "model": "bedrock-mantle/openai.gpt-oss-120b-1:0",
+  "provider": {
+    "bedrock-mantle": {
+      "options": {"region": "us-west-2"}
+    }
+  }
+}
+`
+
+func writeHomeFile(t *testing.T, home, relDir, filename, contents string) string {
+	t.Helper()
+	dir := filepath.Join(home, filepath.FromSlash(relDir))
+	if err := safepath.MkdirAll(dir); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, filename)
+	if err := safepath.WriteFile(dir, path, []byte(contents)); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func applyCLI(t *testing.T, cli string, extra ...string) string {
+	t.Helper()
+	args := append([]string{
+		"apply", "--cli=" + cli, "--auth=" + authmode.BedrockAPIKey, bedrockKeyFlag(),
+		"--region=us-west-2", "--skip-preflight",
+	}, extra...)
+	var applyErr error
+	out := captureStdout(t, func() {
+		applyErr = ExecuteArgs(args)
+	})
+	if applyErr != nil {
+		t.Fatalf("apply --cli=%s: %v", cli, applyErr)
+	}
+	return out
+}
+
+func readHomeFile(t *testing.T, dir, path string) string {
+	t.Helper()
+	content, err := safepath.ReadFile(dir, path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func assertMigrated(t *testing.T, out, written string, wantContains, wantAbsent []string) {
+	t.Helper()
+	if !strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("apply should announce the v5→v6 migration, got:\n%s", out)
+	}
+	for _, s := range wantContains {
+		if !strings.Contains(written, s) {
+			t.Errorf("migrated config should contain %q, got:\n%s", s, written)
+		}
+	}
+	for _, s := range wantAbsent {
+		if strings.Contains(written, s) {
+			t.Errorf("migrated config must NOT contain %q, got:\n%s", s, written)
+		}
+	}
+}
+
+// TestApply_Codex_MantleProvider_PlainApplyMigrates: a real v5 Codex config
+// (model_provider = "bedrock-mantle") must migrate on plain apply — OwnsConfig
+// is false for that id, so this used to refuse without --force (#435).
+func TestApply_Codex_MantleProvider_PlainApplyMigrates(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+	path := writeHomeFile(t, home, ".codex", "config.toml", legacyCodexMantleProvider)
+
+	out := applyCLI(t, "codex")
+	written := readHomeFile(t, filepath.Dir(path), path)
+	assertMigrated(t, out, written,
+		[]string{"global.openai.gpt-5.6-sol", "amazon-bedrock"},
+		[]string{"bedrock-mantle", "openai.gpt-5.5"},
+	)
+	if matches, _ := filepath.Glob(path + ".backup.*"); len(matches) == 0 {
+		t.Error("expected a backup of the leftover Mantle Codex config")
+	}
+}
+
+// TestApply_Codex_HybridMantleLeftover_PlainApplyMigrates: v6 model pin still
+// paired with a leftover [model_providers.bedrock-mantle] table must migrate
+// and drop the Mantle block (deep-merge would otherwise keep the sibling).
+func TestApply_Codex_HybridMantleLeftover_PlainApplyMigrates(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+	path := writeHomeFile(t, home, ".codex", "config.toml", legacyCodexHybridMantle)
+
+	out := applyCLI(t, "codex")
+	written := readHomeFile(t, filepath.Dir(path), path)
+	assertMigrated(t, out, written,
+		[]string{"global.openai.gpt-5.6-sol", "amazon-bedrock"},
+		[]string{"bedrock-mantle"},
+	)
+}
+
+// TestApply_OpenCode_MantleProvider_PlainApplyMigrates: leftover
+// provider.bedrock-mantle must migrate to amazon-bedrock on plain apply.
+func TestApply_OpenCode_MantleProvider_PlainApplyMigrates(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+	path := writeHomeFile(t, home, ".config/opencode", "opencode.json", legacyOpenCodeMantle)
+
+	out := applyCLI(t, "opencode")
+	written := readHomeFile(t, filepath.Dir(path), path)
+	assertMigrated(t, out, written,
+		[]string{"amazon-bedrock"},
+		[]string{"bedrock-mantle"},
+	)
+}
+
+// TestApply_Codex_MantleProvider_DryRunPreviewsMigration: dry-run over a
+// leftover Mantle Codex config must announce the rewrite without writing.
+func TestApply_Codex_MantleProvider_DryRunPreviewsMigration(t *testing.T) {
+	home := setupApplyTest(t)
+	path := writeHomeFile(t, home, ".codex", "config.toml", legacyCodexMantleProvider)
+
+	out := applyCLI(t, "codex", "--dry-run")
+	if !strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("dry-run should preview the v5→v6 migration, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Would write juggernaut config") {
+		t.Errorf("dry-run should still show what would be written, got:\n%s", out)
+	}
+	got := readHomeFile(t, filepath.Dir(path), path)
+	if got != legacyCodexMantleProvider {
+		t.Error("dry-run must not modify the leftover Mantle file")
+	}
+	if matches, _ := filepath.Glob(path + ".backup.*"); len(matches) != 0 {
+		t.Error("dry-run must not create a backup")
+	}
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -339,16 +339,16 @@ func printApplyDryRun(home string, block *schema.Block, prov provider.Provider, 
 	if err != nil {
 		return err
 	}
-	if len(collisions) > 0 && !applyFlags.force {
-		if migrateLegacyJuggernautConfig(prov, home, applyFlags.scope) {
-			announceMigration(prov)
-		} else {
-			// Dry-run never errors — it prints the same refusal the commit
-			// path would return, so the user can preview what a real apply
-			// would do.
-			fmt.Print(refuseForeignConfig(prov, home, applyFlags.scope, plan, path).Error() + "\n")
-			return nil
-		}
+	migrating, refuse := applyWriteGate(home, prov, plan, path, collisions)
+	if refuse != nil {
+		// Dry-run never errors — it prints the same refusal the commit
+		// path would return, so the user can preview what a real apply
+		// would do.
+		fmt.Print(refuse.Error() + "\n")
+		return nil
+	}
+	if migrating {
+		announceMigration(prov)
 	}
 
 	title := prov.DisplayName()
@@ -383,32 +383,135 @@ func detectForeignCollisions(home, scope string, prov provider.Provider, plan pr
 	return config.DetectCollisions(existing, plan.Keys, prov.DeepMergeKeys(), prov.OwnedSubKeys()), nil
 }
 
+const mantleProviderID = "bedrock-mantle"
+
+// applyWriteGate decides whether apply should migrate a legacy Juggernaut
+// config, refuse a foreign config, or proceed. migrating is true when the
+// existing file is a pre-v6 (Mantle-era) Juggernaut config.
+func applyWriteGate(home string, prov provider.Provider, plan provider.ConfigPlan, path string, collisions []config.Collision) (migrating bool, refuse error) {
+	migrating = migrateLegacyJuggernautConfig(prov, home, applyFlags.scope)
+	if migrating || applyFlags.force || len(collisions) == 0 {
+		return migrating, nil
+	}
+	return false, refuseForeignConfig(prov, home, applyFlags.scope, plan, path)
+}
+
 // isJuggernautLegacy reports whether the existing config was written by a
 // pre-v6 Juggernaut (Mantle-era) and is stale for v6's bedrock-runtime
 // routing. Returns false for configs that don't look like Juggernaut's own
 // (foreign user configs, non-Juggernaut tooling) — those still require
 // --force. Legacy Juggernaut configs are migrated by a plain apply: the
 // write clobbers the file and the backup preserves the old content.
+//
+// Detection covers:
+//   - Grok [model.bedrock-grok] base_url pointing at Mantle
+//   - Codex model_provider == "bedrock-mantle" (the real v5 provider id)
+//   - leftover [model_providers.bedrock-mantle] / provider.bedrock-mantle
+//     tables, including hybrid v6 model IDs still aimed at a Mantle URL
+//   - Codex amazon-bedrock + pre-v6 GPT-5 model IDs (openai.gpt-5.x, not 5.6)
 func isJuggernautLegacy(existing map[string]any) bool {
-	// Grok: [model.bedrock-grok] base_url pointed at Mantle.
-	if model, ok := existing["model"].(map[string]any); ok {
-		if grokModel, ok := model["bedrock-grok"].(map[string]any); ok {
-			if bu, ok := grokModel["base_url"].(string); ok && strings.Contains(bu, "mantle") {
-				return true
-			}
-		}
+	if existing == nil {
+		return false
 	}
-	// Codex: a Juggernaut-owned config (amazon-bedrock provider) with a
-	// pre-v6 model ID (openai.gpt-5.x, not the v6 GPT-5.6 family) is a
-	// Mantle-era config. The v6 GPT-5.6 family may appear as either the base
-	// foundation ID (openai.gpt-5.6-*) or the inference-profile ID
-	// (global.openai.gpt-5.6-* / us.openai.gpt-5.6-*); both are current.
-	if mp, ok := existing["model_provider"]; ok && mp == "amazon-bedrock" {
-		if m, ok := existing["model"].(string); ok && strings.HasPrefix(m, "openai.gpt-5.") && !strings.Contains(m, "gpt-5.6") {
+	if grokMantleBaseURL(existing) {
+		return true
+	}
+	if mp, ok := existing["model_provider"].(string); ok && isMantleProviderID(mp) {
+		return true
+	}
+	if hasMantleTable(existing["model_providers"]) || hasMantleTable(existing["provider"]) {
+		return true
+	}
+	return isCodexPreV6AmazonBedrock(existing)
+}
+
+func grokMantleBaseURL(existing map[string]any) bool {
+	model, ok := existing["model"].(map[string]any)
+	if !ok {
+		return false
+	}
+	grokModel, ok := model["bedrock-grok"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return containsMantleURL(grokModel)
+}
+
+func isCodexPreV6AmazonBedrock(existing map[string]any) bool {
+	if existing["model_provider"] != "amazon-bedrock" {
+		return false
+	}
+	m, ok := existing["model"].(string)
+	if !ok {
+		return false
+	}
+	// v6 GPT-5.6 may appear as openai.gpt-5.6-* or global./us. profile IDs;
+	// those are current. openai.gpt-5.4 / gpt-5.5 are Mantle-era pins.
+	return strings.HasPrefix(m, "openai.gpt-5.") && !strings.Contains(m, "gpt-5.6")
+}
+
+func isMantleProviderID(id string) bool {
+	return id == mantleProviderID
+}
+
+func hasMantleTable(v any) bool {
+	tbl, ok := v.(map[string]any)
+	if !ok {
+		return false
+	}
+	for id, entry := range tbl {
+		if isMantleLeftover(id, entry) {
 			return true
 		}
 	}
 	return false
+}
+
+func isMantleLeftover(id string, entry any) bool {
+	return isMantleProviderID(id) || containsMantleURL(entry)
+}
+
+func containsMantleURL(v any) bool {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return false
+	}
+	if stringHasMantle(m["base_url"]) {
+		return true
+	}
+	opt, ok := m["options"].(map[string]any)
+	return ok && stringHasMantle(opt["base_url"])
+}
+
+func stringHasMantle(v any) bool {
+	s, ok := v.(string)
+	return ok && strings.Contains(strings.ToLower(s), "mantle")
+}
+
+// stripMantleLeftovers deletes leftover Mantle provider tables that deep-merge
+// would otherwise preserve as siblings of amazon-bedrock. The native
+// amazon-bedrock entry is never removed.
+func stripMantleLeftovers(existing map[string]any) {
+	stripMantleTable(existing, "model_providers")
+	stripMantleTable(existing, "provider")
+}
+
+func stripMantleTable(root map[string]any, key string) {
+	tbl, ok := root[key].(map[string]any)
+	if !ok {
+		return
+	}
+	for id, entry := range tbl {
+		if id == "amazon-bedrock" {
+			continue
+		}
+		if isMantleLeftover(id, entry) {
+			delete(tbl, id)
+		}
+	}
+	if len(tbl) == 0 {
+		delete(root, key)
+	}
 }
 
 // formatCollisions renders one line per collision for the refusal error/dry-run
@@ -478,12 +581,12 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 	if err != nil {
 		return err
 	}
-	if len(collisions) > 0 && !applyFlags.force {
-		if migrateLegacyJuggernautConfig(prov, home, applyFlags.scope) {
-			announceMigration(prov)
-		} else {
-			return refuseForeignConfig(prov, home, applyFlags.scope, plan, path)
-		}
+	migrating, refuse := applyWriteGate(home, prov, plan, path, collisions)
+	if refuse != nil {
+		return refuse
+	}
+	if migrating {
+		announceMigration(prov)
 	}
 
 	if authmode.IsBedrockAPIKey(authMode) && token != "" {
@@ -496,7 +599,11 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 	if err != nil {
 		return err
 	}
-	if err := mgr.MergeConfigPlanDeep(plan.Keys, prov.DeepMergeKeys()); err != nil {
+	if err := mgr.MergeConfigPlanDeepThen(plan.Keys, prov.DeepMergeKeys(), func(existing map[string]any) {
+		if migrating {
+			stripMantleLeftovers(existing)
+		}
+	}); err != nil {
 		return err
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -485,7 +485,9 @@ func containsMantleURL(v any) bool {
 
 func stringHasMantle(v any) bool {
 	s, ok := v.(string)
-	return ok && strings.Contains(strings.ToLower(s), "mantle")
+	// Match the v5 Mantle host (bedrock-mantle.<region>.api.aws), not any
+	// URL that happens to contain the substring "mantle".
+	return ok && strings.Contains(strings.ToLower(s), "bedrock-mantle.")
 }
 
 // stripMantleLeftovers deletes leftover Mantle provider tables that deep-merge

--- a/cmd/helpers_legacy_test.go
+++ b/cmd/helpers_legacy_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import "testing"
+
+func TestIsJuggernautLegacy(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "empty", in: map[string]any{}, want: false},
+		{
+			name: "grok mantle base_url",
+			in: map[string]any{
+				"model": map[string]any{
+					"bedrock-grok": map[string]any{
+						"base_url": "https://bedrock-mantle.us-west-2.api.aws/openai/v1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "grok native runtime url is current",
+			in: map[string]any{
+				"model": map[string]any{
+					"bedrock-grok": map[string]any{
+						"base_url": "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "codex amazon-bedrock plus gpt-5.5",
+			in: map[string]any{
+				"model":          "openai.gpt-5.5",
+				"model_provider": "amazon-bedrock",
+			},
+			want: true,
+		},
+		{
+			name: "codex amazon-bedrock plus gpt-5.6 is current",
+			in: map[string]any{
+				"model":          "openai.gpt-5.6-sol",
+				"model_provider": "amazon-bedrock",
+			},
+			want: false,
+		},
+		{
+			name: "codex amazon-bedrock plus global gpt-5.6 is current",
+			in: map[string]any{
+				"model":          "global.openai.gpt-5.6-sol",
+				"model_provider": "amazon-bedrock",
+			},
+			want: false,
+		},
+		{
+			name: "codex model_provider bedrock-mantle",
+			in: map[string]any{
+				"model":          "openai.gpt-5.5",
+				"model_provider": "bedrock-mantle",
+			},
+			want: true,
+		},
+		{
+			name: "codex leftover model_providers.bedrock-mantle",
+			in: map[string]any{
+				"model":          "global.openai.gpt-5.6-sol",
+				"model_provider": "amazon-bedrock",
+				"model_providers": map[string]any{
+					"amazon-bedrock": map[string]any{"aws": map[string]any{"region": "us-west-2"}},
+					"bedrock-mantle": map[string]any{
+						"base_url": "https://bedrock-mantle.us-west-2.api.aws/openai/v1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "codex custom provider id with mantle url",
+			in: map[string]any{
+				"model":          "openai.gpt-5.5",
+				"model_provider": "my-bedrock",
+				"model_providers": map[string]any{
+					"my-bedrock": map[string]any{
+						"base_url": "https://bedrock-mantle.us-east-1.api.aws/openai/v1",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "opencode provider.bedrock-mantle",
+			in: map[string]any{
+				"model": "bedrock-mantle/openai.gpt-oss-120b-1:0",
+				"provider": map[string]any{
+					"bedrock-mantle": map[string]any{
+						"options": map[string]any{"region": "us-west-2"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "opencode amazon-bedrock is current",
+			in: map[string]any{
+				"model": "amazon-bedrock/openai.gpt-oss-120b-1:0",
+				"provider": map[string]any{
+					"amazon-bedrock": map[string]any{
+						"options": map[string]any{"region": "us-west-2"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "foreign openai provider",
+			in: map[string]any{
+				"model":          "gpt-5",
+				"model_provider": "openai",
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isJuggernautLegacy(tc.in); got != tc.want {
+				t.Fatalf("isJuggernautLegacy() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStripMantleLeftovers(t *testing.T) {
+	existing := map[string]any{
+		"model_provider": "amazon-bedrock",
+		"model_providers": map[string]any{
+			"amazon-bedrock": map[string]any{"aws": map[string]any{"region": "us-west-2"}},
+			"bedrock-mantle": map[string]any{
+				"base_url": "https://bedrock-mantle.us-west-2.api.aws/openai/v1",
+			},
+			"openai": map[string]any{"name": "openai"},
+		},
+		"provider": map[string]any{
+			"amazon-bedrock": map[string]any{"options": map[string]any{"region": "us-west-2"}},
+			"bedrock-mantle": map[string]any{"options": map[string]any{"region": "us-west-2"}},
+		},
+	}
+	stripMantleLeftovers(existing)
+
+	mp, _ := existing["model_providers"].(map[string]any)
+	if _, ok := mp["bedrock-mantle"]; ok {
+		t.Fatal("model_providers.bedrock-mantle must be stripped")
+	}
+	if _, ok := mp["amazon-bedrock"]; !ok {
+		t.Fatal("model_providers.amazon-bedrock must be kept")
+	}
+	if _, ok := mp["openai"]; !ok {
+		t.Fatal("unrelated model_providers.openai must be kept")
+	}
+
+	prov, _ := existing["provider"].(map[string]any)
+	if _, ok := prov["bedrock-mantle"]; ok {
+		t.Fatal("provider.bedrock-mantle must be stripped")
+	}
+	if _, ok := prov["amazon-bedrock"]; !ok {
+		t.Fatal("provider.amazon-bedrock must be kept")
+	}
+}
+
+func TestStripMantleLeftovers_CustomIDWithMantleURL(t *testing.T) {
+	existing := map[string]any{
+		"model_providers": map[string]any{
+			"my-bedrock": map[string]any{
+				"base_url": "https://bedrock-mantle.us-west-2.api.aws/openai/v1",
+			},
+		},
+	}
+	stripMantleLeftovers(existing)
+	if _, ok := existing["model_providers"]; ok {
+		t.Fatal("empty model_providers table should be dropped")
+	}
+}

--- a/cmd/helpers_legacy_test.go
+++ b/cmd/helpers_legacy_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/config"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+)
 
 func TestIsJuggernautLegacy(t *testing.T) {
 	cases := []struct {
@@ -104,6 +109,19 @@ func TestIsJuggernautLegacy(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "opencode nested options.base_url mantle host",
+			in: map[string]any{
+				"provider": map[string]any{
+					"custom": map[string]any{
+						"options": map[string]any{
+							"base_url": "https://bedrock-mantle.us-west-2.api.aws/openai/v1",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "opencode amazon-bedrock is current",
 			in: map[string]any{
 				"model": "amazon-bedrock/openai.gpt-oss-120b-1:0",
@@ -120,6 +138,19 @@ func TestIsJuggernautLegacy(t *testing.T) {
 			in: map[string]any{
 				"model":          "gpt-5",
 				"model_provider": "openai",
+			},
+			want: false,
+		},
+		{
+			name: "foreign provider whose URL merely contains mantle",
+			in: map[string]any{
+				"model":          "their-model",
+				"model_provider": "my-proxy",
+				"model_providers": map[string]any{
+					"my-proxy": map[string]any{
+						"base_url": "https://mantle.internal.corp/v1",
+					},
+				},
 			},
 			want: false,
 		},
@@ -181,5 +212,48 @@ func TestStripMantleLeftovers_CustomIDWithMantleURL(t *testing.T) {
 	stripMantleLeftovers(existing)
 	if _, ok := existing["model_providers"]; ok {
 		t.Fatal("empty model_providers table should be dropped")
+	}
+}
+
+func TestStripMantleLeftovers_PreservesForeignMantleSubstringURL(t *testing.T) {
+	existing := map[string]any{
+		"model_providers": map[string]any{
+			"my-proxy": map[string]any{
+				"base_url": "https://mantle.internal.corp/v1",
+			},
+		},
+	}
+	stripMantleLeftovers(existing)
+	tbl, _ := existing["model_providers"].(map[string]any)
+	if _, ok := tbl["my-proxy"]; !ok {
+		t.Fatal("foreign provider whose URL merely contains 'mantle' must be kept")
+	}
+}
+
+func TestApplyWriteGate_ForceAndRefuse(t *testing.T) {
+	home := setupApplyTestWithReset(t)
+	prov, err := provider.Get("codex")
+	if err != nil {
+		t.Fatalf("codex provider: %v", err)
+	}
+	plan := provider.ConfigPlan{Keys: map[string]any{"model": "global.openai.gpt-5.6-sol"}}
+	collisions := []config.Collision{{Path: "model", Existing: "their-model"}}
+
+	applyFlags.force = true
+	migrating, refuse := applyWriteGate(home, prov, plan, "config.toml", collisions)
+	if refuse != nil {
+		t.Fatalf("force should not refuse: %v", refuse)
+	}
+	if migrating {
+		t.Fatal("empty home is not a legacy migrate")
+	}
+
+	applyFlags.force = false
+	migrating, refuse = applyWriteGate(home, prov, plan, "config.toml", collisions)
+	if refuse == nil {
+		t.Fatal("collisions without force or legacy should refuse")
+	}
+	if migrating {
+		t.Fatal("refuse path must not report migrating")
 	}
 }

--- a/internal/config/deep_merge_test.go
+++ b/internal/config/deep_merge_test.go
@@ -57,6 +57,49 @@ func TestMergeConfigPlan_DeepMergeKeys_PreservesSiblings(t *testing.T) {
 	}
 }
 
+// TestMergeConfigPlanDeepThen_RunsAfterMergeUnderOneWrite: the then callback
+// mutates the in-memory map after the merge and is committed in the same lock.
+func TestMergeConfigPlanDeepThen_RunsAfterMergeUnderOneWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	if err := m.Write(map[string]any{
+		"model_providers": map[string]any{
+			"bedrock-mantle": map[string]any{"base_url": "https://bedrock-mantle.example/openai/v1"},
+			"openai":         map[string]any{"name": "openai"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := m.MergeConfigPlanDeepThen(map[string]any{
+		"model_provider": "amazon-bedrock",
+		"model_providers": map[string]any{
+			"amazon-bedrock": map[string]any{"aws": map[string]any{"region": "us-west-2"}},
+		},
+	}, []string{"model_providers"}, func(existing map[string]any) {
+		tbl, _ := existing["model_providers"].(map[string]any)
+		delete(tbl, "bedrock-mantle")
+	})
+	if err != nil {
+		t.Fatalf("MergeConfigPlanDeepThen: %v", err)
+	}
+
+	got, _ := m.Read()
+	tbl, _ := got["model_providers"].(map[string]any)
+	if _, ok := tbl["bedrock-mantle"]; ok {
+		t.Error("then callback should have stripped bedrock-mantle")
+	}
+	if _, ok := tbl["amazon-bedrock"]; !ok {
+		t.Error("amazon-bedrock from the plan must be present")
+	}
+	if _, ok := tbl["openai"]; !ok {
+		t.Error("unrelated sibling openai must survive")
+	}
+	if got["model_provider"] != "amazon-bedrock" {
+		t.Errorf("model_provider = %v, want amazon-bedrock", got["model_provider"])
+	}
+}
+
 // TestRemoveManagedKeysDeep_PreservesSiblings is the uninstall-side data-loss
 // regression: removing our bedrock-grok block must NOT delete the user's other
 // model profiles or the whole table.

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -232,8 +232,20 @@ func (m *Manager) MergeConfigPlan(keys map[string]any) error {
 // a user's sibling entries survive. All other keys keep whole-value
 // set-or-delete semantics.
 func (m *Manager) MergeConfigPlanDeep(keys map[string]any, deepKeys []string) error {
+	return m.mergeConfigPlanDeep(keys, deepKeys, nil)
+}
+
+// MergeConfigPlanDeepThen is MergeConfigPlanDeep plus an optional post-merge
+// mutation of the in-memory map, still under the same file lock. Used to
+// strip leftover sibling tables (e.g. Mantle provider blocks) without a
+// second backup rotation.
+func (m *Manager) MergeConfigPlanDeepThen(keys map[string]any, deepKeys []string, then func(map[string]any)) error {
+	return m.mergeConfigPlanDeep(keys, deepKeys, then)
+}
+
+func (m *Manager) mergeConfigPlanDeep(keys map[string]any, deepKeys []string, then func(map[string]any)) error {
 	return m.withConfig(func(existing map[string]any) error {
-		return walkManagedKeys(keys, deepKeys, func(key string, value any, action managedKeyAction) error {
+		err := walkManagedKeys(keys, deepKeys, func(key string, value any, action managedKeyAction) error {
 			switch action {
 			case actionJuggernaut:
 				existing[key] = value
@@ -244,6 +256,13 @@ func (m *Manager) MergeConfigPlanDeep(keys map[string]any, deepKeys []string) er
 			}
 			return nil
 		})
+		if err != nil {
+			return err
+		}
+		if then != nil {
+			then(existing)
+		}
+		return nil
 	})
 }
 

--- a/internal/provider/ownsconfig_test.go
+++ b/internal/provider/ownsconfig_test.go
@@ -39,11 +39,11 @@ func TestCodex_OwnsConfig(t *testing.T) {
 }
 
 // TestCodex_OwnsConfig_OldBedrockMantle: the legacy custom bedrock-mantle
-// provider (pre-amazon-bedrock) must NOT be claimed as owned. This ensures a
-// user upgrading from the old config shape gets a fresh auth prompt on
-// re-apply rather than silently reusing the old auth mode. The old
-// bedrock-mantle entry under model_providers is a different key from
-// amazon-bedrock, so deep merge naturally preserves it alongside the new entry.
+// provider (pre-amazon-bedrock) must NOT be claimed as currently owned.
+// Plain apply still migrates it via isJuggernautLegacy (cmd/) — OwnsConfig
+// stays false so a leftover Mantle table is not treated as a current v6
+// re-apply. The leftover model_providers.bedrock-mantle sibling is stripped
+// on migrate; deep merge alone would preserve it.
 func TestCodex_OwnsConfig_OldBedrockMantle(t *testing.T) {
 	p, _ := Get("codex")
 	if p.OwnsConfig(map[string]any{


### PR DESCRIPTION
Closes #435.

## Problem

v6.1.0 only treated Codex `model_provider = "amazon-bedrock"` plus a pre-5.6 model ID as Juggernaut-legacy. Real v5 configs used `model_provider = "bedrock-mantle"` (and OpenCode `provider.bedrock-mantle`). Those looked **foreign**, so plain `apply` refused without `--force`. Codex kept POSTing to `bedrock-mantle.*.api.aws` and 404'd on `gpt-5.6-sol` / `gpt-5.5`.

Deep-merge of `model_providers` / `provider` also kept leftover Mantle sibling tables after a partial rewrite.

## Fix

- Treat Mantle `base_url` / `bedrock-mantle` tables as legacy, including hybrid v6 model IDs still aimed at Mantle and custom provider ids with a Mantle URL.
- Plain `apply` migrates (announces, backup, rewrite to `amazon-bedrock` + `global.openai.gpt-5.6-sol`).
- Strip leftover Mantle provider tables in the same config lock so Codex cannot keep calling Mantle.
- `OwnsConfig` stays false for `bedrock-mantle` (not a current v6 re-apply).

## Tests

- Unit table for `isJuggernautLegacy` / `stripMantleLeftovers`
- Plain apply: Codex Mantle provider, hybrid leftover table, OpenCode `provider.bedrock-mantle`
- Dry-run: announce, no write, no backup
- `MergeConfigPlanDeepThen` strips sibling under one write

## Touch quality

- Dedup: shared `applyWriteGate` for dry-run and commit; shared Mantle leftover helpers
- Simplify: early-return detection; strip in the same merge lock instead of a second backup
- Tests: new paths above