### PR TITLE
fix(apply): honor --auth, prompt on TTY, fail activation, drop stale auto warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Juggernaut will be documented in this file.
 
 ### Fixed
 
+- **`apply --auth` now wins on re-apply.** Re-applying used to pass the still-empty named return into auth resolution, so `--auth=iam` / `--auth=bedrock-api-key` was ignored and the previous mode was kept while reporting success.
+- **Bare `apply` prompts on a TTY.** First-run with no `--auth` launches the guided prompt when stdin is a terminal. Non-interactive runs (scripts, CI) still use `defaults.auth_mode`. Explicit `--auth` always wins.
+- **Activation install failures now fail `apply`.** A failed shell-block install returns a non-zero exit and does not print "Configuration written successfully." Dry-run is unchanged.
+- **`--mode=auto` no longer claims the Sonnet-tier default cannot show auto.** Default Sonnet 5 is auto-capable (`schema.IsAutoModeCapableModel`); the switch-model hint is only printed when the resolved default is not.
 - **Doctor connectivity probe keeps inference-profile prefixes.** `probe()`
   no longer strips `global.` / `us.` (and other regional prefixes) before
   InvokeModel. The default Haiku pin is a `global.` inference-profile ID;

--- a/cmd/apply_permmode_test.go
+++ b/cmd/apply_permmode_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -76,6 +77,29 @@ func TestApply_ReapplyPreservesExternallySetMode(t *testing.T) {
 	}
 	if got := readNativeEnvValue(t, home, "CLAUDE_CODE_ENABLE_AUTO_MODE"); got != "1" {
 		t.Errorf("re-apply did not restore CLAUDE_CODE_ENABLE_AUTO_MODE for adopted auto mode (got %q)", got)
+	}
+}
+
+// TestApply_ModeAuto_NoFalseSonnetWarning is the regression for #442: default
+// Sonnet 5 is auto-capable, so --mode=auto must not claim the Sonnet-tier
+// default cannot show auto.
+func TestApply_ModeAuto_NoFalseSonnetWarning(t *testing.T) {
+	_ = setupApplyTest(t)
+
+	var applyErr error
+	out := captureStdout(t, func() {
+		applyErr = ExecuteArgs([]string{
+			"apply", "--auth=iam", "--region=us-west-2", "--mode=auto", "--skip-preflight",
+		})
+	})
+	if applyErr != nil {
+		t.Fatalf("apply --mode=auto error: %v", applyErr)
+	}
+	if strings.Contains(out, "not the Sonnet-tier default") || strings.Contains(out, "not the current Sonnet-tier default") {
+		t.Errorf("stale Sonnet-tier warning on auto-capable default:\n%s", out)
+	}
+	if strings.Contains(out, "cannot be enabled") {
+		t.Errorf("false cannot-be-enabled warning:\n%s", out)
 	}
 }
 

--- a/cmd/apply_reapply_test.go
+++ b/cmd/apply_reapply_test.go
@@ -173,3 +173,34 @@ func TestApply_ReapplyWithoutAuth_PreservesExistingMode(t *testing.T) {
 		t.Errorf("re-apply without --auth changed auth mode to %q, want %q (preserved)", got, authmode.IAM)
 	}
 }
+
+// TestApply_ReapplyWithAuth_HonorsFlag is the regression for #438: re-apply
+// with --auth must switch modes instead of keeping the empty named-return
+// authMode and silently preserving the previous install.
+func TestApply_ReapplyWithAuth_HonorsFlag(t *testing.T) {
+	home := setupApplyTest(t)
+	store := setupIsolatedKeychain(t)
+	t.Cleanup(func() { _ = store.DeleteWithFallback(home) })
+
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("first apply error: %v", err)
+	}
+	if got := readJuggernautAuthMode(t, home); got != authmode.IAM {
+		t.Fatalf("after first apply, auth mode = %q, want %q", got, authmode.IAM)
+	}
+
+	if err := ExecuteArgs([]string{
+		"apply",
+		"--auth=" + authmode.BedrockAPIKey,
+		"--bedrock-key=reapply-switch-key",
+		"--region=us-west-2",
+		"--skip-preflight",
+	}); err != nil {
+		t.Fatalf("re-apply --auth error: %v", err)
+	}
+	if got := readJuggernautAuthMode(t, home); got != authmode.BedrockAPIKey {
+		t.Errorf("re-apply --auth did not switch mode: got %q, want %q", got, authmode.BedrockAPIKey)
+	}
+}

