### PR TITLE
fix(show): add --cli for Codex, OpenCode, and Grok configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Juggernaut will be documented in this file.
 
 ### Fixed
 
+- **`show --cli` now displays Codex, OpenCode, and Grok configs.** `juggernaut show`
+  was hardcoded to Claude's `settings.json`. It accepts
+  `--cli=claude|codex|opencode|grok` (default claude), including `--json`, and
+  prints that provider's Juggernaut-managed keys (Claude includes `env` /
+  `model` / the `juggernaut` metadata block). Bearer tokens and similarly named
+  secret fields are redacted. Providers whose user and project paths coincide
+  (Grok) are printed once.
 - **OpenCode and Grok IAM/SSO launches no longer demand a Bedrock API key.**
   Apply succeeded with `--auth=iam` (CapNativeAuth), but launch still treated
   OpenCode/Grok as token-gated (`NeedsToken=true`) and Grok always wrote

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -90,8 +90,9 @@ juggernaut apply --auth=iam --haiku-model=global.anthropic.claude-sonnet-4-6
 # Preview without writing
 juggernaut apply --auth=iam --dry-run
 
-# Show current config
+# Show current config (default --cli=claude)
 juggernaut show
+juggernaut show --cli=codex --json
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ claude          # after apply --cli=claude (default)
 | Command | Description |
 |---------|-------------|
 | `apply` | Write Juggernaut config for the target `--cli` and install shell activation. |
-| `show` | Print the current Juggernaut-managed config from user and project scopes. |
+| `show` | Print the current Juggernaut-managed config from user and project scopes. Supports `--cli=claude\|codex\|opencode\|grok` (default claude) and `--json`. |
 | `doctor` | Read-only diagnostics for settings, credentials, activation, CLI binary, and legacy artifacts. Supports `--cli=claude\|codex\|opencode\|grok`. |
 | `uninstall` | Remove managed config keys and optionally the bearer token. Use `--full` to remove shell activation. |
 | `models refresh` | Discover the models available to the current AWS account and region from native Bedrock (`foundation` + `profile` sources), then cache locally. |

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
-	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/spf13/cobra"
 )
