### PR TITLE
fix(launch): IAM wrap without token; read project-scope auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Hooks: `scripts/setup-hooks.ps1` (Windows) or `bash scripts/setup-hooks.sh` (Lin
 - `internal/safepath/` — containment + owner-only FS ops. Use for anything under user-controlled bases.
 - `npm/` — launcher + platform packages.
 
-Config paths: Claude `~/.claude/settings.json` (user) / `./.claude/settings.json` (project) — the only CLI with both scopes; Codex `~/.codex/config.toml` / `./.codex/config.toml` via `amazon-bedrock` provider; OpenCode `~/.config/opencode/opencode.json` / `./opencode.json` via `provider.amazon-bedrock` (region + discovered `models` + `whitelist`); Grok `~/.grok/config.toml` user-only (`base_url=https://bedrock-runtime.{region}.amazonaws.com/openai/v1` + `auth_provider_command="juggernaut auth-token"`).
+Config paths: Claude `~/.claude/settings.json` (user) / `./.claude/settings.json` (project) — the only CLI with both scopes; Codex `~/.codex/config.toml` / `./.codex/config.toml` via `amazon-bedrock` provider; OpenCode `~/.config/opencode/opencode.json` / `./opencode.json` via `provider.amazon-bedrock` (region + discovered `models` + `whitelist`); Grok `~/.grok/config.toml` user-only (`base_url=https://bedrock-runtime.{region}.amazonaws.com/openai/v1`; `auth_provider_command="juggernaut auth-token"` only for `--auth=bedrock-api-key`). Launch reads `juggernaut.auth.mode` from project then user for non-Claude CLIs (token-gated only for API-key mode).
 
 ## Constraints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Juggernaut will be documented in this file.
 
 ### Fixed
 
+- **OpenCode and Grok IAM/SSO launches no longer demand a Bedrock API key.**
+  Apply succeeded with `--auth=iam` (CapNativeAuth), but launch still treated
+  OpenCode/Grok as token-gated (`NeedsToken=true`) and Grok always wrote
+  `auth_provider_command = "juggernaut auth-token"`. Both now persist
+  `juggernaut.auth.mode` like Codex; the wrapper injects a bearer token only
+  for `--auth=bedrock-api-key`. Grok's auth-token command is API-key-only.
+- **Non-Claude launch reads project-scope auth mode.** The wrapper only probed
+  the user-scope config, so a Codex/OpenCode `--scope=project` API-key apply
+  was invisible at wrap time. Launch now checks project then user, matching
+  the file apply wrote (Claude already did this for settings.json).
 - **`apply --auth` now wins on re-apply.** Re-applying used to pass the still-empty named return into auth resolution, so `--auth=iam` / `--auth=bedrock-api-key` was ignored and the previous mode was kept while reporting success.
 - **Bare `apply` prompts on a TTY.** First-run with no `--auth` launches the guided prompt when stdin is a terminal. Non-interactive runs (scripts, CI) still use `defaults.auth_mode`. Explicit `--auth` always wins.
 - **Activation install failures now fail `apply`.** A failed shell-block install returns a non-zero exit and does not print "Configuration written successfully." Dry-run is unchanged.

--- a/cmd/coverage_batch1_test.go
+++ b/cmd/coverage_batch1_test.go
@@ -745,6 +745,15 @@ func TestLaunchNamedCLI_TokenReadError(t *testing.T) {
 	t.Setenv("JUGGERNAUT_KEYCHAIN_SERVICE", "jug-batch1-launch")
 	blockCredentialWrite(t, home)
 
+	grokDir := filepath.Join(home, ".grok")
+	if err := os.MkdirAll(grokDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "[juggernaut]\n  [juggernaut.auth]\n    mode = \"" + authmode.BedrockAPIKey + "\"\n  [juggernaut.meta]\n    managedBy = \"juggernaut\"\n"
+	if err := os.WriteFile(filepath.Join(grokDir, "config.toml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	err := launchNamedCLI("grok", nil)
 	if err == nil {
 		t.Fatal("expected keychain read error from launch")

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -125,6 +125,26 @@ func resolvedScopes(filter string) []string {
 	return []string{"user", "project"}
 }
 
+// resolveLaunchConfigPaths returns this provider's config files in launch
+// precedence order: project scope first, then user. Duplicate paths (Grok maps
+// both scopes to the same file) are omitted so launch reads each file once.
+func resolveLaunchConfigPaths(prov provider.Provider, home string) []string {
+	var paths []string
+	seen := make(map[string]struct{}, 2)
+	for _, scope := range []string{"project", "user"} {
+		p, err := prov.ConfigPath(home, scope)
+		if err != nil || p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		paths = append(paths, p)
+	}
+	return paths
+}
+
 // ---- Apply phase helpers (extracted from apply.go for size reduction) ----
 
 // toProviderOptions maps the cmd-built schema.Options onto the CLI-neutral

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -79,11 +79,15 @@ func launchNamedCLI(cli string, args []string) error {
 
 	selfPaths := resolveSelfPaths()
 
-	// Resolve the provider's user-scoped config path for auth mode lookup at
-	// launch time. Fall back to user scope — if the user applied project scope,
-	// the launch wrapper still needs to find the auth mode, and user scope is
-	// the default. If user scope doesn't have the block, check project scope too.
-	cfgPath, _ := prov.ConfigPath(home, "user")
+	// Probe project then user so launch sees the same juggernaut.auth.mode apply
+	// wrote (project-only API-key apply used to be invisible to the wrapper).
+	cfgPaths := resolveLaunchConfigPaths(prov, home)
+	cfgPath := ""
+	if len(cfgPaths) > 0 {
+		cfgPath = cfgPaths[0]
+	}
+	target := launchTargetFor(prov, cfgPath)
+	target.ConfigPaths = cfgPaths
 
 	return activation.LaunchWithOptions(activation.LaunchOptions{
 		Home:        home,
@@ -91,7 +95,7 @@ func launchNamedCLI(cli string, args []string) error {
 		Path:        os.Getenv("PATH"),
 		TokenGetter: func() (string, error) { return keychain.Default().GetWithFallback(home) },
 		Runner:      activation.RunBinary,
-		Target:      launchTargetFor(prov, cfgPath),
+		Target:      target,
 		SelfPaths:   selfPaths,
 	})
 }

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -49,6 +49,60 @@ func TestApply_NativeCLIs_AcceptIAM(t *testing.T) {
 	}
 }
 
+func TestApply_OpenCode_IAM_WritesJuggernautAuth(t *testing.T) {
+	home := setupApplyTest(t)
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=opencode", "--auth=iam",
+		"--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	data := readFileForTest(t, filepath.Join(home, ".config", "opencode", "opencode.json"))
+	if !containsStr(data, `"mode": "iam"`) && !containsStr(data, `"mode":"iam"`) {
+		t.Errorf("expected juggernaut.auth.mode=iam, got:\n%s", data)
+	}
+}
+
+func TestApply_Grok_IAM_OmitsAuthProviderCommand(t *testing.T) {
+	home := setupApplyTest(t)
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=grok", "--auth=iam",
+		"--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	data := readFileForTest(t, filepath.Join(home, ".grok", "config.toml"))
+	if containsStr(data, "auth_provider_command") {
+		t.Errorf("IAM apply must not write auth_provider_command, got:\n%s", data)
+	}
+	if !containsStr(data, "mode") || !containsStr(data, "iam") {
+		t.Errorf("expected juggernaut.auth.mode=iam, got:\n%s", data)
+	}
+}
+
+func TestApply_OpenCode_ProjectScope_WritesAuthMode(t *testing.T) {
+	_ = setupApplyTest(t)
+	configBytes, err := os.ReadFile(findBedrockConfigFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := embeddedConfigBytes
+	SetEmbeddedConfig(configBytes)
+	t.Cleanup(func() { SetEmbeddedConfig(orig) })
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := ExecuteArgs([]string{
+		"apply", "--cli=opencode", "--auth=iam",
+		"--scope=project", "--region=us-east-1", "--skip-preflight",
+	}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	data := readFileForTest(t, filepath.Join(dir, "opencode.json"))
+	if !containsStr(data, `"mode": "iam"`) && !containsStr(data, `"mode":"iam"`) {
+		t.Errorf("project apply must write juggernaut.auth.mode, got:\n%s", data)
+	}
+}
+
 // TestApply_Codex_WritesTOMLConfig drives a full codex apply and structurally
 // verifies the TOML config lands at ~/.codex/config.toml with the correct
 // amazon-bedrock provider shape.
@@ -503,6 +557,52 @@ func TestLaunchTargetFor_Codex(t *testing.T) {
 	// block to decide at runtime.
 	if tgt.NeedsToken {
 		t.Error("codex NeedsToken must be false — auth mode is resolved from config at launch time")
+	}
+}
+
+// TestLaunchTargetFor_OpenCodeAndGrok_NeedsNoStaticToken: IAM/SSO apply must
+// launch without a Bedrock API key. Token need is read from juggernaut.auth.
+func TestLaunchTargetFor_OpenCodeAndGrok_NeedsNoStaticToken(t *testing.T) {
+	for _, name := range []string{"opencode", "grok"} {
+		p, _ := provider.Get(name)
+		tgt := launchTargetFor(p, "")
+		if tgt.NeedsToken {
+			t.Errorf("%s LaunchTarget.NeedsToken must be false — auth mode is resolved from config at launch", name)
+		}
+	}
+}
+
+func TestResolveLaunchConfigPaths_ProjectThenUser(t *testing.T) {
+	home := setupApplyTest(t)
+
+	codex, _ := provider.Get("codex")
+	paths := resolveLaunchConfigPaths(codex, home)
+	if len(paths) != 2 {
+		t.Fatalf("codex paths = %v, want project then user", paths)
+	}
+	if filepath.ToSlash(paths[0]) != ".codex/config.toml" && filepath.ToSlash(paths[0]) != "./.codex/config.toml" {
+		t.Errorf("codex project path = %q, want ./.codex/config.toml", paths[0])
+	}
+	if !strings.Contains(filepath.ToSlash(paths[1]), ".codex/config.toml") {
+		t.Errorf("codex user path = %q, want ~/.codex/config.toml", paths[1])
+	}
+
+	opencode, _ := provider.Get("opencode")
+	oPaths := resolveLaunchConfigPaths(opencode, home)
+	if len(oPaths) != 2 {
+		t.Fatalf("opencode paths = %v, want project then user", oPaths)
+	}
+	if filepath.Base(oPaths[0]) != "opencode.json" {
+		t.Errorf("opencode project path = %q, want ./opencode.json", oPaths[0])
+	}
+
+	grok, _ := provider.Get("grok")
+	gPaths := resolveLaunchConfigPaths(grok, home)
+	if len(gPaths) != 1 {
+		t.Fatalf("grok is user-only, got %v", gPaths)
+	}
+	if !strings.Contains(filepath.ToSlash(gPaths[0]), ".grok/config.toml") {
+		t.Errorf("grok path = %q, want ~/.grok/config.toml", gPaths[0])
 	}
 }
 

--- a/internal/activation/activation.go
+++ b/internal/activation/activation.go
@@ -88,6 +88,7 @@ type LaunchTarget struct {
 	StaticEnv        map[string]string
 	NeedsToken       bool
 	ConfigPath       string
+	ConfigPaths      []string // project then user; ConfigPath is used if this is empty
 	RuntimeStateName string
 }
 

--- a/internal/activation/launch.go
+++ b/internal/activation/launch.go
@@ -69,20 +69,20 @@ func LaunchWithOptions(opts LaunchOptions) error {
 
 	// Determine whether this launch is Juggernaut-managed and whether it needs a
 	// bearer token. Claude declares its auth mode in ~/.claude/settings.json
-	// (scanned by authModes). Non-Claude CLIs (Codex) store the auth mode in their
-	// own config file's juggernaut block — read it from ConfigPath if set.
-	// The bearer token is SHARED, so injecting it for a token-needing target
-	// is correct regardless of authModes.
+	// (scanned by authModes). Non-Claude CLIs store the auth mode in their own
+	// config file's juggernaut block — project scope first, then user, matching
+	// the file apply wrote. The bearer token is SHARED, so injecting it for a
+	// token-needing target is correct regardless of authModes.
 	managed := len(modes) > 0 || target.NeedsToken
 	wantToken := needsBearerToken(modes) || target.NeedsToken
 	var fallbackEnv map[string]string
 
-	// If the target has a config path (non-Claude provider), read the auth mode
-	// from its juggernaut block to decide token injection.
-	if target.ConfigPath != "" {
-		if mode := readAuthModeFromConfig(target.ConfigPath); mode != "" {
+	// First non-empty juggernaut.auth.mode wins (project then user).
+	for _, path := range targetConfigPaths(target) {
+		if mode := readAuthModeFromConfig(path); mode != "" {
 			managed = true
 			wantToken = authmode.IsBedrockAPIKey(mode)
+			break
 		}
 	}
 
@@ -229,6 +229,28 @@ func isExecutable(path string) bool {
 }
 
 // --- Auth mode detection ---
+
+// targetConfigPaths returns config files to probe for juggernaut.auth.mode:
+// ConfigPaths in order (project then user), then ConfigPath if not already listed.
+func targetConfigPaths(target LaunchTarget) []string {
+	seen := make(map[string]struct{}, len(target.ConfigPaths)+1)
+	out := make([]string, 0, len(target.ConfigPaths)+1)
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	for _, p := range target.ConfigPaths {
+		add(p)
+	}
+	add(target.ConfigPath)
+	return out
+}
 
 func needsBearerToken(modes []string) bool {
 	for _, mode := range modes {

--- a/internal/activation/launch_cli_test.go
+++ b/internal/activation/launch_cli_test.go
@@ -364,6 +364,187 @@ func TestLaunchWithOptions_Codex_BadConfigFile(t *testing.T) {
 	}
 }
 
+func TestTargetConfigPaths_DedupAndFallback(t *testing.T) {
+	if got := targetConfigPaths(LaunchTarget{}); len(got) != 0 {
+		t.Errorf("empty target: got %v", got)
+	}
+	if got := targetConfigPaths(LaunchTarget{ConfigPath: "user.toml"}); len(got) != 1 || got[0] != "user.toml" {
+		t.Errorf("ConfigPath fallback: got %v", got)
+	}
+	got := targetConfigPaths(LaunchTarget{
+		ConfigPaths: []string{"project.toml", "user.toml"},
+		ConfigPath:  "user.toml",
+	})
+	if len(got) != 2 || got[0] != "project.toml" || got[1] != "user.toml" {
+		t.Errorf("project then user with dedup: got %v", got)
+	}
+}
+
+func writeAuthConfig(t *testing.T, path, mode string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var content string
+	if strings.HasSuffix(path, ".json") {
+		content = `{"juggernaut":{"auth":{"mode":"` + mode + `"},"meta":{"managedBy":"juggernaut"}}}`
+	} else {
+		content = "[juggernaut]\n  [juggernaut.auth]\n    mode = \"" + mode + "\"\n  [juggernaut.meta]\n    managedBy = \"juggernaut\"\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fakeLaunchBinary(t *testing.T, name string) (binDir, binName string) {
+	t.Helper()
+	binDir = t.TempDir()
+	binName = name
+	if runtime.GOOS == "windows" {
+		binName = name + ".exe"
+	}
+	writeExecutableFile(t, binDir, filepath.Join(binDir, binName), "real "+name)
+	return binDir, binName
+}
+
+// TestLaunchWithOptions_OpenCode_IAM_NoToken: OpenCode IAM apply writes a
+// juggernaut.auth.mode=iam block; launch must not demand a keychain token.
+func TestLaunchWithOptions_OpenCode_IAM_NoToken(t *testing.T) {
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+	home := testutil.NewTestHome(t)
+	realDir, binName := fakeLaunchBinary(t, "opencode")
+	cfgPath := filepath.Join(t.TempDir(), "opencode.json")
+	writeAuthConfig(t, cfgPath, "iam")
+
+	tokenCalled := false
+	var gotEnv []string
+	err := LaunchWithOptions(LaunchOptions{
+		Home:        home,
+		Args:        []string{"--version"},
+		Path:        realDir,
+		TokenGetter: func() (string, error) { tokenCalled = true; return "", nil },
+		Runner: func(_ string, _ []string, env []string) error {
+			gotEnv = env
+			return nil
+		},
+		Target: LaunchTarget{
+			BinaryNames: []string{binName},
+			TokenEnvVar: "AWS_BEARER_TOKEN_BEDROCK", // #nosec G101 -- env var name, not a credential
+			NeedsToken:  false,
+			ConfigPath:  cfgPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	if tokenCalled {
+		t.Error("OpenCode IAM must NOT call TokenGetter")
+	}
+	if envValue(gotEnv, "AWS_BEARER_TOKEN_BEDROCK") != "" {
+		t.Errorf("OpenCode IAM must NOT inject bearer token, env=%v", gotEnv)
+	}
+}
+
+// TestLaunchWithOptions_Grok_IAM_NoToken: Grok IAM must launch without a
+// keychain bearer token (NeedsToken is no longer statically true).
+func TestLaunchWithOptions_Grok_IAM_NoToken(t *testing.T) {
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+	home := testutil.NewTestHome(t)
+	realDir, binName := fakeLaunchBinary(t, "grok")
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	writeAuthConfig(t, cfgPath, "iam")
+
+	tokenCalled := false
+	err := LaunchWithOptions(LaunchOptions{
+		Home:        home,
+		Args:        []string{"--version"},
+		Path:        realDir,
+		TokenGetter: func() (string, error) { tokenCalled = true; return "", nil },
+		Runner:      func(string, []string, []string) error { return nil },
+		Target: LaunchTarget{
+			BinaryNames: []string{binName},
+			TokenEnvVar: "AWS_BEARER_TOKEN_BEDROCK", // #nosec G101 -- env var name, not a credential
+			NeedsToken:  false,
+			ConfigPath:  cfgPath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	if tokenCalled {
+		t.Error("Grok IAM must NOT call TokenGetter")
+	}
+}
+
+// TestLaunchWithOptions_ProjectScopeAuthMode_APIKey: project-only API-key apply
+// must be visible to launch (wrapper used to read user-scope config only).
+func TestLaunchWithOptions_ProjectScopeAuthMode_APIKey(t *testing.T) {
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+	home := testutil.NewTestHome(t)
+	realDir, binName := fakeLaunchBinary(t, "codex")
+	projectPath := filepath.Join(t.TempDir(), "project", "config.toml")
+	writeAuthConfig(t, projectPath, "bedrock-api-key")
+	userPath := filepath.Join(t.TempDir(), "user", "config.toml")
+	writeAuthConfig(t, userPath, "iam")
+
+	var gotEnv []string
+	err := LaunchWithOptions(LaunchOptions{
+		Home:        home,
+		Args:        []string{"--version"},
+		Path:        realDir,
+		TokenGetter: func() (string, error) { return "proj-tok", nil },
+		Runner: func(_ string, _ []string, env []string) error {
+			gotEnv = env
+			return nil
+		},
+		Target: LaunchTarget{
+			BinaryNames: []string{binName},
+			TokenEnvVar: "AWS_BEARER_TOKEN_BEDROCK", // #nosec G101 -- env var name, not a credential
+			NeedsToken:  false,
+			ConfigPaths: []string{projectPath, userPath},
+		},
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	if envValue(gotEnv, "AWS_BEARER_TOKEN_BEDROCK") != "proj-tok" {
+		t.Errorf("project API-key mode must inject token, env=%v", gotEnv)
+	}
+}
+
+// TestLaunchWithOptions_ProjectScopeAuthMode_IAMWins: project IAM must win over
+// user-scope API key (same precedence as Claude: project then user).
+func TestLaunchWithOptions_ProjectScopeAuthMode_IAMWins(t *testing.T) {
+	t.Setenv("AWS_BEARER_TOKEN_BEDROCK", "")
+	home := testutil.NewTestHome(t)
+	realDir, binName := fakeLaunchBinary(t, "codex")
+	projectPath := filepath.Join(t.TempDir(), "project", "config.toml")
+	writeAuthConfig(t, projectPath, "iam")
+	userPath := filepath.Join(t.TempDir(), "user", "config.toml")
+	writeAuthConfig(t, userPath, "bedrock-api-key")
+
+	tokenCalled := false
+	err := LaunchWithOptions(LaunchOptions{
+		Home:        home,
+		Args:        []string{"--version"},
+		Path:        realDir,
+		TokenGetter: func() (string, error) { tokenCalled = true; return "should-not", nil },
+		Runner:      func(string, []string, []string) error { return nil },
+		Target: LaunchTarget{
+			BinaryNames: []string{binName},
+			TokenEnvVar: "AWS_BEARER_TOKEN_BEDROCK", // #nosec G101 -- env var name, not a credential
+			NeedsToken:  false,
+			ConfigPaths: []string{projectPath, userPath},
+		},
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	if tokenCalled {
+		t.Error("project IAM must win over user API key — TokenGetter must not run")
+	}
+}
+
 // TestLaunchWithOptions_ClaudeDefault: an empty Target defaults to Claude
 // behavior (claude binary + CLAUDE_CODE_USE_BEDROCK=1) — back-compat.
 func TestLaunchWithOptions_ClaudeDefault(t *testing.T) {

--- a/internal/config/backup_rotation_test.go
+++ b/internal/config/backup_rotation_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
@@ -91,19 +92,38 @@ func TestUniqueBackupPath_SuffixZeroPadded(t *testing.T) {
 	m := NewManager(path)
 
 	// Occupy 10 same-second backup names, forcing the 11th candidate onto
-	// the zero-padded "-010" form.
-	for i := 0; i < 10; i++ {
+	// the zero-padded "-010" form. Retry if the UTC second rolls mid-burst
+	// (slow Windows CI has been seen to span 172237 vs the previous second).
+	var p11 string
+	for attempt := 0; attempt < 5 && p11 == ""; attempt++ {
+		stamp := time.Now().UTC().Format("20060102_150405")
+		rolled := false
+		for i := 0; i < 10; i++ {
+			p, err := m.uniqueBackupPath()
+			if err != nil {
+				t.Fatalf("uniqueBackupPath %d: %v", i, err)
+			}
+			if !strings.Contains(filepath.Base(p), stamp) {
+				rolled = true
+				break
+			}
+			if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
+				t.Fatalf("seed %s: %v", p, err)
+			}
+		}
+		if rolled {
+			continue
+		}
 		p, err := m.uniqueBackupPath()
 		if err != nil {
-			t.Fatalf("uniqueBackupPath %d: %v", i, err)
+			t.Fatalf("uniqueBackupPath 11: %v", err)
 		}
-		if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
-			t.Fatalf("seed %s: %v", p, err)
+		if strings.Contains(filepath.Base(p), stamp) {
+			p11 = p
 		}
 	}
-	p11, err := m.uniqueBackupPath()
-	if err != nil {
-		t.Fatalf("uniqueBackupPath 11: %v", err)
+	if p11 == "" {
+		t.Fatal("could not occupy 11 backup names in the same UTC second")
 	}
 	if !strings.HasSuffix(filepath.Base(p11), "-010") {
 		t.Errorf("expected zero-padded -010 suffix on the 11th candidate, got %q", filepath.Base(p11))

--- a/internal/config/deep_merge_test.go
+++ b/internal/config/deep_merge_test.go
@@ -57,6 +57,45 @@ func TestMergeConfigPlan_DeepMergeKeys_PreservesSiblings(t *testing.T) {
 	}
 }
 
+// TestMergeConfigPlanDeep_EmptyStringDeletesOwnedLeaf: IAM re-apply writes
+// empty strings for Grok's auth_provider_command so the previous API-key
+// command is stripped without wiping sibling user auth keys.
+func TestMergeConfigPlanDeep_EmptyStringDeletesOwnedLeaf(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	m := NewManagerWithFormat(path, tomlFormat{})
+	if err := m.Write(map[string]any{
+		"auth": map[string]any{
+			"auth_provider_command": "juggernaut auth-token",
+			"auth_provider_label":   "Bedrock",
+			"extra_user_setting":    "keep-me",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.MergeConfigPlanDeep(map[string]any{
+		"auth": map[string]any{
+			"auth_provider_command": "",
+			"auth_provider_label":   "",
+		},
+	}, []string{"auth"}); err != nil {
+		t.Fatalf("MergeConfigPlanDeep: %v", err)
+	}
+	got, _ := m.Read()
+	authTbl, _ := got["auth"].(map[string]any)
+	if authTbl == nil {
+		t.Fatal("auth table lost — user siblings must survive")
+	}
+	if _, ok := authTbl["auth_provider_command"]; ok {
+		t.Error("empty-string merge must delete auth_provider_command")
+	}
+	if _, ok := authTbl["auth_provider_label"]; ok {
+		t.Error("empty-string merge must delete auth_provider_label")
+	}
+	if authTbl["extra_user_setting"] != "keep-me" {
+		t.Errorf("user sibling lost: %v", authTbl["extra_user_setting"])
+	}
+}
+
 // TestMergeConfigPlanDeepThen_RunsAfterMergeUnderOneWrite: the then callback
 // mutates the in-memory map after the merge and is committed in the same lock.
 func TestMergeConfigPlanDeepThen_RunsAfterMergeUnderOneWrite(t *testing.T) {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -300,6 +300,10 @@ func mergeNestedPrefix(existing map[string]any, k string, v any, path string, pr
 		}
 	}
 	for sk, sv := range incoming {
+		if s, ok := sv.(string); ok && s == "" {
+			delete(dst, sk)
+			continue
+		}
 		// If both existing and incoming have a map at this sub-key, recurse.
 		if dstRaw, hasDst := dst[sk]; hasDst {
 			if _, isDstMap := dstRaw.(map[string]any); isDstMap {

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -163,6 +163,28 @@ func TestAllCLIs_SupportNativeAuth(t *testing.T) {
 	}
 }
 
+func TestJuggernautAuthBlock_PersistsModeAndRegion(t *testing.T) {
+	opts := baseOpts()
+	opts.AuthMode = "iam"
+	opts.Scope = "project"
+	got, err := juggernautAuthBlock(opts, "us-east-1")
+	if err != nil {
+		t.Fatalf("juggernautAuthBlock: %v", err)
+	}
+	mode, ok := testutil.NestedMapChain(got, "auth", "mode")
+	if !ok || mode != "iam" {
+		t.Errorf("auth.mode = %v, want iam", mode)
+	}
+	region, ok := testutil.NestedMapChain(got, "auth", "region")
+	if !ok || region != "us-east-1" {
+		t.Errorf("auth.region = %v, want us-east-1", region)
+	}
+	scope, ok := testutil.NestedMapChain(got, "meta", "scope")
+	if !ok || scope != "project" {
+		t.Errorf("meta.scope = %v, want project", scope)
+	}
+}
+
 // TestCodex_LaunchSpec: no static enable flag (routes via config), NeedsToken is
 // false — auth mode (IAM or API key) is stored in the config.toml juggernaut block
 // and resolved at launch time.

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/bedrock"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
-	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 )
 
 // codex is the OpenAI Codex CLI provider (config at ~/.codex/config.toml, TOML).
@@ -170,22 +168,9 @@ func (c codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error
 
 		// Persist the juggernaut block so the launch wrapper can read the auth mode
 		// at runtime (IAM → no token needed; API key → inject bearer token).
-		juggernautBlock := &schema.Block{
-			Auth: schema.Auth{
-				Mode:   opts.AuthMode,
-				Region: region,
-			},
-			Meta: schema.Meta{
-				SchemaVersion: 2,
-				Version:       opts.Version,
-				ManagedBy:     "juggernaut",
-				Scope:         opts.Scope,
-				AppliedAt:     fmt.Sprintf("%d", time.Now().Unix()),
-			},
-		}
-		blockMap, err := ToMap(juggernautBlock)
+		blockMap, err := juggernautAuthBlock(opts, region)
 		if err != nil {
-			return ConfigPlan{}, fmt.Errorf("serialize juggernaut block: %w", err)
+			return ConfigPlan{}, err
 		}
 		keys["juggernaut"] = blockMap
 

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -12,9 +12,10 @@ import (
 // grok is the OFFICIAL xAI Grok CLI provider (grok / grok.exe, config TOML at
 // ~/.grok/config.toml). Juggernaut routes to Grok 4.6 on native Bedrock
 // (bedrock-runtime /openai/v1) by writing a [model.bedrock-grok] block
-// (base_url → bedrock-runtime) selected via [models].default, PLUS an [auth]
-// block whose auth_provider_command runs `juggernaut auth-token` to supply the
-// keychain bearer token.
+// (base_url → bedrock-runtime) selected via [models].default. API-key apply
+// also writes an [auth] block whose auth_provider_command runs
+// `juggernaut auth-token`; IAM apply omits that command so Grok does not
+// demand a keychain bearer token.
 //
 // Why the [auth] block (not env_key): Grok's per-model credential order is
 // api_key → env_key → XAI_API_KEY, but a custom [model.*] block does NOT satisfy
@@ -50,7 +51,7 @@ func (g grok) ConfigPath(home, _ string) (string, error) {
 // NativeManagedKeys are the top-level config.toml keys Juggernaut owns: the
 // [model] and [models] tables (nested), plus the [auth] table.
 func (g grok) NativeManagedKeys() []string {
-	return []string{"model", "models", "auth"}
+	return []string{"model", "models", "auth", "juggernaut"}
 }
 
 // DeepMergeKeys: [model.<name>], [models], and [auth] are nested tables that may
@@ -84,18 +85,18 @@ func (g grok) OwnsConfig(data map[string]any) bool {
 }
 
 func (g grok) LaunchSpec() LaunchSpec {
-	// Grok gets its token from the [auth] auth_provider_command (which reads the
-	// keychain directly), so the launch wrapper does not strictly need to inject
-	// the token. NeedsToken stays true: the shared token is still injected as an
-	// env var (harmless) and the launch wrapper can use it for bearer mode.
+	// Token injection is decided at launch from the stored auth mode:
+	// API key → inject AWS_BEARER_TOKEN_BEDROCK (and write auth_provider_command);
+	// IAM → AWS credential chain, no keychain token.
 	return LaunchSpec{
 		TokenEnvVar: authmode.BedrockAuthEnvName,
-		NeedsToken:  true,
+		NeedsToken:  false, // auth mode in juggernaut block decides at launch
 	}
 }
 
 // BuildConfig writes a [model.bedrock-grok] block routing to Grok 4.6 on native
-// Bedrock (bedrock-runtime /openai/v1), [models].default, and an [auth] block
+// Bedrock (bedrock-runtime /openai/v1), [models].default, a juggernaut.auth
+// block for launch, and — only for Bedrock API key auth — an [auth] block
 // whose auth_provider_command supplies the keychain bearer token so Grok skips
 // its interactive sign-in.
 //
@@ -137,10 +138,24 @@ func (g grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error)
 			"models": map[string]any{
 				"default": grokModelName,
 			},
-			"auth": map[string]any{
+		}
+		blockMap, err := juggernautAuthBlock(opts, region)
+		if err != nil {
+			return ConfigPlan{}, err
+		}
+		keys["juggernaut"] = blockMap
+		if authmode.IsBedrockAPIKey(opts.AuthMode) {
+			keys["auth"] = map[string]any{
 				"auth_provider_command": grokAuthCommand,
 				"auth_provider_label":   "Bedrock",
-			},
+			}
+		} else {
+			// Empty strings delete owned [auth] leaves on re-apply so IAM
+			// does not leave auth_provider_command pointing at auth-token.
+			keys["auth"] = map[string]any{
+				"auth_provider_command": "",
+				"auth_provider_label":   "",
+			}
 		}
 
 		return ConfigPlan{

--- a/internal/provider/grok_test.go
+++ b/internal/provider/grok_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
@@ -76,8 +77,8 @@ func TestGrok_LaunchSpec(t *testing.T) {
 	if ls.TokenEnvVar != "AWS_BEARER_TOKEN_BEDROCK" {
 		t.Errorf("TokenEnvVar = %q", ls.TokenEnvVar)
 	}
-	if !ls.NeedsToken {
-		t.Error("Grok via Mantle needs a token")
+	if ls.NeedsToken {
+		t.Error("Grok NeedsToken must be false — auth mode resolved from config at launch")
 	}
 }
 
@@ -184,7 +185,9 @@ func TestGrok_BuildConfig(t *testing.T) {
 // its sign-in and use our keychain bearer token.
 func TestGrok_BuildConfig_AuthBlock(t *testing.T) {
 	p, _ := Get("grok")
-	plan, err := p.BuildConfig(testConfig(), baseOpts())
+	opts := baseOpts()
+	opts.AuthMode = authmode.BedrockAPIKey
+	plan, err := p.BuildConfig(testConfig(), opts)
 	if err != nil {
 		t.Fatalf("BuildConfig: %v", err)
 	}
@@ -211,6 +214,32 @@ func TestGrok_BuildConfig_AuthBlock(t *testing.T) {
 	}
 	if !found {
 		t.Error("auth must be in ManagedKeys")
+	}
+}
+
+// TestGrok_BuildConfig_IAM_OmitsAuthProviderCommand: IAM apply must not write
+// auth_provider_command (that command demands a keychain token) and must persist
+// juggernaut.auth.mode so launch can skip token injection.
+func TestGrok_BuildConfig_IAM_OmitsAuthProviderCommand(t *testing.T) {
+	p, _ := Get("grok")
+	plan, err := p.BuildConfig(testConfig(), baseOpts())
+	if err != nil {
+		t.Fatalf("BuildConfig: %v", err)
+	}
+	auth, ok := testutil.NestedMapChain(plan.Keys, "auth")
+	if !ok {
+		t.Fatal("[auth] block missing (needed so re-apply can strip API-key leaves)")
+	}
+	authMap, ok := auth.(map[string]any)
+	if !ok {
+		t.Fatalf("[auth] not a map: %T", auth)
+	}
+	if cmd, _ := authMap["auth_provider_command"].(string); cmd != "" {
+		t.Errorf("IAM must not set auth_provider_command, got %q", cmd)
+	}
+	jb, ok := testutil.NestedMapChain(plan.Keys, "juggernaut", "auth", "mode")
+	if !ok || jb != authmode.IAM {
+		t.Errorf("juggernaut.auth.mode = %v, want iam", jb)
 	}
 }
 

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -36,7 +36,7 @@ func (o opencode) ConfigPath(home, scope string) (string, error) {
 
 // NativeManagedKeys are the top-level opencode.json keys Juggernaut owns.
 func (o opencode) NativeManagedKeys() []string {
-	return []string{"model", "provider"}
+	return []string{"model", "provider", "juggernaut"}
 }
 
 // DeepMergeKeys: "provider" is a nested map where a user may have their own
@@ -64,10 +64,10 @@ func (o opencode) OwnsConfig(data map[string]any) bool {
 func (o opencode) LaunchSpec() LaunchSpec {
 	// OpenCode routes via config; the built-in amazon-bedrock provider uses
 	// the AWS credential chain (SigV4 or AWS_BEARER_TOKEN_BEDROCK), so no static
-	// enable flag. Token is still injected for bearer mode, but IAM also works.
+	// enable flag. Token injection is decided at launch from juggernaut.auth.
 	return LaunchSpec{
 		TokenEnvVar: authmode.BedrockAuthEnvName,
-		NeedsToken:  true,
+		NeedsToken:  false, // auth mode in juggernaut block decides at launch
 	}
 }
 
@@ -135,6 +135,12 @@ func (o opencode) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, er
 			},
 		},
 	}
+
+	blockMap, err := juggernautAuthBlock(opts, opts.Region)
+	if err != nil {
+		return ConfigPlan{}, err
+	}
+	keys["juggernaut"] = blockMap
 
 	return ConfigPlan{
 		Keys:        keys,

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
 	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
@@ -79,8 +80,8 @@ func TestOpenCode_LaunchSpec(t *testing.T) {
 	if ls.TokenEnvVar != "AWS_BEARER_TOKEN_BEDROCK" {
 		t.Errorf("TokenEnvVar = %q", ls.TokenEnvVar)
 	}
-	if !ls.NeedsToken {
-		t.Error("OpenCode via native still needs token env for bearer mode")
+	if ls.NeedsToken {
+		t.Error("OpenCode NeedsToken must be false — auth mode resolved from config at launch")
 	}
 }
 
@@ -159,6 +160,10 @@ func TestOpenCode_BuildConfig_DefaultAlias(t *testing.T) {
 	}
 	if err := plan.Validate(); err != nil {
 		t.Errorf("plan should validate: %v", err)
+	}
+	mode, ok := testutil.NestedMapChain(plan.Keys, "juggernaut", "auth", "mode")
+	if !ok || mode != authmode.IAM {
+		t.Errorf("juggernaut.auth.mode = %v, want iam", mode)
 	}
 }
 

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/schema"
 )
@@ -19,6 +20,30 @@ func ToMap(v any) (map[string]any, error) {
 	var m map[string]any
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
+	}
+	return m, nil
+}
+
+// juggernautAuthBlock is the shared [juggernaut] table non-Claude providers
+// persist so launch can read auth mode (IAM vs API key) from the same file
+// apply wrote.
+func juggernautAuthBlock(opts Options, region string) (map[string]any, error) {
+	block := &schema.Block{
+		Auth: schema.Auth{
+			Mode:   opts.AuthMode,
+			Region: region,
+		},
+		Meta: schema.Meta{
+			SchemaVersion: schema.SchemaVersion,
+			Version:       opts.Version,
+			ManagedBy:     "juggernaut",
+			Scope:         opts.Scope,
+			AppliedAt:     fmt.Sprintf("%d", time.Now().Unix()),
+		},
+	}
+	m, err := ToMap(block)
+	if err != nil {
+		return nil, fmt.Errorf("serialize juggernaut block: %w", err)
 	}
 	return m, nil
 }


### PR DESCRIPTION
Closes #436.
Closes #439.

## Problem
- OpenCode and Grok `apply --auth=iam` succeeded (`CapNativeAuth`), but launch still demanded a keychain bearer token (`NeedsToken=true`). Grok always wrote `auth_provider_command = "juggernaut auth-token"` even for IAM.
- Non-Claude launch only read user-scope config, so a Codex/OpenCode `--scope=project` API-key apply was invisible at wrap time (`juggernaut.auth.mode` never seen).

## Fix
- OpenCode and Grok persist `juggernaut.auth.mode` like Codex and set `NeedsToken=false`. Token injection is decided at launch from that mode.
- Grok writes `auth_provider_command` only for `--auth=bedrock-api-key`. IAM re-apply strips the owned `[auth]` leaves via empty-string deep-merge delete.
- Launch probes project then user config paths (duplicates dropped; Grok stays user-only).

## Tests
- IAM launch without TokenGetter for OpenCode/Grok.
- Project-scope API-key wins; project IAM wins over user API-key.
- Apply writes `juggernaut.auth.mode` for OpenCode IAM and omits Grok `auth_provider_command` on IAM.
- `gofmt`, `go vet`, `go test ./cmd/ ./internal/activation/ ./internal/provider/ -count=1`