--- a/cmd/apply_test_helpers_test.go
+++ b/cmd/apply_test_helpers_test.go
@@ -219,6 +219,14 @@ func setupApplyTestWithReset(t *testing.T) string {
 	return setupApplyTest(t)
 }
 
+// withInteractiveStdin stubs isInteractiveStdin for the rest of the test.
+func withInteractiveStdin(t *testing.T, interactive bool) {
+	t.Helper()
+	orig := isInteractiveStdin
+	isInteractiveStdin = func() bool { return interactive }
+	t.Cleanup(func() { isInteractiveStdin = orig })
+}
+
 // ---------------------------------------------------------------------------
 // mockPSRunner (unified) — replaces mockApplyCommandRunner and mockDoctorCommandRunner
 // ---------------------------------------------------------------------------

--- a/cmd/coverage_batch1_test.go
+++ b/cmd/coverage_batch1_test.go
@@ -654,7 +654,8 @@ func TestReportLegacyRecovery_ErrorWarns(t *testing.T) {
 }
 
 // TestResolveApplyInputs_PromptsWithoutAuthMode reaches the interactive prompt
-// fallback of resolveApplyInputs. Without a TTY the form fails, which exercises
+// fallback of resolveApplyInputs when stdin is treated as a TTY and --auth is
+// omitted. Without a real console the form fails, which exercises
 // promptApplyInputs' construction and Run-error branches.
 func TestResolveApplyInputs_PromptsWithoutAuthMode(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -662,9 +663,10 @@ func TestResolveApplyInputs_PromptsWithoutAuthMode(t *testing.T) {
 	}
 	defer resetFlags()
 	resetFlags()
+	withInteractiveStdin(t, true)
 
 	home := testutil.NewTestHome(t)
-	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2"}}
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: authmode.IAM}}
 	_, _, _, err := resolveApplyInputs(home, bCfg, provider.MustGet("claude"))
 	if err == nil {
 		t.Log("TUI prompt unexpectedly succeeded (CI may have a pty)")

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -169,12 +169,40 @@ func resolveApplyInputs(home string, bCfg *bedrock.Config, prov provider.Provide
 	}
 
 	if isReapply {
-		return resolveReApplyInputs(bCfg, prov, authMode, region, opusplan, existing)
+		// Pass applyFlags.auth, not the still-empty named return, so an
+		// explicit --auth on re-apply wins over the existing block.
+		return resolveReApplyInputs(bCfg, prov, applyFlags.auth, region, opusplan, existing)
 	}
+	return resolveFirstApplyInputs(bCfg, prov, region, opusplan)
+}
 
