### PR TITLE
fix(doctor): invoke connectivity probe with stored profile IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Juggernaut will be documented in this file.
 
 ### Fixed
 
+- **Doctor connectivity probe keeps inference-profile prefixes.** `probe()`
+  no longer strips `global.` / `us.` (and other regional prefixes) before
+  InvokeModel. The default Haiku pin is a `global.` inference-profile ID;
+  stripping it recovered a foundation ID that Bedrock rejects with HTTP 400
+  (on-demand throughput isn't supported), so `doctor` false-failed healthy
+  Claude installs. Foundation IDs without a prefix are still invoked as stored.
 - **Leftover Codex/OpenCode Mantle providers now migrate on plain `apply`.**
   v6.1.0 only treated Codex `model_provider = "amazon-bedrock"` plus a
   pre-5.6 model ID as legacy. Real v5 configs used

--- a/cmd/doctor_extra_test.go
+++ b/cmd/doctor_extra_test.go
@@ -12,9 +12,13 @@ import (
 // TestCheckBedrockConnectivity_APIKeyNoToken covers the early return when API
 // key auth is configured but no bearer token is present — no network call.
 func TestCheckBedrockConnectivity_APIKeyNoToken(t *testing.T) {
-	result := checkBedrockConnectivity(authmode.BedrockAPIKey, "us-west-2", "model-id", "")
+	const pin = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+	result := checkBedrockConnectivity(authmode.BedrockAPIKey, "us-west-2", pin, "")
 	if result == nil {
 		t.Fatal("expected a non-nil connectivity result")
+	}
+	if result.ModelID != pin {
+		t.Errorf("ModelID = %q, want stored pin %q", result.ModelID, pin)
 	}
 	if !result.IsFailure() {
 		t.Error("missing API key token should be a failure")

--- a/internal/bedrock/connectivity.go
+++ b/internal/bedrock/connectivity.go
@@ -80,9 +80,13 @@ func CheckIAMConnectivity(region, modelID string) *ConnectivityResult {
 // probe sends a minimal InvokeModel request and interprets the response
 // according to the auth mode. It is the shared implementation of
 // CheckAPIKeyConnectivity and CheckIAMConnectivity.
+//
+// The model ID is invoked as stored. Inference-profile prefixes (global., us.,
+// and the rest of RegionalInferencePrefixes) must stay on the pin — stripping
+// them recovers a foundation ID that Bedrock often rejects with HTTP 400
+// (on-demand throughput is not supported).
 func probe(opts probeOpts, region, modelID string) *ConnectivityResult {
 	start := time.Now()
-	modelID = stripRegionPrefix(modelID)
 
 	body, err := json.Marshal(map[string]any{
 		"messages":          []map[string]string{{"role": "user", "content": "hi"}},
@@ -171,11 +175,6 @@ func (r *ConnectivityResult) IsFailure() bool {
 // authorization error (401/403).
 func (r *ConnectivityResult) IsAuthFailure() bool {
 	return r.StatusCode == 401 || r.StatusCode == 403
-}
-
-// stripRegionPrefix delegates to the exported StripRegionPrefix.
-func stripRegionPrefix(modelID string) string {
-	return StripRegionPrefix(modelID)
 }
 
 func formatResponseError(status int, body []byte) string {

--- a/internal/bedrock/connectivity_http_test.go
+++ b/internal/bedrock/connectivity_http_test.go
@@ -3,31 +3,46 @@ package bedrock
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 )
+
+// swapProbeTransport points the package httpClient and endpoint builder at a
+// local httptest server and records the model ID passed to bedrockEndpoint.
+func swapProbeTransport(t *testing.T, handler http.HandlerFunc) *string {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	var invoked string
+	origClient, origEndpoint := httpClient, bedrockEndpoint
+	httpClient = srv.Client()
+	bedrockEndpoint = func(_, modelID string) string {
+		invoked = modelID
+		return srv.URL
+	}
+	t.Cleanup(func() {
+		httpClient = origClient
+		bedrockEndpoint = origEndpoint
+	})
+	return &invoked
+}
 
 // withTestServer points the package httpClient and endpoint builder at a local
 // httptest server for the duration of fn, then restores them.
 func withTestServer(t *testing.T, handler http.HandlerFunc, fn func()) {
 	t.Helper()
-	srv := httptest.NewServer(handler)
-	t.Cleanup(srv.Close)
-
-	origClient, origEndpoint := httpClient, bedrockEndpoint
-	httpClient = srv.Client()
-	bedrockEndpoint = func(_, _ string) string { return srv.URL }
-	t.Cleanup(func() {
-		httpClient = origClient
-		bedrockEndpoint = origEndpoint
-	})
+	_ = swapProbeTransport(t, handler)
 	fn()
 }
 
+func okHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"content":[]}`))
+}
+
 func TestCheckAPIKeyConnectivity_Success(t *testing.T) {
-	withTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"content":[]}`))
-	}, func() {
+	withTestServer(t, okHandler, func() {
 		res := CheckAPIKeyConnectivity("tok", "us-west-2", "model")
 		if res.IsFailure() {
 			t.Errorf("expected success, got failure: %+v", res)
@@ -117,4 +132,66 @@ func TestCheckIAMConnectivity_403WithoutAuthError_IsFailure(t *testing.T) {
 			t.Errorf("403 without auth-error body should be a failure, got: %+v", res)
 		}
 	})
+}
+
+func TestProbe_InvokesStoredModelIDUnchanged(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		iam     bool
+	}{
+		{"global inference profile", "global.anthropic.claude-haiku-4-5-20251001-v1:0", false},
+		{"us inference profile", "us.anthropic.claude-sonnet-4-6", false},
+		{"eu inference profile", "eu.anthropic.claude-sonnet-4-6", true},
+		{"foundation ID", "anthropic.claude-sonnet-4-6", false},
+		{"foundation ID IAM", "anthropic.claude-opus-4-8", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			invoked := swapProbeTransport(t, okHandler)
+			var res *ConnectivityResult
+			if tt.iam {
+				res = CheckIAMConnectivity("us-west-2", tt.modelID)
+			} else {
+				res = CheckAPIKeyConnectivity("tok", "us-west-2", tt.modelID)
+			}
+			if *invoked != tt.modelID {
+				t.Errorf("InvokeModel model ID = %q, want stored pin %q", *invoked, tt.modelID)
+			}
+			if res.ModelID != tt.modelID {
+				t.Errorf("result.ModelID = %q, want stored pin %q", res.ModelID, tt.modelID)
+			}
+			if res.IsFailure() {
+				t.Errorf("expected success, got: %+v", res)
+			}
+		})
+	}
+}
+
+func TestProbe_InvokesBedrockConfigPinsUnchanged(t *testing.T) {
+	cfg, err := Load(filepath.Join("..", "..", "bedrock-config.json"))
+	if err != nil {
+		t.Skipf("cannot load bedrock-config.json: %v", err)
+	}
+	for name, id := range map[string]string{
+		"default": cfg.Models.Default,
+		"fast":    cfg.Models.Fast,
+		"opus":    cfg.Models.Opus,
+		"sonnet":  cfg.Models.Sonnet,
+		"haiku":   cfg.Models.Haiku,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if id == "" {
+				t.Fatalf("bedrock-config.json %s model ID is empty", name)
+			}
+			invoked := swapProbeTransport(t, okHandler)
+			res := CheckAPIKeyConnectivity("tok", "us-west-2", id)
+			if *invoked != id {
+				t.Errorf("InvokeModel model ID = %q, want config pin %q", *invoked, id)
+			}
+			if res.ModelID != id {
+				t.Errorf("result.ModelID = %q, want config pin %q", res.ModelID, id)
+			}
+		})
+	}
 }

--- a/internal/bedrock/connectivity_test.go
+++ b/internal/bedrock/connectivity_test.go
@@ -7,10 +7,12 @@ import (
 )
 
 // -----------------------------------------------------------------------
-// stripRegionPrefix
+// StripRegionPrefix — comparison helper for schema/models, not InvokeModel.
+// Doctor connectivity probes must invoke the stored pin (see
+// connectivity_http_test.go). This helper still recovers the bare ID.
 // -----------------------------------------------------------------------
 
-func TestStripRegionPrefix_PreservesGlobal(t *testing.T) {
+func TestStripRegionPrefix(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -69,47 +71,9 @@ func TestStripRegionPrefix_PreservesGlobal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := stripRegionPrefix(tt.input)
+			got := StripRegionPrefix(tt.input)
 			if got != tt.expected {
-				t.Errorf("stripRegionPrefix(%q) = %q, want %q", tt.input, got, tt.expected)
-			}
-		})
-	}
-}
-
-// TestStripRegionPrefix_BedrockConfigModelIDs verifies that stripRegionPrefix
-// correctly strips regional inference prefixes from model IDs. Model IDs with
-// regional prefixes (global., us., us-gov., eu., apac.) are stripped to their
-// bare provider model ID. Plain model IDs without prefixes are unchanged.
-func TestStripRegionPrefix_BedrockConfigModelIDs(t *testing.T) {
-	repoRoot := filepath.Join("..", "..")
-	cfg, err := Load(filepath.Join(repoRoot, "bedrock-config.json"))
-	if err != nil {
-		t.Skipf("cannot load bedrock-config.json: %v", err)
-	}
-
-	for name, id := range map[string]string{
-		"default": cfg.Models.Default,
-		"fast":    cfg.Models.Fast,
-		"opus":    cfg.Models.Opus,
-		"sonnet":  cfg.Models.Sonnet,
-		"haiku":   cfg.Models.Haiku,
-	} {
-		t.Run(name, func(t *testing.T) {
-			got := stripRegionPrefix(id)
-			// Model IDs with regional prefixes should be stripped to bare form
-			for _, prefix := range []string{"global.", "us.", "us-gov.", "eu.", "apac."} {
-				if strings.HasPrefix(id, prefix) {
-					want := strings.TrimPrefix(id, prefix)
-					if got != want {
-						t.Errorf("stripRegionPrefix(%q) = %q, want %q (strip %q)", id, got, want, prefix)
-					}
-					return
-				}
-			}
-			// Model IDs without regional prefixes should be unchanged
-			if got != id {
-				t.Errorf("stripRegionPrefix(%q) = %q, want %q", id, got, id)
+				t.Errorf("StripRegionPrefix(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -298,35 +262,5 @@ func TestFindBedrockConfigFile(t *testing.T) {
 	// Ensure the model ID starts with global.
 	if !strings.HasPrefix(cfg.Models.Haiku, "global.") {
 		t.Errorf("expected Haiku model ID to start with global., got %q", cfg.Models.Haiku)
-	}
-}
-
-// -----------------------------------------------------------------------
-// Regression: ensure all regional prefixes are stripped correctly
-// -----------------------------------------------------------------------
-
-func TestStripRegionPrefix_OldBehaviorRegression(t *testing.T) {
-	// All regional inference prefixes (including global. and us-gov.) are
-	// stripped to recover the bare provider model ID. The old code had a
-	// stale prefix list that missed global. and us-gov. — this test ensures
-	// the fixed list is used.
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"global-prefix", "global.anthropic.claude-haiku-4-5-20251001-v1:0", "anthropic.claude-haiku-4-5-20251001-v1:0"},
-		{"us-prefix", "us.anthropic.claude-opus-4-8", "anthropic.claude-opus-4-8"},
-		{"us-gov-prefix", "us-gov.anthropic.claude-sonnet-4-20250514", "anthropic.claude-sonnet-4-20250514"},
-		{"eu-prefix", "eu.anthropic.claude-sonnet-4-20250514", "anthropic.claude-sonnet-4-20250514"},
-		{"no-prefix", "anthropic.claude-opus-4-8", "anthropic.claude-opus-4-8"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := stripRegionPrefix(tt.in)
-			if got != tt.want {
-				t.Errorf("stripRegionPrefix(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
 	}
 }


### PR DESCRIPTION
Closes #440.

## Problem

`internal/bedrock/connectivity.go` `probe()` always called `stripRegionPrefix` before InvokeModel. The default Haiku pin is a `global.` inference-profile ID. Stripping `global.` / `us.` recovered a foundation ID that Bedrock rejects with HTTP 400 (on-demand throughput isn't supported), so `doctor` false-failed healthy Claude installs. Tests encoded stripping as the correct probe behavior.

## Fix

- Invoke with the stored pin (keep `global.` / `us.` / other regional prefixes when present).
- Foundation IDs without a prefix are still invoked as stored.
- `StripRegionPrefix` remains the comparison helper for schema/models; it is no longer used on the InvokeModel path.

## Tests

- `TestProbe_InvokesStoredModelIDUnchanged` — `global.` / `us.` / `eu.` profile IDs and bare foundation IDs are passed unchanged to the endpoint (API key and IAM).
- `TestProbe_InvokesBedrockConfigPinsUnchanged` — config pins (including default Haiku) are invoked as stored.
- Removed the connectivity tests that encoded probe-side stripping as correct.

## Touch quality

- Dedup: `withTestServer` now shares `swapProbeTransport`; dropped the duplicate `StripRegionPrefix` regression table.
- Simplify: deleted the probe-only `stripRegionPrefix` wrapper.
- Tests: new invoke-ID paths above; no AWS calls (httptest + swapped `bedrockEndpoint`).