### PR TITLE
feat(logs): export redacted diagnostic bundles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Hooks: `scripts/setup-hooks.ps1` (Windows) or `bash scripts/setup-hooks.sh` (Lin
 ## Architecture
 
 - `main.go` embeds Bedrock config → `cmd.Execute()` (Cobra).
-- `cmd/` — commands, hidden `launch`/`launch-cli`/`auth-token`, shared helpers (`helpers.go`). `models.go` (`models check` release gate) and `model_catalog.go` (`models refresh`/`list`, cache `~/.juggernaut/model-catalog.json` per account+region).
+- `cmd/` — commands, hidden `launch`/`launch-cli`/`auth-token`, shared helpers (`helpers.go`). `models.go` (`models check` release gate) and `model_catalog.go` (`models refresh`/`list`, cache `~/.juggernaut/model-catalog.json` per account+region). `logs.go` (`logs export` writes a redacted diagnostic zip; `--raw` is opt-in).
 - `internal/provider/` — `Provider` interface + 4 implementations (`claude`, `codex`, `opencode`, `grok`). `base.go:BaseProvider` supplies `Name`, `BinaryNames`, `ConfigFormatName`, `ActivationMarkers`, `Supports`; providers override `ConfigPath`, `OwnsConfig`, `NativeManagedKeys`, `DeepMergeKeys`, `OwnedSubKeys`, `BuildConfig`, `LaunchSpec`. New CLI = one file + `register()` in `provider.go`; new knobs = `Capability`, not `if cli=="..."` in `cmd/`.
 - `internal/config/` — atomic JSON/TOML merge, removal, locking, backups. Respects `DeepMergeKeys`/`OwnedSubKeys` for nested tables.
 - `internal/activation/` — marked shell blocks (one per CLI, coexist in same profile) + owner-only runtime fallback `~/.juggernaut/runtime/` + launch wrapper that resolves real CLI binary and avoids recursion.
@@ -41,6 +41,7 @@ Hooks: `scripts/setup-hooks.ps1` (Windows) or `bash scripts/setup-hooks.sh` (Lin
 - `internal/keychain/` — shared bearer token; `*WithFallback` methods are the real path (handles 2560-byte Windows Credential Manager limit via versioned owner-only file). Bare `Set`/`Get`/`Delete` are keychain-only.
 - `internal/discovery/` — only package importing `aws-sdk-go-v2`.
 - `internal/safepath/` — containment + owner-only FS ops. Use for anything under user-controlled bases.
+- `internal/redact/` — diagnostic-bundle privacy: tokens, account IDs, home paths, emails, hostnames, LAN IPs → stable placeholders.
 - `npm/` — launcher + platform packages.
 
 Config paths: Claude `~/.claude/settings.json` (user) / `./.claude/settings.json` (project) — the only CLI with both scopes; Codex `~/.codex/config.toml` / `./.codex/config.toml` via `amazon-bedrock` provider; OpenCode `~/.config/opencode/opencode.json` / `./opencode.json` via `provider.amazon-bedrock` (region + discovered `models` + `whitelist`); Grok `~/.grok/config.toml` user-only (`base_url=https://bedrock-runtime.{region}.amazonaws.com/openai/v1`; `auth_provider_command="juggernaut auth-token"` only for `--auth=bedrock-api-key`). Launch reads `juggernaut.auth.mode` from project then user for non-Claude CLIs (token-gated only for API-key mode).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Juggernaut will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`juggernaut logs export` diagnostic bundle.** Writes a local zip of
+  version, OS/arch, configured CLI names, relevant env var names, and the
+  same `doctor` / `show` data those commands already print. Privacy is on by
+  default (tokens, account IDs, home-path usernames, emails, hostnames, and
+  LAN IPs become stable placeholders). Pass `--raw` / `--include-secrets`
+  only for private/self debugging; that path prints a one-line warning and
+  does not also write a redacted sibling file.
+
 ### Fixed
 
 - **`show --cli` now displays Codex, OpenCode, and Grok configs.** `juggernaut show`

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -56,6 +56,8 @@ Activation blocks for different CLIs coexist in one shell profile. Juggernaut in
 
 ```bash
 juggernaut doctor
+juggernaut logs export                 # redacted zip for support
+# juggernaut logs export --raw         # local/self only; includes secrets
 ```
 
 ## What Gets Configured

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ claude          # after apply --cli=claude (default)
 | `apply` | Write Juggernaut config for the target `--cli` and install shell activation. |
 | `show` | Print the current Juggernaut-managed config from user and project scopes. Supports `--cli=claude\|codex\|opencode\|grok` (default claude) and `--json`. |
 | `doctor` | Read-only diagnostics for settings, credentials, activation, CLI binary, and legacy artifacts. Supports `--cli=claude\|codex\|opencode\|grok`. |
+| `logs export` | Write a local diagnostic zip for support. Redacted by default; `--raw` / `--include-secrets` includes secrets for private/self use only. |
 | `uninstall` | Remove managed config keys and optionally the bearer token. Use `--full` to remove shell activation. |
 | `models refresh` | Discover the models available to the current AWS account and region from native Bedrock (`foundation` + `profile` sources), then cache locally. |
 | `models list` | List the cached inventory, optionally filtered to models compatible with a specific CLI (`--cli=codex\|opencode\|grok`). |
@@ -373,6 +374,8 @@ Close and reopen PowerShell after `doctor` is green. This avoids the old `C:\Use
 **Claude stopped using Bedrock after an update** — Run `juggernaut doctor`. If it reports that the managed config is missing and the runtime fallback is available, Claude can continue launching through Bedrock, but re-run `juggernaut apply --cli=claude` to restore the full `settings.json`.
 
 **`juggernaut doctor`** — always the first diagnostic step.
+
+**Shareable diagnostics** — `juggernaut logs export` writes a redacted zip (tokens, account IDs, and home paths stripped). Use `--raw` only on your own machine.
 
 ## Notes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,7 @@ Juggernaut is a local CLI that writes coding-agent configuration and optional sh
 - **Prefer IAM/SSO** (`--auth=iam`) so no long-lived Bedrock API key is stored (supported for every CLI on native `bedrock-runtime`).
 - **Bedrock API key** (`--auth=bedrock-api-key`) is stored in the OS keychain only and injected as `AWS_BEARER_TOKEN_BEDROCK` at launch (or via per-CLI `auth_provider_command`).
 - Uninstalling one non-Claude CLI does **not** remove the shared bearer token; only the last dependent CLI's uninstall clears it (and never on `--scope=project` when user-scope configs remain).
-- Do not commit `.backup.*` files, `.env`, or real keys. Redact `doctor` output before sharing.
+- Do not commit `.backup.*` files, `.env`, or real keys. Redact `doctor` output before sharing, or use `juggernaut logs export` (redacted by default; `--raw` is local/self only).
 
 ## Recommendations for operators
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -42,9 +42,29 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	prov, err := provider.Get(doctorFlags.cli)
+	r, err := collectDoctorReport(home, doctorFlags.cli, doctorFlags.scope)
 	if err != nil {
 		return err
+	}
+	if doctorFlags.jsonOut {
+		out, err := r.JSON()
+		if err != nil {
+			return fmt.Errorf("formatting doctor report as JSON: %w", err)
+		}
+		fmt.Println(string(out))
+	} else {
+		fmt.Print(r.String())
+	}
+	if r.HasFailures() {
+		return fmt.Errorf("doctor found failures — see above")
+	}
+	return nil
+}
+
+func collectDoctorReport(home, cli, scopeFilter string) (*doctor.Report, error) {
+	prov, err := provider.Get(cli)
+	if err != nil {
+		return nil, err
 	}
 	cliName := prov.Name()
 	isClaude := cliName == "claude"
@@ -57,16 +77,16 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		r.Check("bedrock-config.json", doctor.OK, "loaded (v"+bCfg.Version+")")
 	}
 
-	scopes := resolvedScopes(doctorFlags.scope)
+	scopes := resolvedScopes(scopeFilter)
 	// Grok is always user-scoped (ConfigPath ignores scope).
 	if cliName == "grok" {
-		if doctorFlags.scope == "project" {
-			return fmt.Errorf("grok has no project-scope config — omit --scope or use --scope=user")
+		if scopeFilter == "project" {
+			return nil, fmt.Errorf("grok has no project-scope config — omit --scope or use --scope=user")
 		}
 		scopes = []string{"user"}
 	}
 	for _, scope := range scopes {
-		required := scope != "project" || doctorFlags.scope == "project"
+		required := scope != "project" || scopeFilter == "project"
 		label := providerConfigLabel(prov, scope)
 		if status, detail := checkProviderConfigScope(prov, home, scope, required); status != "" {
 			r.Check(label, status, detail)
@@ -80,7 +100,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			checkFableDataRetention(r, scope, scopeData)
 		}
 	}
-	if doctorFlags.scope != "project" {
+	if scopeFilter != "project" {
 		checkRuntimeFallback(r, prov, home)
 	}
 
@@ -155,20 +175,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	if isClaude {
 		legacyArtifactStatus(home, r)
 	}
-	if doctorFlags.jsonOut {
-		out, err := r.JSON()
-		if err != nil {
-			return fmt.Errorf("formatting doctor report as JSON: %w", err)
-		}
-		fmt.Println(string(out))
-	} else {
-		fmt.Print(r.String())
-	}
-
-	if r.HasFailures() {
-		return fmt.Errorf("doctor found failures — see above")
-	}
-	return nil
+	return r, nil
 }
 
 func claudeCommandStatus() (doctor.Status, string) {

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,277 @@
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+	"github.com/jpvelasco/juggernaut/v5/internal/redact"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+	"github.com/spf13/cobra"
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "Export diagnostic bundles",
+}
+
+var logsExportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Write a diagnostic zip (redacted by default)",
+	Long: `Write a local diagnostic bundle for support.
+
+By default the zip is redacted: tokens, account IDs, home-path usernames,
+emails, hostnames, and LAN IPs are replaced with stable placeholders.
+Pass --raw (or --include-secrets) only for private/self debugging.
+
+The bundle includes juggernaut version, OS/arch, relevant env var names,
+configured CLI names, and the same doctor/show data those commands print.
+It does not copy the live keychain or settings.json into the default zip.`,
+	RunE: runLogsExport,
+}
+
+var logsExportFlags struct {
+	out            string
+	raw            bool
+	includeSecrets bool
+}
+
+var logsExportNow = time.Now
+
+func init() {
+	f := logsExportCmd.Flags()
+	f.StringVar(&logsExportFlags.out, "out", "", "output zip path (default: juggernaut-logs-<timestamp>.zip in the current directory)")
+	f.BoolVar(&logsExportFlags.raw, "raw", false, "include secrets (local/self use only; not the default)")
+	f.BoolVar(&logsExportFlags.includeSecrets, "include-secrets", false, "alias for --raw")
+	logsCmd.AddCommand(logsExportCmd)
+	rootCmd.AddCommand(logsCmd)
+}
+
+func runLogsExport(_ *cobra.Command, _ []string) error {
+	home, err := homeDir()
+	if err != nil {
+		return err
+	}
+	raw := logsExportFlags.raw || logsExportFlags.includeSecrets
+	if raw {
+		warnf("writing unredacted diagnostic bundle with secrets; keep it local and do not share")
+	}
+	files, err := buildDiagnosticFiles(home, raw)
+	if err != nil {
+		return err
+	}
+	path, err := resolveLogsOutPath(logsExportFlags.out)
+	if err != nil {
+		return err
+	}
+	if err := writeDiagnosticZip(path, files); err != nil {
+		return fmt.Errorf("writing diagnostic bundle: %w", err)
+	}
+	kind := "redacted"
+	if raw {
+		kind = "unredacted"
+	}
+	fmt.Printf("Wrote %s diagnostic bundle to %s\n", kind, path)
+	return nil
+}
+
+func defaultLogsFileName() string {
+	return "juggernaut-logs-" + logsExportNow().UTC().Format("20060102T150405Z") + ".zip"
+}
+
+func resolveLogsOutPath(out string) (string, error) {
+	if out == "" {
+		out = defaultLogsFileName()
+	}
+	abs, err := filepath.Abs(out)
+	if err != nil {
+		return "", fmt.Errorf("resolving output path: %w", err)
+	}
+	if info, err := os.Stat(abs); err == nil && info.IsDir() {
+		return "", fmt.Errorf("output path %q is a directory", abs)
+	}
+	base := filepath.Dir(abs)
+	return safepath.JoinUnder(base, filepath.Base(abs))
+}
+
+func writeDiagnosticZip(path string, files map[string][]byte) error {
+	data, err := zipBytes(files)
+	if err != nil {
+		return err
+	}
+	return safepath.WriteFile(filepath.Dir(path), path, data)
+}
+
+func zipBytes(files map[string][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		h := &zip.FileHeader{Name: name, Method: zip.Deflate}
+		h.SetMode(0o600)
+		w, err := zw.CreateHeader(h)
+		if err != nil {
+			_ = zw.Close()
+			return nil, err
+		}
+		if _, err := w.Write(files[name]); err != nil {
+			_ = zw.Close()
+			return nil, err
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func buildDiagnosticFiles(home string, raw bool) (map[string][]byte, error) {
+	report, err := collectDoctorReport(home, "claude", "")
+	if err != nil {
+		return nil, fmt.Errorf("collecting doctor output: %w", err)
+	}
+	// The bundle never uses show's field-level [redacted] masking: redact.String
+	// is the single redactor (and is skipped entirely under --raw), so the raw
+	// value is left intact for the pattern pass to handle.
+	showOut, err := formatShow(collectShowResults(provider.MustGet("claude"), home, "", false), "", false)
+	if err != nil {
+		return nil, fmt.Errorf("collecting show output: %w", err)
+	}
+
+	doctorOut := report.String()
+	if !raw {
+		opts := redact.Options{Home: home}
+		if token, err := keychain.Default().GetWithFallback(home); err == nil && token != "" {
+			opts.Secrets = []string{token}
+		}
+		doctorOut = redact.String(doctorOut, opts)
+		showOut = redact.String(showOut, opts)
+	}
+
+	privacy := "redacted"
+	if raw {
+		privacy = "raw"
+	}
+	return map[string][]byte{
+		"manifest.txt":  []byte(fmt.Sprintf("privacy=%s\ncreated=%s\n", privacy, logsExportNow().UTC().Format(time.RFC3339))),
+		"version.txt":   []byte(Version + "\n"),
+		"runtime.txt":   []byte(fmt.Sprintf("os=%s\narch=%s\n", runtime.GOOS, runtime.GOARCH)),
+		"env.txt":       []byte(formatRelevantEnv(raw)),
+		"providers.txt": []byte(formatConfiguredProviders(home)),
+		"doctor.txt":    []byte(doctorOut),
+		"show.txt":      []byte(showOut),
+	}, nil
+}
+
+func formatConfiguredProviders(home string) string {
+	var configured []string
+	for _, name := range provider.AllNames() {
+		p := provider.MustGet(name)
+		if providerConfigured(p, home) {
+			configured = append(configured, name)
+		}
+	}
+	var b strings.Builder
+	b.WriteString("supported: " + provider.SupportedNames() + "\n")
+	if len(configured) == 0 {
+		b.WriteString("configured: (none)\n")
+		return b.String()
+	}
+	b.WriteString("configured: " + strings.Join(configured, ", ") + "\n")
+	return b.String()
+}
+
+func providerConfigured(p provider.Provider, home string) bool {
+	for _, scope := range []string{"user", "project"} {
+		data, err := readProviderConfig(p, home, scope)
+		if err != nil || len(data) == 0 {
+			continue
+		}
+		if p.OwnsConfig(data) {
+			return true
+		}
+	}
+	return false
+}
+
+func formatRelevantEnv(raw bool) string {
+	names := relevantEnvNames()
+	sort.Strings(names)
+	var b strings.Builder
+	for _, name := range names {
+		value := os.Getenv(name)
+		if !raw {
+			value = redactedEnvValue(name)
+		}
+		fmt.Fprintf(&b, "%s=%s\n", name, value)
+	}
+	return b.String()
+}
+
+func relevantEnvNames() []string {
+	seen := map[string]struct{}{}
+	var names []string
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for _, kv := range os.Environ() {
+		name, _, _ := strings.Cut(kv, "=")
+		if isDiagnosticEnv(name) {
+			add(name)
+		}
+	}
+	return names
+}
+
+func isDiagnosticEnv(name string) bool {
+	switch {
+	case strings.HasPrefix(name, "AWS_"),
+		strings.HasPrefix(name, "ANTHROPIC_"),
+		strings.HasPrefix(name, "CLAUDE_"),
+		strings.HasPrefix(name, "BEDROCK_"),
+		strings.HasPrefix(name, "JUGGERNAUT_"):
+		return true
+	}
+	switch name {
+	case "HOME", "USERPROFILE", "USERNAME", "USER", "LOGNAME",
+		"HOSTNAME", "COMPUTERNAME", "PATH":
+		return true
+	}
+	return false
+}
+
+func redactedEnvValue(name string) string {
+	upper := strings.ToUpper(name)
+	switch {
+	case strings.Contains(upper, "TOKEN"),
+		strings.Contains(upper, "SECRET"),
+		strings.Contains(upper, "PASSWORD"),
+		strings.Contains(upper, "CREDENTIAL"),
+		strings.Contains(upper, "ACCESS_KEY"),
+		strings.HasSuffix(upper, "_KEY"):
+		return redact.Token
+	case name == "HOME", name == "USERPROFILE":
+		return redact.Home
+	default:
+		return "<redacted>"
+	}
+}

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/redact"
+	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
+)
+
+const logsTestToken = "super-secret-token-value"
+const logsTestAccount = "123456789012"
+
+func TestLogsExport_DefaultRedactsSecrets(t *testing.T) {
+	home := setupLogsExportHome(t)
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", logsTestToken)
+
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+	printed := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"logs", "export", "--out", out}); err != nil {
+			t.Fatalf("logs export: %v", err)
+		}
+	})
+	if !strings.Contains(printed, "redacted diagnostic bundle") {
+		t.Fatalf("expected redacted confirmation, got %q", printed)
+	}
+
+	files := readLogsZip(t, out)
+	show := files["show.txt"]
+	env := files["env.txt"]
+	if showContainsPath(show, home) {
+		t.Errorf("show.txt still contains home path %q:\n%s", home, show)
+	}
+	for _, secret := range []string{logsTestToken, logsTestAccount} {
+		if strings.Contains(show, secret) {
+			t.Errorf("show.txt still contains %q:\n%s", secret, show)
+		}
+		if strings.Contains(env, secret) {
+			t.Errorf("env.txt still contains %q:\n%s", secret, env)
+		}
+	}
+	if !strings.Contains(show, redact.Token) {
+		t.Errorf("show.txt missing %s:\n%s", redact.Token, show)
+	}
+	if !strings.Contains(show, redact.AccountID) {
+		t.Errorf("show.txt missing %s:\n%s", redact.AccountID, show)
+	}
+	if !strings.Contains(show, redact.Home) {
+		t.Errorf("show.txt missing %s:\n%s", redact.Home, show)
+	}
+	if !strings.Contains(env, "AWS_BEARER_TOKEN_BEDROCK="+redact.Token) {
+		t.Errorf("env.txt should redact bearer token value, got:\n%s", env)
+	}
+	assertBundleMinimum(t, files)
+	for _, leaked := range []string{"settings.json", "juggernaut-credential", "credential-fallback.json"} {
+		if _, ok := files[leaked]; ok {
+			t.Errorf("default zip must not copy %s", leaked)
+		}
+	}
+}
+
+func TestLogsExport_RawIncludesSecrets(t *testing.T) {
+	home := setupLogsExportHome(t)
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", logsTestToken)
+
+	dir := t.TempDir()
+	out := filepath.Join(dir, "raw.zip")
+	var stderr string
+	stdout := captureStdout(t, func() {
+		stderr = captureStderr(t, func() {
+			if err := ExecuteArgs([]string{"logs", "export", "--raw", "--out", out}); err != nil {
+				t.Fatalf("logs export --raw: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(stderr, "unredacted") {
+		t.Fatalf("expected one-line raw warning on stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "unredacted diagnostic bundle") {
+		t.Fatalf("expected unredacted confirmation, got %q", stdout)
+	}
+
+	files := readLogsZip(t, out)
+	show := files["show.txt"]
+	env := files["env.txt"]
+	if !strings.Contains(show, logsTestToken) {
+		t.Errorf("raw show.txt should include token, got:\n%s", show)
+	}
+	if !strings.Contains(show, logsTestAccount) {
+		t.Errorf("raw show.txt should include account id, got:\n%s", show)
+	}
+	if !showContainsPath(show, home) {
+		t.Errorf("raw show.txt should include home path, got:\n%s", show)
+	}
+	if !strings.Contains(env, logsTestToken) {
+		t.Errorf("raw env.txt should include token, got:\n%s", env)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("raw export must not also write a redacted sibling, got %d files", len(entries))
+	}
+}
+
+func TestLogsExport_IncludeSecretsAlias(t *testing.T) {
+	_ = setupLogsExportHome(t)
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", logsTestToken)
+
+	out := filepath.Join(t.TempDir(), "alias.zip")
+	if err := ExecuteArgs([]string{"logs", "export", "--include-secrets", "--out", out}); err != nil {
+		t.Fatalf("logs export --include-secrets: %v", err)
+	}
+	env := readLogsZip(t, out)["env.txt"]
+	if !strings.Contains(env, logsTestToken) {
+		t.Errorf("--include-secrets should keep env secrets, got:\n%s", env)
+	}
+}
+
+func TestLogsExport_SucceedsWhenDoctorWouldFail(t *testing.T) {
+	_ = setupApplyTest(t)
+	out := filepath.Join(t.TempDir(), "broken.zip")
+	if err := ExecuteArgs([]string{"logs", "export", "--out", out}); err != nil {
+		t.Fatalf("export should succeed even when doctor reports failures: %v", err)
+	}
+	files := readLogsZip(t, out)
+	if !strings.Contains(files["doctor.txt"], "FAIL") && !strings.Contains(files["doctor.txt"], "not found") {
+		t.Errorf("expected doctor failure details in bundle, got:\n%s", files["doctor.txt"])
+	}
+}
+
+func TestLogsExport_HomeDirError(t *testing.T) {
+	noHomeEnv(t)
+	err := ExecuteArgs([]string{"logs", "export", "--out", filepath.Join(t.TempDir(), "x.zip")})
+	assertHomeDirError(t, err)
+}
+
+func TestLogsExport_DefaultOutPath(t *testing.T) {
+	_ = setupLogsExportHome(t)
+	dir := t.TempDir()
+	chdirTo(t, dir)
+	logsExportNow = func() time.Time {
+		return time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	}
+	t.Cleanup(func() { logsExportNow = time.Now })
+
+	if err := ExecuteArgs([]string{"logs", "export"}); err != nil {
+		t.Fatalf("logs export: %v", err)
+	}
+	want := filepath.Join(dir, "juggernaut-logs-20260904T120000Z.zip")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected default zip at %s: %v", want, err)
+	}
+}
+
+func TestRedactedEnvValue_StablePlaceholders(t *testing.T) {
+	if got := redactedEnvValue("AWS_BEARER_TOKEN_BEDROCK"); got != redact.Token {
+		t.Errorf("token env = %q, want %s", got, redact.Token)
+	}
+	if got := redactedEnvValue("AWS_ACCESS_KEY_ID"); got != redact.Token {
+		t.Errorf("access key env = %q, want %s", got, redact.Token)
+	}
+	if got := redactedEnvValue("HOME"); got != redact.Home {
+		t.Errorf("HOME = %q, want %s", got, redact.Home)
+	}
+	if got := redactedEnvValue("AWS_REGION"); got != "<redacted>" {
+		t.Errorf("region env = %q, want <redacted>", got)
+	}
+}
+
+func TestIsDiagnosticEnv(t *testing.T) {
+	for _, name := range []string{"AWS_REGION", "ANTHROPIC_MODEL", "CLAUDE_CODE_USE_BEDROCK", "HOME", "PATH"} {
+		if !isDiagnosticEnv(name) {
+			t.Errorf("%s should be diagnostic", name)
+		}
+	}
+	if isDiagnosticEnv("EDITOR") {
+		t.Error("EDITOR should not be treated as a diagnostic env var")
+	}
+}
+
+func TestLogsExport_RejectsDirectoryOut(t *testing.T) {
+	_ = setupApplyTest(t)
+	dir := t.TempDir()
+	err := ExecuteArgs([]string{"logs", "export", "--out", dir})
+	if err == nil || !strings.Contains(err.Error(), "directory") {
+		t.Fatalf("expected directory error, got %v", err)
+	}
+}
+
+func setupLogsExportHome(t *testing.T) string {
+	t.Helper()
+	home := setupApplyTest(t)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := safepath.MkdirAll(claudeDir); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"juggernaut": map[string]any{
+			"meta": map[string]any{
+				"managedBy": "juggernaut",
+			},
+			"auth": map[string]any{
+				"token":   "Bearer " + logsTestToken,
+				"account": logsTestAccount,
+			},
+			"home": home,
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	path := filepath.Join(claudeDir, "settings.json")
+	if err := safepath.WriteFile(claudeDir, path, payload); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	return home
+}
+
+func readLogsZip(t *testing.T, path string) map[string]string {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	out := map[string]string{}
+	for _, f := range r.File {
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", f.Name, err)
+		}
+		body, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("read %s: %v", f.Name, err)
+		}
+		out[f.Name] = string(body)
+	}
+	return out
+}
+
+func showContainsPath(show, home string) bool {
+	if strings.Contains(show, home) {
+		return true
+	}
+	escaped := strings.ReplaceAll(home, `\`, `\\`)
+	if escaped != home && strings.Contains(show, escaped) {
+		return true
+	}
+	return strings.Contains(show, filepath.ToSlash(home))
+}
+
+func assertBundleMinimum(t *testing.T, files map[string]string) {
+	t.Helper()
+	for _, name := range []string{
+		"version.txt", "runtime.txt", "env.txt", "providers.txt",
+		"doctor.txt", "show.txt", "manifest.txt",
+	} {
+		if strings.TrimSpace(files[name]) == "" {
+			t.Errorf("bundle missing %s", name)
+		}
+	}
+	if !strings.Contains(files["version.txt"], Version) {
+		t.Errorf("version.txt should contain %s, got %q", Version, files["version.txt"])
+	}
+	if !strings.Contains(files["runtime.txt"], "os=") || !strings.Contains(files["runtime.txt"], "arch=") {
+		t.Errorf("runtime.txt missing os/arch:\n%s", files["runtime.txt"])
+	}
+	if !strings.Contains(files["manifest.txt"], "privacy=redacted") {
+		t.Errorf("manifest should record redacted privacy, got %q", files["manifest.txt"])
+	}
+	if !strings.Contains(files["providers.txt"], "supported:") {
+		t.Errorf("providers.txt missing supported list:\n%s", files["providers.txt"])
+	}
+}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -37,11 +37,19 @@ func runShow(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	scopes := resolvedScopes(showFlags.scope)
+	// show always redacts secret-bearing fields; the bundle path passes false.
+	out, err := formatShow(collectShowResults(prov, home, showFlags.scope, true), showFlags.scope, showFlags.jsonOut)
+	if err != nil {
+		return err
+	}
+	fmt.Print(out)
+	return nil
+}
 
+func collectShowResults(prov provider.Provider, home, scopeFilter string, redact bool) map[string]any {
 	results := map[string]any{}
 	seenPath := map[string]bool{}
-	for _, scope := range scopes {
+	for _, scope := range resolvedScopes(scopeFilter) {
 		path, perr := prov.ConfigPath(home, scope)
 		if perr != nil {
 			warnf("could not determine %s scope path: %v", scope, perr)
@@ -56,46 +64,56 @@ func runShow(_ *cobra.Command, _ []string) error {
 			warnf("could not read %s settings: %v", scope, err)
 			continue
 		}
-		results[scope] = showPayload(prov, data)
+		results[scope] = showPayload(prov, data, redact)
 	}
+	return results
+}
 
-	if showFlags.jsonOut {
+func formatShow(results map[string]any, scopeFilter string, jsonOut bool) (string, error) {
+	if jsonOut {
 		out, err := json.MarshalIndent(results, "", "  ")
 		if err != nil {
-			return fmt.Errorf("serializing configuration: %w", err)
+			return "", fmt.Errorf("serializing configuration: %w", err)
 		}
-		fmt.Println(string(out))
-		return nil
+		return string(out) + "\n", nil
 	}
 
 	// Iterate the canonical scopes order, not the map — Go randomizes map
 	// iteration and scripts diff this output.
-	for _, scope := range scopes {
+	var b strings.Builder
+	for _, scope := range resolvedScopes(scopeFilter) {
 		block, found := results[scope]
 		if !found {
 			continue
 		}
-		fmt.Printf("=== %s scope ===\n", scope)
+		fmt.Fprintf(&b, "=== %s scope ===\n", scope)
 		if block == nil {
-			fmt.Println("  (not configured)")
+			b.WriteString("  (not configured)\n")
 			continue
 		}
 		out, err := json.MarshalIndent(block, "", "  ")
 		if err != nil {
-			return fmt.Errorf("serializing %s configuration: %w", scope, err)
+			return "", fmt.Errorf("serializing %s configuration: %w", scope, err)
 		}
-		fmt.Println(string(out))
+		b.WriteString(string(out))
+		b.WriteByte('\n')
 	}
-	return nil
+	return b.String(), nil
 }
 
 // showPayload returns the Juggernaut-managed slice of a provider config, or
-// nil when Juggernaut does not own the file. Secret-bearing fields are redacted.
-func showPayload(prov provider.Provider, data map[string]any) any {
+// nil when Juggernaut does not own the file. When redact is true, secret-bearing
+// fields are masked; the logs export path passes false so its --raw bundles and
+// its redact.String pass are the sole secret control.
+func showPayload(prov provider.Provider, data map[string]any, redact bool) any {
 	if data == nil || !prov.OwnsConfig(data) {
 		return nil
 	}
-	return redactSecrets(managedShowConfig(prov, data))
+	cfg := managedShowConfig(prov, data)
+	if !redact {
+		return cfg
+	}
+	return redactSecrets(cfg)
 }
 
 // managedShowConfig copies the juggernaut block (when present) plus the

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -279,10 +279,10 @@ func TestShowPayload_NotOwned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provider.Get: %v", err)
 	}
-	if payload := showPayload(prov, map[string]any{"model": "user-owned"}); payload != nil {
+	if payload := showPayload(prov, map[string]any{"model": "user-owned"}, true); payload != nil {
 		t.Errorf("foreign config should be not-configured, got %#v", payload)
 	}
-	if payload := showPayload(prov, nil); payload != nil {
+	if payload := showPayload(prov, nil, true); payload != nil {
 		t.Errorf("nil config should be not-configured, got %#v", payload)
 	}
 }

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,173 @@
+// Package redact strips secrets and identifying values from diagnostic text.
+package redact
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// Stable placeholders. Empty strings are never used as replacements.
+const (
+	Token       = "<token>"
+	AccountID   = "<account-id>"
+	Home        = "<home>"
+	Email       = "<email>"
+	Hostname    = "<hostname>"
+	IP          = "<ip>"
+	ARN         = "<arn>"
+	AccessKeyID = "<access-key-id>"
+)
+
+// Options controls extra values to scrub in addition to built-in patterns.
+type Options struct {
+	Home     string
+	Secrets  []string
+	Hostname string
+}
+
+var (
+	reAccessKeyID = regexp.MustCompile(`(?:AKIA|ASIA|AROA|AIDA)[A-Z0-9]{16}`)
+	reAccountID   = regexp.MustCompile(`\b\d{12}\b`)
+	reEmail       = regexp.MustCompile(`(?i)[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}`)
+	reARN         = regexp.MustCompile(`arn:aws[\w-]*:[^\s"'\\]+`)
+	reBearer      = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._\-+=/]+`)
+	reAuthHeader  = regexp.MustCompile(`(?i)\bauthorization\s*[:=]\s*\S.*`)
+	reBedrockKey  = regexp.MustCompile(`bedrock-api-key-[A-Za-z0-9+/=_\-]+`)
+	reABSK        = regexp.MustCompile(`\bABSK[A-Za-z0-9+/=_\-]{8,}`)
+	reJWT         = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`)
+	reSecretKey   = regexp.MustCompile(`(?i)(aws_secret_access_key\s*[=:]\s*)([A-Za-z0-9/+=]{40})`)
+	reSessionTok  = regexp.MustCompile(`(?i)(aws_session_token\s*[=:]\s*)(\S+)`)
+	reIPv4        = regexp.MustCompile(`\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\b`)
+	reHomeUser    = regexp.MustCompile(`(?i)([/\\](?:Users|home)[/\\])([^/\\]+)`)
+)
+
+// String replaces secrets, account identifiers, and home-path usernames with
+// stable placeholders. The input is unchanged when empty.
+func String(s string, opts Options) string {
+	if s == "" {
+		return s
+	}
+	s = replaceSecrets(s, opts.Secrets)
+	s = reBearer.ReplaceAllString(s, "Bearer "+Token)
+	s = reAuthHeader.ReplaceAllString(s, "Authorization: "+Token)
+	s = reBedrockKey.ReplaceAllString(s, Token)
+	s = reABSK.ReplaceAllString(s, Token)
+	s = reJWT.ReplaceAllString(s, Token)
+	s = reSecretKey.ReplaceAllString(s, "${1}"+Token)
+	s = reSessionTok.ReplaceAllString(s, "${1}"+Token)
+	s = reAccessKeyID.ReplaceAllString(s, AccessKeyID)
+	s = reARN.ReplaceAllString(s, ARN)
+	s = reEmail.ReplaceAllString(s, Email)
+	s = replaceHome(s, opts.Home)
+	s = replaceHostname(s, opts.Hostname)
+	s = redactPrivateIPs(s)
+	s = reAccountID.ReplaceAllString(s, AccountID)
+	return s
+}
+
+func replaceSecrets(s string, secrets []string) string {
+	vals := uniqueNonEmpty(secrets)
+	sort.Slice(vals, func(i, j int) bool { return len(vals[i]) > len(vals[j]) })
+	for _, secret := range vals {
+		s = strings.ReplaceAll(s, secret, Token)
+	}
+	return s
+}
+
+func replaceHome(s, home string) string {
+	for _, variant := range homeVariants(home) {
+		s = replaceInsensitive(s, variant, Home)
+	}
+	return reHomeUser.ReplaceAllString(s, "${1}"+Home)
+}
+
+func replaceHostname(s, host string) string {
+	if host == "" {
+		host, _ = os.Hostname()
+	}
+	host = strings.TrimSpace(host)
+	if host == "" || strings.EqualFold(host, "localhost") {
+		return s
+	}
+	s = replaceInsensitive(s, host, Hostname)
+	if short, _, ok := strings.Cut(host, "."); ok && len(short) > 1 && !strings.EqualFold(short, "localhost") {
+		s = replaceInsensitive(s, short, Hostname)
+	}
+	return s
+}
+
+func redactPrivateIPs(s string) string {
+	return reIPv4.ReplaceAllStringFunc(s, func(match string) string {
+		ip := net.ParseIP(match)
+		if ip == nil {
+			return match
+		}
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() {
+			return IP
+		}
+		return match
+	})
+}
+
+func homeVariants(home string) []string {
+	real, _ := os.UserHomeDir()
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(v string) {
+		v = strings.TrimRight(v, `/\`)
+		if v == "" {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, raw := range []string{home, os.Getenv("HOME"), os.Getenv("USERPROFILE"), real} {
+		if raw == "" {
+			continue
+		}
+		clean := filepath.Clean(raw)
+		add(clean)
+		add(filepath.ToSlash(clean))
+		if runtime.GOOS == "windows" {
+			add(strings.ReplaceAll(clean, `\`, `\\`))
+			add(strings.ReplaceAll(clean, `\`, `/`))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return len(out[i]) > len(out[j]) })
+	return out
+}
+
+func replaceInsensitive(s, old, neu string) string {
+	if old == "" || neu == "" {
+		return s
+	}
+	re, err := regexp.Compile(`(?i)` + regexp.QuoteMeta(old))
+	if err != nil {
+		return strings.ReplaceAll(s, old, neu)
+	}
+	return re.ReplaceAllString(s, neu)
+}
+
+func uniqueNonEmpty(in []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, v := range in {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,108 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestString_RedactsTokenAccountAndHome(t *testing.T) {
+	home := `C:\Users\alice\AppData\Local\Temp\juggernaut-test`
+	in := strings.Join([]string{
+		"Authorization: Bearer super-secret-token-value",
+		"account 123456789012",
+		"path " + home + `\settings.json`,
+		"also /Users/bob/.claude/settings.json",
+	}, "\n")
+
+	out := String(in, Options{Home: home})
+	for _, secret := range []string{
+		"super-secret-token-value",
+		"123456789012",
+		home,
+		`\Users\alice`,
+		"/Users/bob",
+	} {
+		if strings.Contains(out, secret) {
+			t.Errorf("redacted output still contains %q:\n%s", secret, out)
+		}
+	}
+	for _, placeholder := range []string{Token, AccountID, Home} {
+		if !strings.Contains(out, placeholder) {
+			t.Errorf("expected placeholder %s in:\n%s", placeholder, out)
+		}
+		if placeholder == "" {
+			t.Fatal("placeholder must not be empty")
+		}
+	}
+}
+
+func TestString_RedactsAccessKeyARNEmailHostnameAndLANIP(t *testing.T) {
+	accessKey := "AKIA" + "TESTKEYNOTREAL00"
+	in := strings.Join([]string{
+		"key " + accessKey,
+		"arn:aws:iam::123456789012:role/Admin",
+		"user  test.user@example.com",
+		"host my-laptop.local",
+		"lan 192.168.1.50",
+		"loop 127.0.0.1",
+	}, "\n")
+
+	out := String(in, Options{Hostname: "my-laptop.local"})
+	if strings.Contains(out, accessKey) {
+		t.Errorf("access key still present:\n%s", out)
+	}
+	if strings.Contains(out, "arn:aws:iam::") {
+		t.Errorf("ARN still present:\n%s", out)
+	}
+	if strings.Contains(out, "test.user@example.com") {
+		t.Errorf("email still present:\n%s", out)
+	}
+	if strings.Contains(out, "my-laptop.local") {
+		t.Errorf("hostname still present:\n%s", out)
+	}
+	if strings.Contains(out, "192.168.1.50") || strings.Contains(out, "127.0.0.1") {
+		t.Errorf("LAN/loopback IP still present:\n%s", out)
+	}
+	if !strings.Contains(out, AccessKeyID) || !strings.Contains(out, ARN) || !strings.Contains(out, Email) {
+		t.Errorf("missing placeholders:\n%s", out)
+	}
+	if !strings.Contains(out, Hostname) || !strings.Contains(out, IP) {
+		t.Errorf("missing host/ip placeholders:\n%s", out)
+	}
+}
+
+func TestString_ReplacesExplicitSecretsFirst(t *testing.T) {
+	out := String("token=abc-literal-secret", Options{Secrets: []string{"abc-literal-secret"}})
+	if strings.Contains(out, "abc-literal-secret") {
+		t.Fatalf("secret still present: %s", out)
+	}
+	if !strings.Contains(out, Token) {
+		t.Fatalf("expected %s, got %s", Token, out)
+	}
+}
+
+func TestString_EmptyInputUnchanged(t *testing.T) {
+	if got := String("", Options{Home: "/tmp"}); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+func TestString_DoesNotRedactPublicIP(t *testing.T) {
+	in := "reach 8.8.8.8"
+	out := String(in, Options{})
+	if !strings.Contains(out, "8.8.8.8") {
+		t.Fatalf("public IP should remain, got %s", out)
+	}
+}
+
+func TestString_BedrockAPIKeyAndJWT(t *testing.T) {
+	jwt := "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiIxIn0." + "abc"
+	in := "bedrock-api-key-AAAA\n" + jwt
+	out := String(in, Options{})
+	if strings.Contains(out, "bedrock-api-key-AAAA") || strings.Contains(out, jwt) {
+		t.Fatalf("key material still present: %s", out)
+	}
+	if !strings.Contains(out, Token) {
+		t.Fatalf("expected %s, got %s", Token, out)
+	}
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -65,6 +65,7 @@ The interactive setup guides you through the first run. After applying, restart 
 | **Safe activation** | Never overwrite an unknown CLI binary; fall through to the real CLI if Juggernaut is unavailable |
 | **Cross-platform launcher** | Use the same workflow on macOS, Linux, Windows, and WSL |
 | **`doctor` diagnostics** | Check credentials, configuration, activation, PATH, binaries, and legacy artifacts |
+| **Redacted log export** | `juggernaut logs export` writes a support zip; `--raw` is opt-in for local/self use |
 
 ## Discover models your account can actually access
 


### PR DESCRIPTION
## Summary

Adds `juggernaut logs export` so support bundles can be shared without leaking credentials. Privacy is on by default; `--raw` / `--include-secrets` is an explicit opt-in for local/self debugging.

```
juggernaut logs export                 # redacted zip
juggernaut logs export --raw           # unredacted; one-line warning
juggernaut logs export --out path.zip
```

Closes #434.

## Behavior

- **Default:** redacts Bedrock/API/IAM/SSO tokens and keychain material, Authorization/bearer values, AWS account IDs, SSO ARNs, access key IDs, emails, usernames in home paths, hostnames, and LAN IPs. Replacements are stable placeholders (`<token>`, `<account-id>`, `<home>`), never empty strings.
- **`--raw` / `--include-secrets`:** unredacted bundle plus a one-line warning. Raw is not the default and is not written next to the redacted file.
- Bundle includes juggernaut version, OS/arch, relevant env var *names* (values redacted unless `--raw`), configured CLI/provider names, and the same `doctor` / `show` data those commands already print.
- Default zip does **not** copy the live keychain or `settings.json`.
- Export succeeds even when `doctor` would fail, so a broken install can still produce a bundle.
- Output path is contained with `internal/safepath`.

Doctor and show internals are reused (`collectDoctorReport` / `collectShowResults` + `formatShow`); the binary is not re-exec'd.

## Tests

- `internal/redact`: tokens, account IDs, home paths, ARNs, emails, hostnames, LAN IPs; public IPs left intact.
- `cmd` Logs tests: default redacts secrets; `--raw` includes them; `--include-secrets` alias; no raw sibling file; doctor failures do not fail export; home-dir error; default timestamped `--out`; directory `--out` rejected.

## Quality

- **Dedup:** doctor/show collection extracted and reused by export; no second copy of those printers.
- **Simplify:** `runDoctor`/`runShow` now print collected output; zip write split from path resolve.
- **Tests:** redaction + export default vs `--raw` + error paths.

Out of scope: apply/launch changes, uploading the bundle.