-	authMode = resolveAuthMode(applyFlags.auth, prov, bCfg, nil)
-	if authMode != "" {
-		return authMode, region, opusplan, nil
+// isInteractiveStdin reports whether stdin is a terminal. Tests replace it.
+var isInteractiveStdin = defaultIsInteractiveStdin
+
+func defaultIsInteractiveStdin() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return isCharDeviceMode(fi.Mode())
+}
+
+func isCharDeviceMode(mode os.FileMode) bool {
+	return mode&os.ModeCharDevice != 0
+}
+
+// resolveFirstApplyInputs picks auth for a first-time apply. Explicit --auth
+// always wins. A TTY with no --auth runs the guided first-run prompt even
+// when defaults.auth_mode is set. Non-interactive runs use resolveAuthMode
+// defaults so scripts keep working without a prompt.
+func resolveFirstApplyInputs(bCfg *bedrock.Config, prov provider.Provider, region string, opusplan bool) (string, string, bool, error) {
+	if applyFlags.auth != "" {
+		return applyFlags.auth, region, opusplan, nil
+	}
+	if !isInteractiveStdin() {
+		if authMode := resolveAuthMode("", prov, bCfg, nil); authMode != "" {
+			return authMode, region, opusplan, nil
+		}
 	}
 	return promptApplyInputs(bCfg, region, opusplan)
 }
@@ -610,7 +638,9 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 	}
 
 	persistRuntimeState(home, prov, authMode, plan)
-	installActivation(home, prov)
+	if err := installActivation(home, prov); err != nil {
+		return err
+	}
 	reportLegacyRecovery(home)
 	fmt.Println("Configuration written successfully.")
 	for _, w := range plan.Warnings {
@@ -648,47 +678,48 @@ func persistRuntimeState(home string, prov provider.Provider, authMode string, p
 	}
 }
 