@@ -16,11 +16,13 @@ var showCmd = &cobra.Command{
 }
 
 var showFlags struct {
+	cli     string
 	scope   string
 	jsonOut bool
 }
 
 func init() {
+	showCmd.Flags().StringVar(&showFlags.cli, "cli", "claude", "coding CLI to display: "+provider.SupportedNames())
 	showCmd.Flags().StringVar(&showFlags.scope, "scope", "", "show only user or project scope")
 	showCmd.Flags().BoolVar(&showFlags.jsonOut, "json", false, "output as JSON")
 	rootCmd.AddCommand(showCmd)
@@ -31,23 +33,30 @@ func runShow(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	prov, err := provider.Get(showFlags.cli)
+	if err != nil {
+		return err
+	}
 	scopes := resolvedScopes(showFlags.scope)
-	prov := provider.MustGet("claude")
 
 	results := map[string]any{}
+	seenPath := map[string]bool{}
 	for _, scope := range scopes {
 		path, perr := prov.ConfigPath(home, scope)
 		if perr != nil {
 			warnf("could not determine %s scope path: %v", scope, perr)
 			continue
 		}
-		mgr := config.NewManager(path)
-		data, err := mgr.Read()
+		if seenPath[path] {
+			continue
+		}
+		seenPath[path] = true
+		data, err := readProviderConfig(prov, home, scope)
 		if err != nil {
 			warnf("could not read %s settings: %v", scope, err)
 			continue
 		}
-		results[scope] = data["juggernaut"]
+		results[scope] = showPayload(prov, data)
 	}
 
 	if showFlags.jsonOut {
@@ -78,4 +87,68 @@ func runShow(_ *cobra.Command, _ []string) error {
 		fmt.Println(string(out))
 	}
 	return nil
+}
+
+// showPayload returns the Juggernaut-managed slice of a provider config, or
+// nil when Juggernaut does not own the file. Secret-bearing fields are redacted.
+func showPayload(prov provider.Provider, data map[string]any) any {
+	if data == nil || !prov.OwnsConfig(data) {
+		return nil
+	}
+	return redactSecrets(managedShowConfig(prov, data))
+}
+
+// managedShowConfig copies the juggernaut block (when present) plus the
+// provider's native managed keys so show is CLI-agnostic.
+func managedShowConfig(prov provider.Provider, data map[string]any) map[string]any {
+	out := map[string]any{}
+	if v, ok := data["juggernaut"]; ok {
+		out["juggernaut"] = v
+	}
+	for _, k := range prov.NativeManagedKeys() {
+		if k == "juggernaut" {
+			continue
+		}
+		if v, ok := data[k]; ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func redactSecrets(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if secretKeyName(k) {
+				if s, ok := val.(string); ok && s != "" {
+					out[k] = "[redacted]"
+					continue
+				}
+			}
+			out[k] = redactSecrets(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, item := range t {
+			out[i] = redactSecrets(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func secretKeyName(k string) bool {
+	n := strings.ToLower(strings.ReplaceAll(k, "-", "_"))
+	return strings.Contains(n, "token") ||
+		strings.Contains(n, "secret") ||
+		strings.Contains(n, "password") ||
+		strings.Contains(n, "api_key") ||
+		n == "apikey" ||
+		strings.Contains(n, "access_key") ||
+		n == "authorization" ||
+		n == "credential"
 }

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
 
 func TestShow_Text_AfterApply(t *testing.T) {
@@ -15,7 +19,7 @@ func TestShow_Text_AfterApply(t *testing.T) {
 		t.Fatalf("apply error: %v", err)
 	}
 
-	out := captureStdout(t, func() {
+	out := captureStreaming(t, func() {
 		if err := ExecuteArgs([]string{"show", "--scope=user"}); err != nil {
 			t.Fatalf("show error: %v", err)
 		}
@@ -38,7 +42,7 @@ func TestShow_JSON_AfterApply(t *testing.T) {
 		t.Fatalf("apply error: %v", err)
 	}
 
-	out := captureStdout(t, func() {
+	out := captureStreaming(t, func() {
 		if err := ExecuteArgs([]string{"show", "--scope=user", "--json"}); err != nil {
 			t.Fatalf("show --json error: %v", err)
 		}
@@ -56,7 +60,7 @@ func TestShow_JSON_AfterApply(t *testing.T) {
 func TestShow_NotConfigured(t *testing.T) {
 	_ = setupApplyTest(t)
 
-	out := captureStdout(t, func() {
+	out := captureStreaming(t, func() {
 		if err := ExecuteArgs([]string{"show", "--scope=user"}); err != nil {
 			t.Fatalf("show on clean home error: %v", err)
 		}
@@ -64,5 +68,236 @@ func TestShow_NotConfigured(t *testing.T) {
 
 	if !strings.Contains(out, "not configured") {
 		t.Errorf("show on a clean home should report 'not configured', got:\n%s", out)
+	}
+}
+
+func TestShow_CLI_TextAndJSON(t *testing.T) {
+	cases := []struct {
+		cli       string
+		applyArgs []string
+		wantText  []string
+	}{
+		{
+			cli:       "claude",
+			applyArgs: []string{"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight"},
+			wantText:  []string{"managedBy", `"env"`},
+		},
+		{
+			cli:       "codex",
+			applyArgs: []string{"apply", "--cli=codex", "--auth=iam", "--region=us-east-1", "--skip-preflight"},
+			wantText:  []string{"amazon-bedrock", "juggernaut"},
+		},
+		{
+			cli:       "opencode",
+			applyArgs: []string{"apply", "--cli=opencode", "--auth=iam", "--region=us-west-2", "--skip-preflight"},
+			wantText:  []string{"amazon-bedrock"},
+		},
+		{
+			cli:       "grok",
+			applyArgs: []string{"apply", "--cli=grok", "--auth=iam", "--region=us-west-2", "--skip-preflight"},
+			wantText:  []string{"bedrock-grok"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cli, func(t *testing.T) {
+			_ = setupApplyTest(t)
+			if err := ExecuteArgs(tc.applyArgs); err != nil {
+				t.Fatalf("apply --cli=%s: %v", tc.cli, err)
+			}
+
+			text := captureStreaming(t, func() {
+				if err := ExecuteArgs([]string{"show", "--cli=" + tc.cli, "--scope=user"}); err != nil {
+					t.Fatalf("show --cli=%s: %v", tc.cli, err)
+				}
+			})
+			if !strings.Contains(text, "user scope") {
+				t.Errorf("show --cli=%s missing user scope header:\n%s", tc.cli, text)
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(text, want) {
+					t.Errorf("show --cli=%s text omitted %q:\n%s", tc.cli, want, text)
+				}
+			}
+
+			js := captureStreaming(t, func() {
+				if err := ExecuteArgs([]string{"show", "--cli=" + tc.cli, "--scope=user", "--json"}); err != nil {
+					t.Fatalf("show --cli=%s --json: %v", tc.cli, err)
+				}
+			})
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(js), &parsed); err != nil {
+				t.Fatalf("show --cli=%s --json invalid JSON:\n%s\nerr: %v", tc.cli, js, err)
+			}
+			if _, ok := parsed["user"].(map[string]any); !ok {
+				t.Fatalf("show --cli=%s --json missing user object:\n%s", tc.cli, js)
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(js, want) {
+					t.Errorf("show --cli=%s --json omitted %q:\n%s", tc.cli, want, js)
+				}
+			}
+		})
+	}
+}
+
+func TestShow_UnknownCLI_Errors(t *testing.T) {
+	_ = setupApplyTest(t)
+	err := ExecuteArgs([]string{"show", "--cli=nonesuch"})
+	if err == nil {
+		t.Fatal("expected error for unknown --cli")
+	}
+	if !strings.Contains(err.Error(), "nonesuch") {
+		t.Errorf("error should name the bad CLI, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should list supported CLI names, got: %v", err)
+	}
+}
+
+func TestShow_DefaultCLI_IsClaude(t *testing.T) {
+	_ = setupApplyTest(t)
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=codex", "--auth=iam", "--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply --cli=codex: %v", err)
+	}
+	out := captureStreaming(t, func() {
+		if err := ExecuteArgs([]string{"show", "--scope=user"}); err != nil {
+			t.Fatalf("show: %v", err)
+		}
+	})
+	if !strings.Contains(out, "not configured") {
+		t.Errorf("show without --cli should stay on claude, got:\n%s", out)
+	}
+	if strings.Contains(out, "amazon-bedrock") {
+		t.Errorf("show without --cli must not dump Codex config, got:\n%s", out)
+	}
+}
+
+func TestShow_Grok_SkipsDuplicateProjectPath(t *testing.T) {
+	_ = setupApplyTest(t)
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=grok", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply --cli=grok: %v", err)
+	}
+	out := captureStreaming(t, func() {
+		if err := ExecuteArgs([]string{"show", "--cli=grok"}); err != nil {
+			t.Fatalf("show --cli=grok: %v", err)
+		}
+	})
+	if strings.Count(out, "=== ") != 1 {
+		t.Errorf("grok is user-only; expected one scope section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "=== user scope ===") {
+		t.Errorf("expected user scope for grok, got:\n%s", out)
+	}
+}
+
+func TestShow_RedactsBearerToken(t *testing.T) {
+	home := setupApplyTest(t)
+	if err := ExecuteArgs([]string{
+		"apply", "--auth=iam", "--region=us-west-2", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	raw := readSettingsJSON(t, home)
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		t.Fatalf("parse settings.json: %v", err)
+	}
+	env, _ := settings["env"].(map[string]any)
+	if env == nil {
+		env = map[string]any{}
+		settings["env"] = env
+	}
+	const leaked = "super-secret-value-not-a-real-key"
+	env["AWS_BEARER_TOKEN_BEDROCK"] = leaked
+	rewritten, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	if err := safepath.WriteFile(filepath.Join(home, ".claude"), settingsPath, rewritten); err != nil {
+		t.Fatalf("rewrite settings.json: %v", err)
+	}
+
+	out := captureStreaming(t, func() {
+		if err := ExecuteArgs([]string{"show", "--scope=user", "--json"}); err != nil {
+			t.Fatalf("show: %v", err)
+		}
+	})
+	if strings.Contains(out, leaked) {
+		t.Errorf("show dumped bearer token:\n%s", out)
+	}
+	if !strings.Contains(out, "[redacted]") {
+		t.Errorf("show should redact the token field, got:\n%s", out)
+	}
+}
+
+func TestRedactSecrets_NestedAndNonSecrets(t *testing.T) {
+	in := map[string]any{
+		"model":                    "keep",
+		"AWS_BEARER_TOKEN_BEDROCK": "hide-me",
+		"nested": map[string]any{
+			"api_key": "hide-nested",
+			"region":  "us-west-2",
+		},
+		"list":   []any{map[string]any{"token": "hide-list", "name": "ok"}},
+		"apikey": "",
+	}
+	got, ok := redactSecrets(in).(map[string]any)
+	if !ok {
+		t.Fatalf("redactSecrets should return a map, got %T", redactSecrets(in))
+	}
+	if got["model"] != "keep" {
+		t.Errorf("non-secret model = %v, want keep", got["model"])
+	}
+	if got["AWS_BEARER_TOKEN_BEDROCK"] != "[redacted]" {
+		t.Errorf("token field = %v, want [redacted]", got["AWS_BEARER_TOKEN_BEDROCK"])
+	}
+	if got["apikey"] != "" {
+		t.Errorf("empty secret string should stay empty, got %v", got["apikey"])
+	}
+	nested, _ := got["nested"].(map[string]any)
+	if nested["api_key"] != "[redacted]" {
+		t.Errorf("nested api_key = %v, want [redacted]", nested["api_key"])
+	}
+	if nested["region"] != "us-west-2" {
+		t.Errorf("nested region = %v, want us-west-2", nested["region"])
+	}
+	list, _ := got["list"].([]any)
+	item, _ := list[0].(map[string]any)
+	if item["token"] != "[redacted]" || item["name"] != "ok" {
+		t.Errorf("list item = %v", item)
+	}
+}
+
+func TestShowPayload_NotOwned(t *testing.T) {
+	prov, err := provider.Get("codex")
+	if err != nil {
+		t.Fatalf("provider.Get: %v", err)
+	}
+	if payload := showPayload(prov, map[string]any{"model": "user-owned"}); payload != nil {
+		t.Errorf("foreign config should be not-configured, got %#v", payload)
+	}
+	if payload := showPayload(prov, nil); payload != nil {
+		t.Errorf("nil config should be not-configured, got %#v", payload)
+	}
+}
+
+func TestSecretKeyName(t *testing.T) {
+	secrets := []string{"token", "AWS_BEARER_TOKEN_BEDROCK", "api-key", "apiKey", "secret", "password", "access_key", "authorization", "credential"}
+	for _, k := range secrets {
+		if !secretKeyName(k) {
+			t.Errorf("secretKeyName(%q) = false, want true", k)
+		}
+	}
+	safe := []string{"model", "region", "env", "auth_provider_command", "model_provider"}
+	for _, k := range safe {
+		if secretKeyName(k) {
+			t.Errorf("secretKeyName(%q) = true, want false", k)
+		}
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -182,8 +182,7 @@ func Get(name string) (Provider, error) {
 
 // MustGet resolves a provider by name and panics if not found. Use for
 // hard-coded provider names that are always registered (e.g. "claude" in
-// doctor/show) where the error path is unreachable and only adds uncovered
-// lines.
+// doctor) where the error path is unreachable and only adds uncovered lines.
 func MustGet(name string) Provider {
 	p, err := Get(name)
 	if err != nil {

--- a/npm/README.md
+++ b/npm/README.md
@@ -163,7 +163,7 @@ No overwriting the real CLI binary. No copying API keys into env vars. A backup 
 | Command | What it does |
 |---------|--------------|
 | `apply` | Configure Bedrock for the target `--cli` and install shell activation |
-| `show` | Print your current Juggernaut config |
+| `show` | Print your current Juggernaut config (`--cli=claude\|codex\|opencode\|grok`, `--json`) |
 | `doctor` | Diagnostics for settings, credentials, activation, CLI binary, and legacy artifacts |
 | `uninstall` | Remove managed config and token; `--full` also removes shell activation |
 | `models refresh` | Discover account/region model inventory from native Bedrock |


### PR DESCRIPTION
Closes #441.

## Problem

`juggernaut show` was hardcoded to Claude (`provider.MustGet("claude")`) with no `--cli`. Codex, OpenCode, and Grok configs were invisible, and TOML files were parsed as JSON.

## Fix

- `--cli=claude|codex|opencode|grok` (default claude), including `--json`
- Route through `provider.Get` and `readProviderConfig` (format-aware)
- Print Juggernaut-managed keys (`juggernaut` block plus `NativeManagedKeys`)
- Redact secret-bearing fields (tokens, API keys, passwords)
- Skip duplicate config paths so Grok (user-only) is printed once

## Tests

- Text + JSON for each CLI after apply
- Unknown `--cli` error
- Default `--cli` stays Claude
- Grok does not emit a duplicate project section
- Bearer token in Claude `env` is redacted
- Foreign/unowned config reports not configured

## Touch quality

- Dedup: table-driven per-CLI show coverage; reuse `readProviderConfig`
- Simplify: path-identity skip instead of a Grok `if cli==` branch
- Tests: new paths above