-// warnAutoModeModel handles the two --mode=auto outcomes. If at least one
-// configured model can use auto mode (AutoModeAvailable), Juggernaut has enabled
-// it — print how to actually reach it, since auto only appears in the Shift+Tab
-// cycle when the ACTIVE session model is capable (Sonnet 5 / Opus 4.7 or later),
-// not when the Sonnet-tier default is active. If NO configured model is capable,
-// warn that auto can't be enabled at all. Only relevant when --mode=auto was
-// requested.
+// warnAutoModeModel handles --mode=auto outcomes. AutoModeUsable means the
+// default session model (Sonnet-tier pin) is capable — do not tell the user
+// they must switch models. AutoModeAvailable without usable still needs the
+// Shift+Tab / `claude --model opus` hint. If no configured model is capable,
+// warn that auto can't be enabled. Only relevant when --mode=auto was requested.
 func warnAutoModeModel(block *schema.Block) {
 	if block.Meta.PermissionMode != "auto" {
 		return
 	}
 	fmt.Println()
-	if block.AutoModeAvailable() {
-		fmt.Println("ℹ Auto mode is enabled (CLAUDE_CODE_ENABLE_AUTO_MODE=1).")
-		fmt.Println("  On Bedrock it appears in the Shift+Tab cycle only while your active session")
-		fmt.Println("  model is Sonnet 5, or Opus 4.7 or later — not the Sonnet-tier default. Run")
-		fmt.Println("  `claude --model opus` (or `/model opus` in a session) to use it. Requires")
-		fmt.Println("  Claude Code v2.1.158+.")
+	if !block.AutoModeAvailable() {
+		fmt.Println("⚠ Auto mode cannot be enabled: none of the configured models support it.")
+		fmt.Println("  On Bedrock auto mode requires Sonnet 5, or Opus 4.7 or later (Claude Code")
+		fmt.Println("  v2.1.158+). Configure one of those (e.g. keep the default Opus alias) and")
+		fmt.Println("  re-run with --mode=auto.")
 		return
 	}
-	fmt.Println("⚠ Auto mode cannot be enabled: none of the configured models support it.")
-	fmt.Println("  On Bedrock auto mode requires Sonnet 5, or Opus 4.7 or later (Claude Code")
-	fmt.Println("  v2.1.158+). Configure one of those (e.g. keep the default Opus alias) and")
-	fmt.Println("  re-run with --mode=auto.")
+	fmt.Println("ℹ Auto mode is enabled (CLAUDE_CODE_ENABLE_AUTO_MODE=1).")
+	if block.AutoModeUsable() {
+		return
+	}
+	fmt.Println("  On Bedrock it appears in the Shift+Tab cycle only while your active session")
+	fmt.Println("  model is Sonnet 5, or Opus 4.7 or later — not the current Sonnet-tier default.")
+	fmt.Println("  Run `claude --model opus` (or `/model opus` in a session) to use it. Requires")
+	fmt.Println("  Claude Code v2.1.158+.")
 }
 
-func installActivation(home string, prov provider.Provider) {
+func installActivation(home string, prov provider.Provider) error {
 	begin, end := prov.ActivationMarkers()
 	paths, err := activation.InstallWith(home, activation.InstallOptions{
 		Spec: activation.CLISpec{Name: prov.Name(), Begin: begin, End: end},
 	})
 	if err != nil {
-		warnf("could not install shell activation: %v", err)
-		return
+		return fmt.Errorf("could not install shell activation: %w", err)
 	}
 	title := prov.DisplayName()
 	if len(paths) == 0 {
 		fmt.Printf("  ✓ %s shell activation already up to date\n", title)
-		return
+		return nil
 	}
 	fmt.Printf("  ✓ Updated %s activation in %d shell profile(s)\n", title, len(paths))
+	return nil
 }
 
 func reportLegacyRecovery(home string) {

--- a/cmd/helpers_test_phases_test.go
+++ b/cmd/helpers_test_phases_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
@@ -393,7 +394,8 @@ func TestWarnAutoModeModel_NotAuto(t *testing.T) {
 }
 
 func TestWarnAutoModeModel_Available(t *testing.T) {
-	// Opus 4.8 configured — auto mode IS available.
+	// Opus 4.8 configured, Sonnet 4.6 default — auto is available but the
+	// Sonnet-tier pin is not usable, so the switch-model hint still applies.
 	block := &schema.Block{
 		Meta: schema.Meta{PermissionMode: "auto"},
 		Models: schema.ModelOverrides{
@@ -412,6 +414,30 @@ func TestWarnAutoModeModel_Available(t *testing.T) {
 	}
 	if strings.Contains(out, "cannot be enabled") {
 		t.Error("must not warn 'cannot be enabled' when Opus 4.8 is configured")
+	}
+}
+
+func TestWarnAutoModeModel_UsableDefaultSonnet(t *testing.T) {
+	// Default Sonnet 5 is auto-capable — do not claim the Sonnet-tier default
+	// cannot show auto (#442).
+	block := &schema.Block{
+		Meta: schema.Meta{PermissionMode: "auto"},
+		Models: schema.ModelOverrides{
+			Opus:   "global.anthropic.claude-opus-4-8",
+			Sonnet: "global.anthropic.claude-sonnet-5",
+		},
+	}
+	out := captureStdout(t, func() {
+		warnAutoModeModel(block)
+	})
+	if !strings.Contains(out, "Auto mode is enabled") {
+		t.Errorf("expected enabled confirmation, got:\n%s", out)
+	}
+	if strings.Contains(out, "not the") || strings.Contains(out, "claude --model opus") {
+		t.Errorf("must not warn to switch models when the default is auto-capable:\n%s", out)
+	}
+	if strings.Contains(out, "cannot be enabled") {
+		t.Errorf("must not warn cannot-be-enabled when Sonnet 5 is the default:\n%s", out)
 	}
 }
 
@@ -1066,9 +1092,13 @@ func TestInstallActivation_AlreadyUpToDate(t *testing.T) {
 	if err != nil {
 		t.Skip("claude provider not registered")
 	}
+	var actErr error
 	out := captureStdout(t, func() {
-		installActivation(home, prov)
+		actErr = installActivation(home, prov)
 	})
+	if actErr != nil {
+		t.Fatalf("installActivation: %v", actErr)
+	}
 	// With mock, the result is either "up to date" or "updated" depending on
 	// whether the profile already has the activation block.
 	if !strings.Contains(out, "activation") {
@@ -1115,6 +1145,46 @@ func TestResolveApplyInputs_OwnedConfigPreservesAuthMode(t *testing.T) {
 	}
 	if authMode != "iam" {
 		t.Errorf("authMode = %q, want 'iam' (preserved from existing config)", authMode)
+	}
+}
+
+func TestResolveApplyInputs_ReapplyHonorsAuthFlag(t *testing.T) {
+	defer resetFlags()
+	resetFlags()
+	applyFlags.scope = "user"
+	applyFlags.auth = authmode.BedrockAPIKey
+
+	home := setupApplyTest(t)
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil { // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- directory
+		t.Fatalf("mkdir: %v", err)
+	}
+	ownedConfig := `{
+		"juggernaut": {
+			"auth": {"mode": "iam", "region": "us-west-2"},
+			"meta": {"managedBy": "juggernaut"}
+		}
+	}`
+	if err := os.WriteFile(settingsPath, []byte(ownedConfig), 0o600); err != nil {
+		t.Fatalf("write owned config: %v", err)
+	}
+
+	bCfg, err := loadBedrockConfig()
+	if err != nil {
+		t.Skipf("no bedrock config: %v", err)
+	}
+	prov, err := provider.Get("claude")
+	if err != nil {
+		t.Fatalf("get claude provider: %v", err)
+	}
+
+	authMode, _, _, err := resolveApplyInputs(home, bCfg, prov)
+	if err != nil {
+		t.Fatalf("resolveApplyInputs: %v", err)
+	}
+	if authMode != authmode.BedrockAPIKey {
+		t.Errorf("authMode = %q, want %q (--auth must win on re-apply)", authMode, authmode.BedrockAPIKey)
 	}
 }
 
@@ -1269,9 +1339,13 @@ func TestInstallActivation_UpdatedProfiles(t *testing.T) {
 		t.Fatalf("write .bashrc: %v", err)
 	}
 
+	var actErr error
 	out := captureStdout(t, func() {
-		installActivation(home, prov)
+		actErr = installActivation(home, prov)
 	})
+	if actErr != nil {
+		t.Fatalf("installActivation: %v", actErr)
+	}
 	// The output should contain either "updated" or "up to date" — both are
 	// valid depending on whether the profile already had the block.
 	if !strings.Contains(out, "activation") {
@@ -1310,15 +1384,16 @@ func TestReportLegacyRecovery_ErrorPath(t *testing.T) {
 // commitApply — warnings output path
 // ---------------------------------------------------------------------------
 
-func TestCommitApply_WarningsOutput(t *testing.T) {
-	home := setupApplyTestWithReset(t)
-
+func claudeIAMCommitArgs(t *testing.T) (*bedrock.Config, provider.Provider, *schema.Block, provider.Options) {
+	t.Helper()
 	bCfg, err := loadBedrockConfig()
 	if err != nil {
 		t.Skipf("no bedrock config: %v", err)
 	}
-	prov, _ := provider.Get("claude")
-
+	prov, err := provider.Get("claude")
+	if err != nil {
+		t.Fatalf("provider.Get(claude): %v", err)
+	}
 	opts := schema.Options{
 		AuthMode:      "iam",
 		Region:        "us-west-2",
@@ -1331,27 +1406,26 @@ func TestCommitApply_WarningsOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("schema.Build: %v", err)
 	}
-
-	provOpts := provider.Options{
-		SchemaOpts: schema.Options{
-			AuthMode:      "iam",
-			Region:        "us-west-2",
-			Scope:         "user",
-			Version:       "5.4.0",
-			Effort:        "high",
-			AuthValidated: true,
-		},
-		AuthMode: "iam",
-		Region:   "us-west-2",
-		Scope:    "user",
-		Version:  "5.4.0",
+	return bCfg, prov, block, provider.Options{
+		SchemaOpts: opts,
+		AuthMode:   "iam",
+		Region:     "us-west-2",
+		Scope:      "user",
+		Version:    "5.4.0",
 	}
+}
 
+func TestCommitApply_WarningsOutput(t *testing.T) {
+	home := setupApplyTestWithReset(t)
+
+	bCfg, prov, block, provOpts := claudeIAMCommitArgs(t)
+
+	var commitErr error
 	out := captureStdout(t, func() {
-		err = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
+		commitErr = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
 	})
-	if err != nil {
-		t.Fatalf("commitApply: %v", err)
+	if commitErr != nil {
+		t.Fatalf("commitApply: %v", commitErr)
 	}
 	if !strings.Contains(out, "Configuration written successfully.") {
 		t.Fatalf("expected success message, got:\n%s", out)
@@ -1821,45 +1895,14 @@ func TestCommitApply_SuccessPath_ActivationInstalled(t *testing.T) {
 		t.Fatalf("write .bashrc: %v", err)
 	}
 
-	bCfg, err := loadBedrockConfig()
-	if err != nil {
-		t.Skipf("no bedrock config: %v", err)
-	}
-	prov, _ := provider.Get("claude")
+	bCfg, prov, block, provOpts := claudeIAMCommitArgs(t)
 
-	opts := schema.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
-	}
-	block, err := schema.Build(bCfg, opts)
-	if err != nil {
-		t.Fatalf("schema.Build: %v", err)
-	}
-
-	provOpts := provider.Options{
-		SchemaOpts: schema.Options{
-			AuthMode:      "iam",
-			Region:        "us-west-2",
-			Scope:         "user",
-			Version:       "5.4.0",
-			Effort:        "high",
-			AuthValidated: true,
-		},
-		AuthMode: "iam",
-		Region:   "us-west-2",
-		Scope:    "user",
-		Version:  "5.4.0",
-	}
-
+	var commitErr error
 	out := captureStdout(t, func() {
-		err = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
+		commitErr = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
 	})
-	if err != nil {
-		t.Fatalf("commitApply: %v", err)
+	if commitErr != nil {
+		t.Fatalf("commitApply: %v", commitErr)
 	}
 
 	// Verify success message.
@@ -1876,6 +1919,31 @@ func TestCommitApply_SuccessPath_ActivationInstalled(t *testing.T) {
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
 		t.Error("settings.json should have been written")
+	}
+}
+
+func TestCommitApply_ActivationInstallFailure(t *testing.T) {
+	home := setupApplyTestWithReset(t)
+
+	// .bashrc as a directory makes InstallTargetFor fail (#443).
+	bashrcPath := filepath.Join(home, ".bashrc")
+	if err := os.MkdirAll(bashrcPath, 0o700); err != nil { // nosemgrep: go.lang.correctness.permissions.file_permission.incorrect-default-permission -- directory
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	bCfg, prov, block, provOpts := claudeIAMCommitArgs(t)
+	var commitErr error
+	out := captureStdout(t, func() {
+		commitErr = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
+	})
+	if commitErr == nil {
+		t.Fatal("commitApply should fail when activation install fails")
+	}
+	if !strings.Contains(commitErr.Error(), "could not install shell activation") {
+		t.Errorf("error = %v, want activation failure", commitErr)
+	}
+	if strings.Contains(out, "Configuration written successfully") {
+		t.Errorf("must not print success when activation install fails, got:\n%s", out)
 	}
 }
 
@@ -1900,45 +1968,14 @@ func TestCommitApply_ForceBypassesCollision(t *testing.T) {
 		t.Fatalf("write foreign config: %v", err)
 	}
 
-	bCfg, err := loadBedrockConfig()
-	if err != nil {
-		t.Skipf("no bedrock config: %v", err)
-	}
-	prov, _ := provider.Get("claude")
+	bCfg, prov, block, provOpts := claudeIAMCommitArgs(t)
 
-	opts := schema.Options{
-		AuthMode:      "iam",
-		Region:        "us-west-2",
-		Scope:         "user",
-		Version:       "5.4.0",
-		Effort:        "high",
-		AuthValidated: true,
-	}
-	block, err := schema.Build(bCfg, opts)
-	if err != nil {
-		t.Fatalf("schema.Build: %v", err)
-	}
-
-	provOpts := provider.Options{
-		SchemaOpts: schema.Options{
-			AuthMode:      "iam",
-			Region:        "us-west-2",
-			Scope:         "user",
-			Version:       "5.4.0",
-			Effort:        "high",
-			AuthValidated: true,
-		},
-		AuthMode: "iam",
-		Region:   "us-west-2",
-		Scope:    "user",
-		Version:  "5.4.0",
-	}
-
+	var commitErr error
 	out := captureStdout(t, func() {
-		err = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
+		commitErr = commitApply(home, "iam", "", block, prov, bCfg, provOpts)
 	})
-	if err != nil {
-		t.Fatalf("commitApply with --force should not error: %v", err)
+	if commitErr != nil {
+		t.Fatalf("commitApply with --force should not error: %v", commitErr)
 	}
 	if !strings.Contains(out, "Configuration written successfully.") {
 		t.Fatalf("expected success message with --force, got:\n%s", out)
@@ -2006,14 +2043,19 @@ func TestInstallActivation_ErrorPath(t *testing.T) {
 		t.Skip("claude provider not registered")
 	}
 
+	var actErr error
 	out := captureStdout(t, func() {
-		installActivation(home, prov)
+		actErr = installActivation(home, prov)
 	})
-
-	// On error, installActivation prints a warning to stderr and returns.
-	// Stdout should contain the warning message (or be empty if only stderr).
-	// The key thing is the function does not panic.
-	_ = out
+	if actErr == nil {
+		t.Fatal("expected installActivation error when .bashrc is a directory")
+	}
+	if !strings.Contains(actErr.Error(), "could not install shell activation") {
+		t.Errorf("error = %v, want wrapped activation failure", actErr)
+	}
+	if strings.Contains(out, "Configuration written successfully") {
+		t.Errorf("activation failure must not print success, got: %q", out)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/resolve_auth_mode_test.go
+++ b/cmd/resolve_auth_mode_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
@@ -141,6 +144,96 @@ func TestResolveAuthMode_Table(t *testing.T) {
 					tc.flagVal, tc.prov.Name(), tc.bCfg != nil, tc.existing != nil, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsCharDeviceMode(t *testing.T) {
+	if !isCharDeviceMode(os.ModeCharDevice) {
+		t.Error("ModeCharDevice should be a TTY")
+	}
+	if isCharDeviceMode(0) {
+		t.Error("regular file mode should not be a TTY")
+	}
+}
+
+func TestDefaultIsInteractiveStdin_PipeIsNotTTY(t *testing.T) {
+	testutil.WithStdin(t, "", func() {
+		if defaultIsInteractiveStdin() {
+			t.Error("piped stdin should not be treated as a TTY")
+		}
+	})
+}
+
+func TestDefaultIsInteractiveStdin_ClosedFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "closed-stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(name); err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = orig })
+	if defaultIsInteractiveStdin() {
+		t.Error("closed stdin should not be treated as a TTY")
+	}
+}
+
+func TestResolveFirstApplyInputs_NonInteractiveUsesDefaultAuth(t *testing.T) {
+	defer resetFlags()
+	resetFlags()
+	withInteractiveStdin(t, false)
+
+	home := testutil.NewTestHome(t)
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: authmode.IAM}}
+	got, _, _, err := resolveApplyInputs(home, bCfg, mustProvider(t, "claude"))
+	if err != nil {
+		t.Fatalf("non-interactive first-run should use defaults: %v", err)
+	}
+	if got != authmode.IAM {
+		t.Errorf("authMode = %q, want iam from defaults.auth_mode", got)
+	}
+}
+
+func TestResolveFirstApplyInputs_ExplicitAuthSkipsPromptOnTTY(t *testing.T) {
+	defer resetFlags()
+	resetFlags()
+	applyFlags.auth = authmode.BedrockAPIKey
+	withInteractiveStdin(t, true)
+
+	home := testutil.NewTestHome(t)
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: authmode.IAM}}
+	got, _, _, err := resolveApplyInputs(home, bCfg, mustProvider(t, "claude"))
+	if err != nil {
+		t.Fatalf("explicit --auth should skip prompt: %v", err)
+	}
+	if got != authmode.BedrockAPIKey {
+		t.Errorf("authMode = %q, want flag value", got)
+	}
+}
+
+func TestResolveFirstApplyInputs_InteractiveNoAuthPrompts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("TUI form blocks on Windows without a real console")
+	}
+	defer resetFlags()
+	resetFlags()
+	withInteractiveStdin(t, true)
+
+	home := testutil.NewTestHome(t)
+	bCfg := &bedrock.Config{Defaults: bedrock.Defaults{Region: "us-west-2", AuthMode: authmode.IAM}}
+	_, _, _, err := resolveApplyInputs(home, bCfg, mustProvider(t, "claude"))
+	if err == nil {
+		t.Fatal("expected guided prompt to run (and fail without a real TTY)")
+	}
+	if !strings.Contains(err.Error(), "terminal") && !strings.Contains(err.Error(), "tty") &&
+		!strings.Contains(err.Error(), "interactive") && !strings.Contains(err.Error(), "could not open") {
+		t.Logf("prompt failed as expected: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes four apply/helpers bugs in one PR.

**#437 product choice:** make the guided first-run prompt reachable when stdin is a TTY and `--auth` was not passed. Non-interactive runs (scripts, CI, piped stdin) still use `defaults.auth_mode` (typically `iam`). Explicit `--auth` always wins, including on re-apply. Docs still match this behavior; no README/QUICKSTART change.

## Changes
- **#438** Re-apply now passes `applyFlags.auth` into `resolveReApplyInputs` instead of the still-empty named return, so `--auth` switches IAM ↔ bedrock-api-key.
- **#437** First-run with no `--auth` prompts on a TTY; non-interactive uses `resolveAuthMode` defaults.
- **#443** `installActivation` returns an error; `commitApply` fails with a non-zero exit and does not print "Configuration written successfully." Dry-run is unchanged.
- **#442** `--mode=auto` no longer claims the Sonnet-tier default cannot show auto when the resolved default (Sonnet 5) is auto-capable. The switch-model hint remains only when `AutoModeAvailable` but not `AutoModeUsable`.

## Testing
- [x] `go test ./cmd/ ./internal/schema/ -count=1` passes
- [x] `go vet ./cmd/ ./internal/schema/` passes
- [ ] `cd npm && npm test` (npm/ not touched)
- [x] Tested on: Windows 11 / PowerShell 7

New coverage:
- Re-apply `--auth` switch (`TestApply_ReapplyWithAuth_HonorsFlag`, `TestResolveApplyInputs_ReapplyHonorsAuthFlag`)
- Prompt vs default-auth (`TestResolveFirstApplyInputs_*`, updated `TestResolveApplyInputs_PromptsWithoutAuthMode`)
- Activation install failure returns error and no success print (`TestInstallActivation_ErrorPath`, `TestCommitApply_ActivationInstallFailure`)
- Auto-mode no false Sonnet warning (`TestWarnAutoModeModel_UsableDefaultSonnet`, `TestApply_ModeAuto_NoFalseSonnetWarning`)

## Documentation
- [x] CHANGELOG Unreleased Fixed for each issue
- [x] README/QUICKSTART already claim the TTY prompt; behavior now matches

## Related Issues
Closes #438.
Closes #437.
Closes #443.
Closes #442.