### PR TITLE
feat(codex): route Codex via built-in amazon-bedrock-runtime provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Hooks: `scripts/setup-hooks.ps1` (Windows) or `bash scripts/setup-hooks.sh` (Lin
 - `internal/redact/` — diagnostic-bundle privacy: tokens, account IDs, home paths, emails, hostnames, LAN IPs → stable placeholders.
 - `npm/` — launcher + platform packages.
 
-Config paths: Claude `~/.claude/settings.json` (user) / `./.claude/settings.json` (project) — the only CLI with both scopes; Codex `~/.codex/config.toml` / `./.codex/config.toml` via `amazon-bedrock` provider; OpenCode `~/.config/opencode/opencode.json` / `./opencode.json` via `provider.amazon-bedrock` (region + discovered `models` + `whitelist`); Grok `~/.grok/config.toml` user-only (`base_url=https://bedrock-runtime.{region}.amazonaws.com/openai/v1`; `auth_provider_command="juggernaut auth-token"` only for `--auth=bedrock-api-key`). Launch reads `juggernaut.auth.mode` from project then user for non-Claude CLIs (token-gated only for API-key mode).
+Config paths: Claude `~/.claude/settings.json` (user) / `./.claude/settings.json` (project) — the only CLI with both scopes; Codex `~/.codex/config.toml` / `./.codex/config.toml` via the built-in `amazon-bedrock-runtime` provider (`[model_providers.amazon-bedrock-runtime.aws]` region table; requires Codex ≥ 0.153.4 — apply/doctor warn on older binaries); OpenCode `~/.config/opencode/opencode.json` / `./opencode.json` via `provider.amazon-bedrock` (region + discovered `models` + `whitelist`); Grok `~/.grok/config.toml` user-only (`base_url=https://bedrock-runtime.{region}.amazonaws.com/openai/v1`, model `global.xai.grok-4.6`; `auth_provider_command="juggernaut auth-token"` only for `--auth=bedrock-api-key`). Launch reads `juggernaut.auth.mode` from project then user for non-Claude CLIs (token-gated only for API-key mode).
 
 ## Constraints
 
@@ -61,6 +61,7 @@ Config paths: Claude `~/.claude/settings.json` (user) / `./.claude/settings.json
 - `--fallback-model`, `--service-tier`, `--always-thinking`, `--effort`, `skipWebFetchPreflight` are managed; `max`/`auto` effort are env-only, fixed levels also persist as native `effortLevel`.
 - Preserve compat for `launch`/`launch-cli`, hidden `auth-token`, deprecated flags, and exit-code passthrough (`Execute()` exits with wrapped CLI's status; launch commands silence cobra error/usage).
 - Mantle removed in v6 — all CLIs route via `bedrock-runtime`; after upgrade `juggernaut models refresh --source native --region <region>`.
+- v5 Codex configs still on the custom `amazon-bedrock` provider id are legacy for v6 (that table points at the dead Mantle host): a plain `apply` migrates them to the built-in `amazon-bedrock-runtime` and strips `model_providers.amazon-bedrock` (Codex-only — OpenCode's `provider.amazon-bedrock` is a different, current table and never gets touched). The version gate requires Codex ≥ 0.153.4 (warns on apply/doctor).
 - Suppressions (`//nolint`, `#nosec`, `// nosemgrep`) require rationale in `docs/ci-suppressions.md`; prefer code fix over suppression.
 
 ## Testing

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -17,7 +17,7 @@ curl -fsSL https://claude.ai/install.sh | bash
 
 Run `juggernaut apply` without flags for an interactive first-run prompt. Apply will not enable Bedrock routing unless a valid credential source is confirmed; if the target config already has foreign values on keys Juggernaut would write, apply refuses unless you pass `--force`.
 
-Upgrading from an older Juggernaut? Install v6 directly with npm (`npm install -g juggernaut-bedrock@latest`); there is no required v3 → v4 → v5 chain. **v6 is breaking:** Mantle is removed — every CLI now uses `bedrock-runtime`. After upgrading, re-run `juggernaut models refresh --source native --region <region>` and re-apply each CLI (`juggernaut apply --cli=<cli> --region <region>`). Windows v3 API-key users who need to keep an old DPAPI-stored key should still use the bridge script in [README.md](README.md#windows-v3-api-key-installs).
+Upgrading from an older Juggernaut? Install v6 directly with npm (`npm install -g juggernaut-bedrock@latest`); there is no required v3 → v4 → v5 chain. **v6 is breaking:** Mantle is removed — every CLI now uses `bedrock-runtime`. After upgrading, re-run `juggernaut models refresh --source native --region <region>` and re-apply each CLI (`juggernaut apply --cli=<cli> --region <region>`); a re-apply over a Mantle-era config migrates it in place (backup saved first). Codex now routes through its built-in `amazon-bedrock-runtime` provider and needs Codex CLI ≥ 0.153.4 (`npm i -g @openai/codex@latest` if `apply`/`doctor` warn). Windows v3 API-key users who need to keep an old DPAPI-stored key should still use the bridge script in [README.md](README.md#windows-v3-api-key-installs).
 
 ## Prerequisites (if using IAM/SSO)
 
@@ -69,7 +69,7 @@ juggernaut logs export                 # redacted zip for support
 - Claude Code 1M context accounting for Opus and Sonnet by default
 - All three model tiers visible in `/model` selector
 - Optimized token limits (32768 output, 65536 thinking)
-- Native `bedrock-runtime` routing for every CLI (no proxy/Mantle); Codex uses the built-in `amazon-bedrock` provider, OpenCode uses `provider.amazon-bedrock` (region + live models + whitelist), Grok uses `https://bedrock-runtime.{region}.amazonaws.com/openai/v1`
+- Native `bedrock-runtime` routing for every CLI (no proxy/Mantle); Codex uses the built-in `amazon-bedrock-runtime` provider (Codex CLI ≥ 0.153.4 — apply/doctor warn on older binaries), OpenCode uses `provider.amazon-bedrock` (region + live models + whitelist), Grok uses `https://bedrock-runtime.{region}.amazonaws.com/openai/v1`
 - Configuration in `~/.claude/settings.json` (Claude), `~/.codex/config.toml` (Codex), `~/.config/opencode/opencode.json` (OpenCode), `~/.grok/config.toml` (Grok)
 - A non-secret runtime fallback in `~/.juggernaut/runtime/claude.json` so Claude updates cannot silently disable Bedrock routing
 - A marked shell activation block that delegates `claude` to `juggernaut launch`

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ juggernaut apply --cli=grok --auth=iam
 juggernaut models refresh --source native --region us-west-2
 ```
 
+**Codex:** requires Codex CLI ≥ 0.153.4 (the first release with the built-in `amazon-bedrock-runtime` provider). Juggernaut pins `model_provider = "amazon-bedrock-runtime"` plus a region under `[model_providers.amazon-bedrock-runtime.aws]` — no custom `base_url`. If your `codex` binary is older, `apply` and `doctor` warn; update with `npm i -g @openai/codex@latest`.
+
 Activation blocks for different CLIs coexist in one shell profile. The Bedrock bearer token is **shared** across CLIs — uninstalling one non-Claude CLI does not remove it (only the last dependent CLI clears it).
 
 ### Safety model
@@ -311,7 +313,9 @@ juggernaut uninstall --full
 
 ## Migrating from v3/v4 and upgrading to v6
 
-Go straight to v5/v6 with npm. You do not need to install an intermediate v3 or v4 release first. **v6 is breaking:** Mantle routing is removed — every CLI now uses `bedrock-runtime`. After upgrading, re-run `juggernaut models refresh --source native --region <region>` and `juggernaut apply --cli=<cli> --region <region>` per CLI; `--mantle`/`--no-mantle`/`--mantle-url` and `mantle` catalog source are gone, Codex `gpt-5.5`/`5.4` → `gpt-5.6` `sol`/`terra`/`luna`, Grok `xai.grok-4.3` → `xai.grok-4.6`, OpenCode switches from `provider.bedrock-mantle` to the built-in `provider.amazon-bedrock` (verify `qwen3-coder`/`gpt-oss` IDs now end in `-1:0` / `-v1:0`).
+Go straight to v5/v6 with npm. You do not need to install an intermediate v3 or v4 release first. **v6 is breaking:** Mantle routing is removed — every CLI now uses `bedrock-runtime`. After upgrading, re-run `juggernaut models refresh --source native --region <region>` and `juggernaut apply --cli=<cli> --region <region>` per CLI; `--mantle`/`--no-mantle`/`--mantle-url` and `mantle` catalog source are gone, Codex `gpt-5.5`/`5.4` → `gpt-5.6` `sol`/`terra`/`luna`, Grok `xai.grok-4.3` → `xai.grok-4.6` (written as the `global.xai.grok-4.6` CRIS profile ID), OpenCode switches from `provider.bedrock-mantle` to the built-in `provider.amazon-bedrock` (verify `qwen3-coder`/`gpt-oss` IDs now end in `-1:0` / `-v1:0`).
+
+Re-applying over a Mantle-era config migrates it automatically (a backup is saved first): the old Codex `model_provider = "amazon-bedrock"` is rewritten to the built-in `amazon-bedrock-runtime` and the stale `model_providers.amazon-bedrock` table is removed. Requires Codex CLI ≥ 0.153.4 for Codex — `apply` and `doctor` warn on older binaries.
 
 ```bash
 npm install -g juggernaut-bedrock@latest

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -183,6 +183,9 @@ func buildApplyPlan(home, region string, bCfg *bedrock.Config, authMode string, 
 
 // executeApply performs the final step: dry-run display or commit.
 func executeApply(home string, prov provider.Provider, bCfg *bedrock.Config, authMode string, token string, plan *applyPlan) error {
+	if prov.Name() == "codex" {
+		warnCodexVersion()
+	}
 	if applyFlags.dryRun {
 		return printApplyDryRun(home, plan.block, prov, bCfg, plan.provOpts)
 	}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -183,9 +183,7 @@ func buildApplyPlan(home, region string, bCfg *bedrock.Config, authMode string, 
 
 // executeApply performs the final step: dry-run display or commit.
 func executeApply(home string, prov provider.Provider, bCfg *bedrock.Config, authMode string, token string, plan *applyPlan) error {
-	if prov.Name() == "codex" {
-		warnCodexVersion()
-	}
+	warnCodexVersion(prov)
 	if applyFlags.dryRun {
 		return printApplyDryRun(home, plan.block, prov, bCfg, plan.provOpts)
 	}

--- a/cmd/apply_collision_test.go
+++ b/cmd/apply_collision_test.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/authmode"
+	"github.com/jpvelasco/juggernaut/v5/internal/config"
 	"github.com/jpvelasco/juggernaut/v5/internal/keychain"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 	"github.com/jpvelasco/juggernaut/v5/internal/safepath"
 )
 
@@ -707,6 +710,7 @@ region = "us-east-1"
 	if strings.Contains(written, "openai.gpt-5.5") {
 		t.Errorf("migrated config must NOT contain old v5 model openai.gpt-5.5, got:\n%s", written)
 	}
+	assertCodexRuntimeMigration(t, configPath, "us-west-2")
 
 	matches, _ := filepath.Glob(configPath + ".backup.*")
 	if len(matches) == 0 {
@@ -876,10 +880,12 @@ func TestApply_Codex_LegacyJuggernautConfig_Force_MigratesToV6(t *testing.T) {
 	}
 	configPath := filepath.Join(codexDir, "config.toml")
 	legacy := `model = "openai.gpt-5.5"
-model_provider = "amazon-bedrock"
+model_provider = "bedrock-mantle"
 
-[model_providers.amazon-bedrock.aws]
-region = "us-east-1"
+[model_providers.bedrock-mantle]
+name = "Amazon Bedrock (Mantle)"
+base_url = "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+wire_api = "responses"
 `
 	if err := safepath.WriteFile(codexDir, configPath, []byte(legacy)); err != nil {
 		t.Fatalf("write legacy codex config: %v", err)
@@ -903,6 +909,7 @@ region = "us-east-1"
 	if strings.Contains(written, "openai.gpt-5.5") {
 		t.Errorf("migrated config must NOT contain old v5 model openai.gpt-5.5, got:\n%s", written)
 	}
+	assertCodexRuntimeMigration(t, configPath, "us-west-2")
 
 	matches, _ := filepath.Glob(configPath + ".backup.*")
 	if len(matches) == 0 {
@@ -938,6 +945,36 @@ const legacyOpenCodeMantle = `{
   }
 }
 `
+
+// assertCodexRuntimeMigration structurally verifies a migrated Codex config:
+// the top-level model_provider is the built-in runtime id, the legacy v5
+// [model_providers.amazon-bedrock] table is GONE, and the runtime table holds
+// the region. A plain substring check is a trap here — "amazon-bedrock" is a
+// prefix of "amazon-bedrock-runtime" and would pass either way.
+func assertCodexRuntimeMigration(t *testing.T, cfgPath, wantRegion string) {
+	t.Helper()
+	tomlFmt, _ := config.FormatByName("toml")
+	mgr := config.NewManagerWithFormat(cfgPath, tomlFmt)
+	got, err := mgr.Read()
+	if err != nil {
+		t.Fatalf("parse migrated config.toml: %v", err)
+	}
+	if mp := got["model_provider"]; mp != provider.CodexBedrockRuntimeProviderID {
+		t.Errorf("model_provider = %v, want %s", mp, provider.CodexBedrockRuntimeProviderID)
+	}
+	tbl, _ := got["model_providers"].(map[string]any)
+	if _, ok := tbl[provider.CodexLegacyProviderID]; ok {
+		t.Errorf("legacy [model_providers.%s] table must be stripped on migrate, got: %v", provider.CodexLegacyProviderID, tbl[provider.CodexLegacyProviderID])
+	}
+	rt, ok := tbl[provider.CodexBedrockRuntimeProviderID].(map[string]any)
+	if !ok {
+		t.Fatalf("[model_providers.%s] table missing after migrate: %v", provider.CodexBedrockRuntimeProviderID, got["model_providers"])
+	}
+	aws, ok := rt["aws"].(map[string]any)
+	if !ok || aws["region"] != wantRegion {
+		t.Errorf("migrated config must set model_providers.%s.aws.region = %q, got: %v", provider.CodexBedrockRuntimeProviderID, wantRegion, rt["aws"])
+	}
+}
 
 func writeHomeFile(t *testing.T, home, relDir, filename, contents string) string {
 	t.Helper()
@@ -1027,6 +1064,11 @@ func TestApply_Codex_HybridMantleLeftover_PlainApplyMigrates(t *testing.T) {
 		[]string{"global.openai.gpt-5.6-sol", "amazon-bedrock"},
 		[]string{"bedrock-mantle"},
 	)
+	// The hybrid fixture is the definitive legacy-table case: v6 model ID
+	// still paired with the v5 custom amazon-bedrock table. After the migrate
+	// the legacy table must be stripped (substring checks can't tell
+	// "amazon-bedrock" apart from "amazon-bedrock-runtime").
+	assertCodexRuntimeMigration(t, path, "us-west-2")
 }
 
 // TestApply_OpenCode_MantleProvider_PlainApplyMigrates: leftover
@@ -1063,5 +1105,66 @@ func TestApply_Codex_MantleProvider_DryRunPreviewsMigration(t *testing.T) {
 	}
 	if matches, _ := filepath.Glob(path + ".backup.*"); len(matches) != 0 {
 		t.Error("dry-run must not create a backup")
+	}
+}
+
+// TestApply_Codex_AlreadyMigrated_ReapplyDoesNotReannounce: a config that was
+// already migrated to the built-in amazon-bedrock-runtime provider is NOT
+// legacy — re-applying over it must be a plain re-apply, with no v5→v6
+// migration announcement.
+func TestApply_Codex_AlreadyMigrated_ReapplyDoesNotReannounce(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+	path := writeHomeFile(t, home, ".codex", "config.toml",
+		`model = "global.openai.gpt-5.6-sol"
+model_provider = "amazon-bedrock-runtime"
+
+[model_providers.amazon-bedrock-runtime.aws]
+region = "us-west-2"
+`)
+
+	out := applyCLI(t, "codex")
+	if strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("re-apply over an already-migrated config must NOT re-announce the v5→v6 migration, got:\n%s", out)
+	}
+	assertCodexRuntimeMigration(t, path, "us-west-2")
+	// The backup (taken before the write) captured the already-migrated
+	// runtime config — proof the re-apply saw a current config, not a legacy
+	// one.
+	matches, _ := filepath.Glob(path + ".backup.*")
+	if len(matches) == 0 {
+		t.Fatal("expected a pre-write backup of the config")
+	}
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if !strings.Contains(string(data), "model_provider = \"amazon-bedrock-runtime\"") {
+		t.Errorf("backup should preserve the already-migrated config, got:\n%s", data)
+	}
+}
+
+// TestApply_Grok_AlreadyMigrated_ReapplyDoesNotReannounce: same contract for
+// Grok — a config already on the v6 bedrock-runtime URL is not legacy.
+func TestApply_Grok_AlreadyMigrated_ReapplyDoesNotReannounce(t *testing.T) {
+	home := setupApplyTest(t)
+	setupIsolatedKeychain(t)
+	path := writeHomeFile(t, home, ".grok", "config.toml",
+		`[models]
+default = "bedrock-grok"
+
+[model.bedrock-grok]
+model = "global.xai.grok-4.6"
+base_url = "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
+name = "Amazon Bedrock (Runtime)"
+`)
+
+	out := applyCLI(t, "grok")
+	if strings.Contains(out, "written by Juggernaut v5") {
+		t.Errorf("re-apply over an already-migrated config must NOT re-announce the v5→v6 migration, got:\n%s", out)
+	}
+	got := readHomeFile(t, filepath.Dir(path), path)
+	if !strings.Contains(got, "bedrock-runtime") {
+		t.Errorf("re-applied grok config must still route via bedrock-runtime, got:\n%s", got)
 	}
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -954,7 +954,7 @@ func TestApply_CodexDryRun_ReapplySkipsPromptWhenCodexConfigExists(t *testing.T)
 		t.Fatalf("mkdir .codex: %v", err)
 	}
 	configPath := filepath.Join(codexDir, "config.toml")
-	content := []byte("model = \"openai.gpt-5.5\"\nmodel_provider = \"amazon-bedrock\"\n\n[model_providers.amazon-bedrock.aws]\nregion = \"us-west-2\"\n")
+	content := []byte("model = \"global.openai.gpt-5.6-sol\"\nmodel_provider = \"amazon-bedrock-runtime\"\n\n[model_providers.amazon-bedrock-runtime.aws]\nregion = \"us-west-2\"\n")
 	if err := safepath.WriteFile(codexDir, configPath, content); err != nil {
 		t.Fatalf("write codex config: %v", err)
 	}

--- a/cmd/codex_version.go
+++ b/cmd/codex_version.go
@@ -52,16 +52,21 @@ func parseCodexVersion(out string) (string, bool) {
 var codexVersionPath = os.Getenv("PATH")
 
 // codexBinaryVersion resolves the codex binary on PATH and returns its
-// version. Returns ok=false when the binary is absent or the probe fails —
-// callers treat that as "cannot determine" and do NOT warn (a missing binary
-// is reported separately by the binary-status checks).
+// version. Returns ok=false when the binary is absent, the probe fails, or the
+// version can't be parsed into a numeric triple — callers treat that as
+// "cannot determine" and do NOT warn (a missing binary is reported separately
+// by the binary-status checks).
 func codexBinaryVersion() (string, bool) {
 	names := provider.MustGet("codex").BinaryNames()
 	found, err := activation.ResolveBinary(codexVersionPath, names)
 	if err != nil {
 		return "", false
 	}
-	return codexVersionProbe(found)
+	v, ok := codexVersionProbe(found)
+	if !ok || len(versionTriple(v)) == 0 {
+		return "", false
+	}
+	return v, true
 }
 
 // codexVersionAtLeast reports whether v is >= min by numeric triple.

--- a/cmd/codex_version.go
+++ b/cmd/codex_version.go
@@ -45,13 +45,19 @@ func parseCodexVersion(out string) (string, bool) {
 	return fields[len(fields)-1], true
 }
 
+// codexVersionPath is the PATH the codex binary is resolved from. A package
+// var (defaulted to the real PATH) so tests point it at a temp dir — PATH is
+// process-global and CI runners have no codex, so resolving the real binary
+// would make the version gate depend on the host.
+var codexVersionPath = os.Getenv("PATH")
+
 // codexBinaryVersion resolves the codex binary on PATH and returns its
 // version. Returns ok=false when the binary is absent or the probe fails —
 // callers treat that as "cannot determine" and do NOT warn (a missing binary
 // is reported separately by the binary-status checks).
-func codexBinaryVersion() (version string, ok bool) {
+func codexBinaryVersion() (string, bool) {
 	names := provider.MustGet("codex").BinaryNames()
-	found, err := activation.ResolveBinary(os.Getenv("PATH"), names)
+	found, err := activation.ResolveBinary(codexVersionPath, names)
 	if err != nil {
 		return "", false
 	}

--- a/cmd/codex_version.go
+++ b/cmd/codex_version.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/activation"
+	"github.com/jpvelasco/juggernaut/v5/internal/doctor"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+)
+
+// codexMinVersion is the minimum Codex CLI that ships the built-in
+// amazon-bedrock-runtime provider (which routes to the bedrock-runtime
+// endpoint with SigV4). Codex < 0.153.4 lacks that provider, so apply and
+// doctor warn the user to update instead of writing a config that would 404 on
+// a missing provider. Verified: npm @openai/codex 0.153.4 has it; the
+// 0.148.0-alpha.9 native build does not.
+const codexMinVersion = "0.153.4"
+
+// codexVersionProbe runs `codex --version` for the given binary path and
+// returns the parsed semantic version. A package var so tests substitute a
+// stub (the real probe execs the on-PATH codex binary, which is absent in CI).
+var codexVersionProbe = func(path string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "--version").Output()
+	if err != nil {
+		return "", false
+	}
+	return parseCodexVersion(string(out))
+}
+
+// parseCodexVersion extracts the semantic version from `codex --version`
+// output of the form "codex-cli 0.153.4\n" (the version is the last field).
+func parseCodexVersion(out string) (string, bool) {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) < 2 {
+		return "", false
+	}
+	return fields[len(fields)-1], true
+}
+
+// codexBinaryVersion resolves the codex binary on PATH and returns its
+// version. Returns ok=false when the binary is absent or the probe fails —
+// callers treat that as "cannot determine" and do NOT warn (a missing binary
+// is reported separately by the binary-status checks).
+func codexBinaryVersion() (version string, ok bool) {
+	names := provider.MustGet("codex").BinaryNames()
+	found, err := activation.ResolveBinary(os.Getenv("PATH"), names)
+	if err != nil {
+		return "", false
+	}
+	return codexVersionProbe(found)
+}
+
+// codexVersionAtLeast reports whether v is >= min by numeric triple.
+func codexVersionAtLeast(v, min string) bool {
+	vc := versionTriple(v)
+	mc := versionTriple(min)
+	for i := 0; i < len(mc); i++ {
+		if i >= len(vc) {
+			return false
+		}
+		if vc[i] != mc[i] {
+			return vc[i] > mc[i]
+		}
+	}
+	return true
+}
+
+// versionTriple splits a semantic version into its numeric components,
+// stopping at the first pre-release/build suffix (e.g. "0.148.0-alpha.9" →
+// [0 148 0]).
+func versionTriple(v string) []int {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	var out []int
+	for _, part := range strings.Split(v, ".") {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			break
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// warnCodexVersion prints an apply-time warning when the resolved codex binary
+// is older than the minimum that ships the built-in amazon-bedrock-runtime
+// provider. No-op when the binary is absent or its version can't be
+// determined.
+func warnCodexVersion() {
+	v, ok := codexBinaryVersion()
+	if !ok || codexVersionAtLeast(v, codexMinVersion) {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"⚠ codex %s is older than %s, which is required for the built-in %s provider.\n"+
+			"  Juggernaut routes Codex through %s; an older Codex lacks it and requests will 404.\n"+
+			"  Update with: npm i -g @openai/codex@latest\n",
+		v, codexMinVersion, provider.CodexBedrockRuntimeProviderID, provider.CodexBedrockRuntimeProviderID)
+}
+
+// doctorCodexVersion reports the codex CLI version for the doctor report.
+// It returns an empty status when the binary is absent or its version can't be
+// determined (the separate binary-status check reports that), an OK line when
+// the version is adequate, and a Warn line when it is too old.
+func doctorCodexVersion(prov provider.Provider) (doctor.Status, string) {
+	if prov.Name() != "codex" {
+		return "", ""
+	}
+	v, ok := codexBinaryVersion()
+	if !ok {
+		return "", ""
+	}
+	if codexVersionAtLeast(v, codexMinVersion) {
+		return doctor.OK, fmt.Sprintf("codex %s (>= %s)", v, codexMinVersion)
+	}
+	return doctor.Warn, fmt.Sprintf("codex %s is older than %s — update to %s+ for the built-in %s provider (npm i -g @openai/codex@latest)",
+		v, codexMinVersion, codexMinVersion, provider.CodexBedrockRuntimeProviderID)
+}

--- a/cmd/codex_version.go
+++ b/cmd/codex_version.go
@@ -37,9 +37,11 @@ var codexVersionProbe = func(path string) (string, bool) {
 
 // parseCodexVersion extracts the semantic version from `codex --version`
 // output of the form "codex-cli 0.153.4\n" (the version is the last field).
+// A bare version ("0.160.0") is accepted too; callers reject anything that
+// doesn't parse into a numeric triple.
 func parseCodexVersion(out string) (string, bool) {
 	fields := strings.Fields(strings.TrimSpace(out))
-	if len(fields) < 2 {
+	if len(fields) == 0 {
 		return "", false
 	}
 	return fields[len(fields)-1], true
@@ -105,9 +107,12 @@ func versionTriple(v string) []int {
 
 // warnCodexVersion prints an apply-time warning when the resolved codex binary
 // is older than the minimum that ships the built-in amazon-bedrock-runtime
-// provider. No-op when the binary is absent or its version can't be
-// determined.
-func warnCodexVersion() {
+// provider. Self-gates on the codex provider and is a no-op when the binary is
+// absent or its version can't be determined.
+func warnCodexVersion(prov provider.Provider) {
+	if prov.Name() != "codex" {
+		return
+	}
 	v, ok := codexBinaryVersion()
 	if !ok || codexVersionAtLeast(v, codexMinVersion) {
 		return

--- a/cmd/codex_version_test.go
+++ b/cmd/codex_version_test.go
@@ -1,12 +1,43 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jpvelasco/juggernaut/v5/internal/doctor"
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 )
+
+// stubCodexVersion points the version source at a temp PATH dir holding a file
+// named like the codex binary and stubs the probe to report the given version.
+// The real PATH resolution (activation.ResolveBinary) still runs; only the
+// probe exec is faked (a stub file isn't a real executable on every OS). CI
+// runners have no codex on PATH, so tests must not depend on the host binary.
+func stubCodexVersion(t *testing.T, version string) {
+	t.Helper()
+	dir := t.TempDir()
+	name := provider.MustGet("codex").BinaryNames()[0]
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("stub\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	codexVersionPath = dir
+	restoreProbe := codexVersionProbe
+	codexVersionProbe = func(string) (string, bool) { return version, true }
+	t.Cleanup(func() {
+		codexVersionPath = ""
+		codexVersionProbe = restoreProbe
+	})
+}
+
+// stubCodexAbsent points the version source at an empty PATH dir so the real
+// resolution legitimately fails with exec.ErrNotFound.
+func stubCodexAbsent(t *testing.T) {
+	t.Helper()
+	codexVersionPath = t.TempDir()
+	t.Cleanup(func() { codexVersionPath = "" })
+}
 
 func TestParseCodexVersion(t *testing.T) {
 	cases := []struct {
@@ -54,9 +85,10 @@ func TestCodexVersionAtLeast(t *testing.T) {
 // warning (stderr) telling the user to update.
 func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
 	_ = setupApplyTest(t)
-	restore := codexVersionProbe
-	codexVersionProbe = func(string) (string, bool) { return "0.148.0-alpha.9", true }
-	defer func() { codexVersionProbe = restore }()
+	// Stub PATH + probe (not just the probe): CI runners have no codex binary
+	// on PATH, so resolving the real binary would make the gate depend on the
+	// host.
+	stubCodexVersion(t, "0.148.0-alpha.9")
 
 	stderr := captureStderr(t, func() { warnCodexVersion() })
 	for _, want := range []string{"0.148.0-alpha.9", codexMinVersion, provider.CodexBedrockRuntimeProviderID} {
@@ -70,20 +102,20 @@ func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
 // absent/unparseable binary must NOT warn (absence is the binary-status
 // check's job, not the version gate's).
 func TestCodexVersionGate_NoWarnOnModernOrMissingBinary(t *testing.T) {
-	_ = setupApplyTest(t)
-	cases := map[string]func(string) (string, bool){
-		"modern": func(string) (string, bool) { return "0.153.4", true },
-		"absent": func(string) (string, bool) { return "", false },
-		"badout": func(string) (string, bool) { return "", false },
-	}
-	for name, probe := range cases {
-		restore := codexVersionProbe
-		codexVersionProbe = probe
-		defer func() { codexVersionProbe = restore }()
+	t.Run("modern", func(t *testing.T) {
+		_ = setupApplyTest(t)
+		stubCodexVersion(t, "0.153.4")
 		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
-			t.Errorf("%s: no warning expected, got:\n%s", name, got)
+			t.Errorf("no warning expected, got:\n%s", got)
 		}
-	}
+	})
+	t.Run("absent", func(t *testing.T) {
+		_ = setupApplyTest(t)
+		stubCodexAbsent(t)
+		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
+			t.Errorf("no warning expected, got:\n%s", got)
+		}
+	})
 }
 
 func TestDoctorCodexVersion(t *testing.T) {
@@ -92,21 +124,22 @@ func TestDoctorCodexVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	stub := func(version string) func(t *testing.T) {
+		return func(t *testing.T) { stubCodexVersion(t, version) }
+	}
 	cases := []struct {
 		name    string
-		probe   func(string) (string, bool)
+		setup   func(t *testing.T)
 		want    doctor.Status
 		wantSub string
 	}{
-		{name: "modern", probe: func(string) (string, bool) { return "0.153.4", true }, want: doctor.OK, wantSub: "0.153.4"},
-		{name: "old", probe: func(string) (string, bool) { return "0.148.0-alpha.9", true }, want: doctor.Warn, wantSub: "update"},
-		{name: "absent", probe: func(string) (string, bool) { return "", false }, want: ""},
+		{name: "modern", setup: stub("0.153.4"), want: doctor.OK, wantSub: "0.153.4"},
+		{name: "old", setup: stub("0.148.0-alpha.9"), want: doctor.Warn, wantSub: "update"},
+		{name: "absent", setup: func(t *testing.T) { stubCodexAbsent(t) }, want: ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			restore := codexVersionProbe
-			codexVersionProbe = c.probe
-			defer func() { codexVersionProbe = restore }()
+			c.setup(t)
 
 			status, detail := doctorCodexVersion(codexProv)
 			if status != c.want {

--- a/cmd/codex_version_test.go
+++ b/cmd/codex_version_test.go
@@ -50,9 +50,9 @@ func TestParseCodexVersion(t *testing.T) {
 	}{
 		{out: "codex-cli 0.153.4\n", want: "0.153.4", ok: true},
 		{out: "codex-cli 0.148.0-alpha.9", want: "0.148.0-alpha.9", ok: true},
-		{out: "0.153.4\n", ok: false}, // no preceding product name
-		{out: "\n", ok: false},        // nothing
-		{out: "codex-cli\n", ok: false},
+		{out: "0.153.4\n", want: "0.153.4", ok: true},     // bare version accepted
+		{out: "codex-cli\n", want: "codex-cli", ok: true}, // single field: triple check rejects downstream
+		{out: "\n", ok: false},                            // nothing
 	}
 	for _, c := range cases {
 		got, ok := parseCodexVersion(c.out)
@@ -88,12 +88,13 @@ func TestCodexVersionAtLeast(t *testing.T) {
 // warning (stderr) telling the user to update.
 func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
 	_ = setupApplyTest(t)
+	prov := provider.MustGet("codex")
 	// Stub PATH + probe (not just the probe): CI runners have no codex binary
 	// on PATH, so resolving the real binary would make the gate depend on the
 	// host.
 	stubCodexProbe(t, "0.148.0-alpha.9")
 
-	stderr := captureStderr(t, func() { warnCodexVersion() })
+	stderr := captureStderr(t, func() { warnCodexVersion(prov) })
 	for _, want := range []string{"0.148.0-alpha.9", codexMinVersion, provider.CodexBedrockRuntimeProviderID} {
 		if !strings.Contains(stderr, want) {
 			t.Errorf("warning should name %q, got:\n%s", want, stderr)
@@ -105,27 +106,39 @@ func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
 // absent/unparseable binary must NOT warn (absence is the binary-status
 // check's job, not the version gate's).
 func TestCodexVersionGate_NoWarnOnModernOrMissingBinary(t *testing.T) {
+	prov := provider.MustGet("codex")
 	t.Run("modern", func(t *testing.T) {
 		_ = setupApplyTest(t)
 		stubCodexProbe(t, "0.153.4")
-		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
+		if got := captureStderr(t, func() { warnCodexVersion(prov) }); got != "" {
 			t.Errorf("no warning expected, got:\n%s", got)
 		}
 	})
 	t.Run("absent", func(t *testing.T) {
 		_ = setupApplyTest(t)
 		stubCodexAbsent(t)
-		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
+		if got := captureStderr(t, func() { warnCodexVersion(prov) }); got != "" {
 			t.Errorf("no warning expected, got:\n%s", got)
 		}
 	})
 	t.Run("unparseable", func(t *testing.T) {
 		_ = setupApplyTest(t)
 		stubCodexProbe(t, "unknown")
-		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
+		if got := captureStderr(t, func() { warnCodexVersion(prov) }); got != "" {
 			t.Errorf("no warning expected, got:\n%s", got)
 		}
 	})
+}
+
+// TestCodexVersionGate_NonCodex: the gate is codex-scoped — other CLIs
+// produce no warning even with an old codex on PATH.
+func TestCodexVersionGate_NonCodex(t *testing.T) {
+	_ = setupApplyTest(t)
+	prov := provider.MustGet("grok")
+	stubCodexProbe(t, "0.148.0-alpha.9")
+	if got := captureStderr(t, func() { warnCodexVersion(prov) }); got != "" {
+		t.Errorf("no warning expected, got:\n%s", got)
+	}
 }
 
 func TestDoctorCodexVersion(t *testing.T) {

--- a/cmd/codex_version_test.go
+++ b/cmd/codex_version_test.go
@@ -10,23 +10,25 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/provider"
 )
 
-// stubCodexVersion points the version source at a temp PATH dir holding a file
-// named like the codex binary and stubs the probe to report the given version.
+// stubCodexProbe points the version source at a temp PATH dir holding a file
+// named like the codex binary, and stubs the probe to report the given version.
 // The real PATH resolution (activation.ResolveBinary) still runs; only the
 // probe exec is faked (a stub file isn't a real executable on every OS). CI
 // runners have no codex on PATH, so tests must not depend on the host binary.
-func stubCodexVersion(t *testing.T, version string) {
+// version "unknown" exercises the unparseable ("cannot determine") path.
+func stubCodexProbe(t *testing.T, version string) {
 	t.Helper()
 	dir := t.TempDir()
 	name := provider.MustGet("codex").BinaryNames()[0]
 	if err := os.WriteFile(filepath.Join(dir, name), []byte("stub\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	restorePath := codexVersionPath
 	codexVersionPath = dir
 	restoreProbe := codexVersionProbe
 	codexVersionProbe = func(string) (string, bool) { return version, true }
 	t.Cleanup(func() {
-		codexVersionPath = ""
+		codexVersionPath = restorePath
 		codexVersionProbe = restoreProbe
 	})
 }
@@ -35,8 +37,9 @@ func stubCodexVersion(t *testing.T, version string) {
 // resolution legitimately fails with exec.ErrNotFound.
 func stubCodexAbsent(t *testing.T) {
 	t.Helper()
+	restorePath := codexVersionPath
 	codexVersionPath = t.TempDir()
-	t.Cleanup(func() { codexVersionPath = "" })
+	t.Cleanup(func() { codexVersionPath = restorePath })
 }
 
 func TestParseCodexVersion(t *testing.T) {
@@ -88,7 +91,7 @@ func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
 	// Stub PATH + probe (not just the probe): CI runners have no codex binary
 	// on PATH, so resolving the real binary would make the gate depend on the
 	// host.
-	stubCodexVersion(t, "0.148.0-alpha.9")
+	stubCodexProbe(t, "0.148.0-alpha.9")
 
 	stderr := captureStderr(t, func() { warnCodexVersion() })
 	for _, want := range []string{"0.148.0-alpha.9", codexMinVersion, provider.CodexBedrockRuntimeProviderID} {
@@ -104,7 +107,7 @@ func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
 func TestCodexVersionGate_NoWarnOnModernOrMissingBinary(t *testing.T) {
 	t.Run("modern", func(t *testing.T) {
 		_ = setupApplyTest(t)
-		stubCodexVersion(t, "0.153.4")
+		stubCodexProbe(t, "0.153.4")
 		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
 			t.Errorf("no warning expected, got:\n%s", got)
 		}
@@ -112,6 +115,13 @@ func TestCodexVersionGate_NoWarnOnModernOrMissingBinary(t *testing.T) {
 	t.Run("absent", func(t *testing.T) {
 		_ = setupApplyTest(t)
 		stubCodexAbsent(t)
+		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
+			t.Errorf("no warning expected, got:\n%s", got)
+		}
+	})
+	t.Run("unparseable", func(t *testing.T) {
+		_ = setupApplyTest(t)
+		stubCodexProbe(t, "unknown")
 		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
 			t.Errorf("no warning expected, got:\n%s", got)
 		}
@@ -124,18 +134,16 @@ func TestDoctorCodexVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stub := func(version string) func(t *testing.T) {
-		return func(t *testing.T) { stubCodexVersion(t, version) }
-	}
 	cases := []struct {
 		name    string
 		setup   func(t *testing.T)
 		want    doctor.Status
 		wantSub string
 	}{
-		{name: "modern", setup: stub("0.153.4"), want: doctor.OK, wantSub: "0.153.4"},
-		{name: "old", setup: stub("0.148.0-alpha.9"), want: doctor.Warn, wantSub: "update"},
-		{name: "absent", setup: func(t *testing.T) { stubCodexAbsent(t) }, want: ""},
+		{name: "modern", setup: func(t *testing.T) { stubCodexProbe(t, "0.153.4") }, want: doctor.OK, wantSub: "0.153.4"},
+		{name: "old", setup: func(t *testing.T) { stubCodexProbe(t, "0.148.0-alpha.9") }, want: doctor.Warn, wantSub: "update"},
+		{name: "absent", setup: stubCodexAbsent, want: ""},
+		{name: "unparseable", setup: func(t *testing.T) { stubCodexProbe(t, "unknown") }, want: ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/cmd/codex_version_test.go
+++ b/cmd/codex_version_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/juggernaut/v5/internal/doctor"
+	"github.com/jpvelasco/juggernaut/v5/internal/provider"
+)
+
+func TestParseCodexVersion(t *testing.T) {
+	cases := []struct {
+		out  string
+		want string
+		ok   bool
+	}{
+		{out: "codex-cli 0.153.4\n", want: "0.153.4", ok: true},
+		{out: "codex-cli 0.148.0-alpha.9", want: "0.148.0-alpha.9", ok: true},
+		{out: "0.153.4\n", ok: false}, // no preceding product name
+		{out: "\n", ok: false},        // nothing
+		{out: "codex-cli\n", ok: false},
+	}
+	for _, c := range cases {
+		got, ok := parseCodexVersion(c.out)
+		if ok != c.ok || got != c.want {
+			t.Errorf("parseCodexVersion(%q) = (%q, %v), want (%q, %v)", c.out, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestCodexVersionAtLeast(t *testing.T) {
+	cases := []struct {
+		v, min string
+		want   bool
+	}{
+		{v: "0.153.4", min: "0.153.4", want: true}, // equal
+		{v: "0.153.5", min: "0.153.4", want: true},
+		{v: "0.154.0", min: "0.153.4", want: true},
+		{v: "1.0.0", min: "0.153.4", want: true},
+		{v: "0.153.3", min: "0.153.4", want: false},
+		{v: "0.152.9", min: "0.153.4", want: false},
+		{v: "0.148.0-alpha.9", min: "0.153.4", want: false}, // suffix stripped for compare
+		{v: "0.153", min: "0.153.4", want: false},           // short triple is less
+	}
+	for _, c := range cases {
+		if got := codexVersionAtLeast(c.v, c.min); got != c.want {
+			t.Errorf("codexVersionAtLeast(%q, %q) = %v, want %v", c.v, c.min, got, c.want)
+		}
+	}
+}
+
+// TestCodexVersionGate_WarnsOnOldBinary: an on-PATH codex older than the
+// minimum that ships amazon-bedrock-runtime must produce a visible apply
+// warning (stderr) telling the user to update.
+func TestCodexVersionGate_WarnsOnOldBinary(t *testing.T) {
+	_ = setupApplyTest(t)
+	restore := codexVersionProbe
+	codexVersionProbe = func(string) (string, bool) { return "0.148.0-alpha.9", true }
+	defer func() { codexVersionProbe = restore }()
+
+	stderr := captureStderr(t, func() { warnCodexVersion() })
+	for _, want := range []string{"0.148.0-alpha.9", codexMinVersion, provider.CodexBedrockRuntimeProviderID} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("warning should name %q, got:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestCodexVersionGate_NoWarnOnModernOrMissingBinary: a modern binary and an
+// absent/unparseable binary must NOT warn (absence is the binary-status
+// check's job, not the version gate's).
+func TestCodexVersionGate_NoWarnOnModernOrMissingBinary(t *testing.T) {
+	_ = setupApplyTest(t)
+	cases := map[string]func(string) (string, bool){
+		"modern": func(string) (string, bool) { return "0.153.4", true },
+		"absent": func(string) (string, bool) { return "", false },
+		"badout": func(string) (string, bool) { return "", false },
+	}
+	for name, probe := range cases {
+		restore := codexVersionProbe
+		codexVersionProbe = probe
+		defer func() { codexVersionProbe = restore }()
+		if got := captureStderr(t, func() { warnCodexVersion() }); got != "" {
+			t.Errorf("%s: no warning expected, got:\n%s", name, got)
+		}
+	}
+}
+
+func TestDoctorCodexVersion(t *testing.T) {
+	_ = setupApplyTest(t)
+	codexProv, err := provider.Get("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name    string
+		probe   func(string) (string, bool)
+		want    doctor.Status
+		wantSub string
+	}{
+		{name: "modern", probe: func(string) (string, bool) { return "0.153.4", true }, want: doctor.OK, wantSub: "0.153.4"},
+		{name: "old", probe: func(string) (string, bool) { return "0.148.0-alpha.9", true }, want: doctor.Warn, wantSub: "update"},
+		{name: "absent", probe: func(string) (string, bool) { return "", false }, want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			restore := codexVersionProbe
+			codexVersionProbe = c.probe
+			defer func() { codexVersionProbe = restore }()
+
+			status, detail := doctorCodexVersion(codexProv)
+			if status != c.want {
+				t.Fatalf("status = %q, want %q (detail %q)", status, c.want, detail)
+			}
+			if c.wantSub != "" && !strings.Contains(detail, c.wantSub) {
+				t.Errorf("detail %q should contain %q", detail, c.wantSub)
+			}
+		})
+	}
+}
+
+// TestDoctorCodexVersion_NonCodex: the check is codex-scoped — other CLIs
+// report nothing.
+func TestDoctorCodexVersion_NonCodex(t *testing.T) {
+	prov, err := provider.Get("grok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status, _ := doctorCodexVersion(prov); status != "" {
+		t.Errorf("non-codex doctor check must be empty, got %q", status)
+	}
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -172,6 +172,9 @@ func collectDoctorReport(home, cli, scopeFilter string) (*doctor.Report, error) 
 	if status, detail := cliBinaryStatus(prov); status != "" {
 		r.Check(cliName+" binary", status, detail)
 	}
+	if status, detail := doctorCodexVersion(prov); status != "" {
+		r.Check("codex CLI version", status, detail)
+	}
 	if isClaude {
 		legacyArtifactStatus(home, r)
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -456,7 +456,9 @@ func applyWriteGate(home string, prov provider.Provider, plan provider.ConfigPla
 //   - Codex model_provider == "bedrock-mantle" (the real v5 provider id)
 //   - leftover [model_providers.bedrock-mantle] / provider.bedrock-mantle
 //     tables, including hybrid v6 model IDs still aimed at a Mantle URL
-//   - Codex amazon-bedrock + pre-v6 GPT-5 model IDs (openai.gpt-5.x, not 5.6)
+//   - Codex model_provider == "amazon-bedrock" (the v5 custom provider) — ANY
+//     model, since v6 routes Codex through the built-in amazon-bedrock-runtime
+//     and the custom amazon-bedrock table still points at the dead Mantle host
 func isJuggernautLegacy(existing map[string]any) bool {
 	if existing == nil {
 		return false
@@ -464,13 +466,13 @@ func isJuggernautLegacy(existing map[string]any) bool {
 	if grokMantleBaseURL(existing) {
 		return true
 	}
-	if mp, ok := existing["model_provider"].(string); ok && isMantleProviderID(mp) {
+	switch mp, ok := existing["model_provider"].(string); {
+	case ok && isMantleProviderID(mp):
+		return true
+	case ok && mp == provider.CodexLegacyProviderID:
 		return true
 	}
-	if hasMantleTable(existing["model_providers"]) || hasMantleTable(existing["provider"]) {
-		return true
-	}
-	return isCodexPreV6AmazonBedrock(existing)
+	return hasMantleTable(existing["model_providers"]) || hasMantleTable(existing["provider"])
 }
 
 func grokMantleBaseURL(existing map[string]any) bool {
@@ -483,19 +485,6 @@ func grokMantleBaseURL(existing map[string]any) bool {
 		return false
 	}
 	return containsMantleURL(grokModel)
-}
-
-func isCodexPreV6AmazonBedrock(existing map[string]any) bool {
-	if existing["model_provider"] != "amazon-bedrock" {
-		return false
-	}
-	m, ok := existing["model"].(string)
-	if !ok {
-		return false
-	}
-	// v6 GPT-5.6 may appear as openai.gpt-5.6-* or global./us. profile IDs;
-	// those are current. openai.gpt-5.4 / gpt-5.5 are Mantle-era pins.
-	return strings.HasPrefix(m, "openai.gpt-5.") && !strings.Contains(m, "gpt-5.6")
 }
 
 func isMantleProviderID(id string) bool {
@@ -652,6 +641,7 @@ func commitApply(home, authMode, token string, block *schema.Block, prov provide
 	if err := mgr.MergeConfigPlanDeepThen(plan.Keys, prov.DeepMergeKeys(), func(existing map[string]any) {
 		if migrating {
 			stripMantleLeftovers(existing)
+			provider.StripLegacyConfig(prov, existing)
 		}
 	}); err != nil {
 		return err

--- a/cmd/helpers_legacy_test.go
+++ b/cmd/helpers_legacy_test.go
@@ -46,20 +46,23 @@ func TestIsJuggernautLegacy(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "codex amazon-bedrock plus gpt-5.6 is current",
+			// Any top-level model_provider == "amazon-bedrock" is legacy,
+			// regardless of model: the custom table still points at the dead
+			// Mantle host, so even a v6 model ID is stale and must migrate.
+			name: "codex amazon-bedrock plus gpt-5.6 is legacy",
 			in: map[string]any{
 				"model":          "openai.gpt-5.6-sol",
 				"model_provider": "amazon-bedrock",
 			},
-			want: false,
+			want: true,
 		},
 		{
-			name: "codex amazon-bedrock plus global gpt-5.6 is current",
+			name: "codex amazon-bedrock plus global gpt-5.6 is legacy",
 			in: map[string]any{
 				"model":          "global.openai.gpt-5.6-sol",
 				"model_provider": "amazon-bedrock",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "codex model_provider bedrock-mantle",

--- a/cmd/launch_test.go
+++ b/cmd/launch_test.go
@@ -104,8 +104,9 @@ func TestApply_OpenCode_ProjectScope_WritesAuthMode(t *testing.T) {
 }
 
 // TestApply_Codex_WritesTOMLConfig drives a full codex apply and structurally
-// verifies the TOML config lands at ~/.codex/config.toml with the correct
-// amazon-bedrock provider shape.
+// verifies the TOML config lands at ~/.codex/config.toml with the built-in
+// amazon-bedrock-runtime provider shape (v6 routes Codex via bedrock-runtime,
+// not the custom v5 amazon-bedrock table).
 func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	home := setupApplyTest(t)
 	setupIsolatedKeychain(t) // stores a real token; skip if keychain backend hangs (macOS CI)
@@ -127,20 +128,23 @@ func TestApply_Codex_WritesTOMLConfig(t *testing.T) {
 	if got["model"] != "global.openai.gpt-5.6-sol" {
 		t.Errorf("model = %v, want global.openai.gpt-5.6-sol", got["model"])
 	}
-	if got["model_provider"] != "amazon-bedrock" {
-		t.Errorf("model_provider = %v, want amazon-bedrock", got["model_provider"])
+	if got["model_provider"] != "amazon-bedrock-runtime" {
+		t.Errorf("model_provider = %v, want amazon-bedrock-runtime", got["model_provider"])
 	}
 	mp, ok := got["model_providers"].(map[string]any)
 	if !ok {
 		t.Fatalf("model_providers not a table: %T", got["model_providers"])
 	}
-	ab, ok := mp["amazon-bedrock"].(map[string]any)
-	if !ok {
-		t.Fatalf("amazon-bedrock not a table: %T", mp["amazon-bedrock"])
+	if _, ok := mp["amazon-bedrock"]; ok {
+		t.Errorf("legacy [model_providers.amazon-bedrock] table must not be written, got: %v", mp["amazon-bedrock"])
 	}
-	aws, ok := ab["aws"].(map[string]any)
+	rt, ok := mp["amazon-bedrock-runtime"].(map[string]any)
 	if !ok {
-		t.Fatalf("aws not a table: %T", ab["aws"])
+		t.Fatalf("amazon-bedrock-runtime not a table: %T", mp["amazon-bedrock-runtime"])
+	}
+	aws, ok := rt["aws"].(map[string]any)
+	if !ok {
+		t.Fatalf("aws not a table: %T", rt["aws"])
 	}
 	if aws["region"] != "us-east-1" {
 		t.Errorf("aws.region = %v, want us-east-1", aws["region"])
@@ -168,8 +172,8 @@ func TestApply_Codex_ModelFlag_Respected(t *testing.T) {
 	if containsStr(data, "gpt-5.6-sol") {
 		t.Errorf("must not fall back to sol when --model=terra given:\n%s", data)
 	}
-	if !containsStr(data, `model_provider = "amazon-bedrock"`) {
-		t.Errorf("terra should use amazon-bedrock provider, got:\n%s", data)
+	if !containsStr(data, `model_provider = "amazon-bedrock-runtime"`) {
+		t.Errorf("terra should use the amazon-bedrock-runtime provider, got:\n%s", data)
 	}
 }
 
@@ -276,8 +280,8 @@ func TestUninstall_Codex_ActuallyRemoves(t *testing.T) {
 // TestUninstall_Codex_PreservesUserSiblingKeys: uninstall removes ONLY the
 // leaves Juggernaut owns. A user's own top-level keys, their own
 // model_providers entries, and sibling settings inside the
-// model_providers.amazon-bedrock.aws table must survive — uninstall is a
-// leaf-prune, not a data wipe.
+// model_providers.amazon-bedrock-runtime.aws table must survive — uninstall
+// is a leaf-prune, not a data wipe.
 func TestUninstall_Codex_PreservesUserSiblingKeys(t *testing.T) {
 	home := setupApplyTest(t)
 	setupIsolatedKeychain(t) // apply stores a real credential; skip if keychain backend hangs (macOS CI)
@@ -300,7 +304,7 @@ func TestUninstall_Codex_PreservesUserSiblingKeys(t *testing.T) {
 	got["telemetry"] = false
 	mp := got["model_providers"].(map[string]any)
 	mp["my-own"] = map[string]any{"base_url": "http://192.168.0.1/v1", "env_key": "MY_OWN_KEY"}
-	aws := mp["amazon-bedrock"].(map[string]any)["aws"].(map[string]any)
+	aws := mp["amazon-bedrock-runtime"].(map[string]any)["aws"].(map[string]any)
 	aws["profile"] = "bedrock-ops"
 	if err := mgr.Write(got); err != nil {
 		t.Fatalf("writing config.toml: %v", err)
@@ -331,7 +335,7 @@ func TestUninstall_Codex_PreservesUserSiblingKeys(t *testing.T) {
 	if _, ok := mpAfter["my-own"]; !ok {
 		t.Error("user's own provider entry lost on uninstall — data loss!")
 	}
-	awsAfter := mpAfter["amazon-bedrock"].(map[string]any)["aws"].(map[string]any)
+	awsAfter := mpAfter["amazon-bedrock-runtime"].(map[string]any)["aws"].(map[string]any)
 	if _, ok := awsAfter["region"]; ok {
 		t.Error("Juggernaut's region leaf should be removed")
 	}

--- a/cmd/uninstall_token_test.go
+++ b/cmd/uninstall_token_test.go
@@ -79,7 +79,7 @@ func TestUninstall_FullClaude_WithCodexConfigured_KeepsSharedToken(t *testing.T)
 	if err := os.MkdirAll(codexDir, 0o755); err != nil {
 		t.Fatalf("creating codex dir: %v", err)
 	}
-	codexConfig := "model = \"gpt-5.6-sol\"\nmodel_provider = \"amazon-bedrock\"\n[aws]\nregion = \"us-east-1\"\n"
+	codexConfig := "model = \"global.openai.gpt-5.6-sol\"\nmodel_provider = \"amazon-bedrock-runtime\"\n[model_providers.amazon-bedrock-runtime.aws]\nregion = \"us-east-1\"\n"
 	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(codexConfig), 0o644); err != nil {
 		t.Fatalf("seeding codex config: %v", err)
 	}

--- a/internal/provider/buildconfig_test.go
+++ b/internal/provider/buildconfig_test.go
@@ -217,26 +217,26 @@ func TestCodex_Supports(t *testing.T) {
 	}
 }
 
-// TestCodex_BuildConfig_AmazonBedrockProvider verifies the Codex plan writes
-// the built-in amazon-bedrock provider shape: model, model_provider, and a
-// nested [model_providers.amazon-bedrock.aws] table with region.
+// TestCodex_BuildConfig_AmazonBedrockRuntime verifies the Codex plan writes
+// the built-in amazon-bedrock-runtime provider shape: model, model_provider,
+// and a nested [model_providers.amazon-bedrock-runtime.aws] table with region.
 func TestCodex_BuildConfig_AmazonBedrockProvider(t *testing.T) {
 	p, _ := Get("codex")
 	plan, err := p.BuildConfig(testConfig(), baseOpts())
 	if err != nil {
 		t.Fatalf("BuildConfig: %v", err)
 	}
-	if plan.Keys["model_provider"] != "amazon-bedrock" {
-		t.Errorf("model_provider = %v, want amazon-bedrock", plan.Keys["model_provider"])
+	if plan.Keys["model_provider"] != "amazon-bedrock-runtime" {
+		t.Errorf("model_provider = %v, want amazon-bedrock-runtime", plan.Keys["model_provider"])
 	}
 	if plan.Keys["model"] != "global.openai.gpt-5.6-sol" {
 		t.Errorf("model = %v, want global.openai.gpt-5.6-sol", plan.Keys["model"])
 	}
 	// baseOpts uses the default region us-west-2 (non-explicit). sol is available
 	// in us-west-2, so no auto-switch.
-	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock", "aws", "region")
+	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock-runtime", "aws", "region")
 	if !ok {
-		t.Fatal("model_providers.amazon-bedrock.aws.region missing")
+		t.Fatal("model_providers.amazon-bedrock-runtime.aws.region missing")
 	}
 	if got := region.(string); got != "us-west-2" {
 		t.Errorf("region = %q, want us-west-2", got)
@@ -272,9 +272,9 @@ func TestCodex_BuildConfig_RegionIronFist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildConfig: %v", err)
 	}
-	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock", "aws", "region")
+	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock-runtime", "aws", "region")
 	if !ok {
-		t.Fatal("model_providers.amazon-bedrock.aws.region missing")
+		t.Fatal("model_providers.amazon-bedrock-runtime.aws.region missing")
 	}
 	if got := region.(string); got != "us-east-1" {
 		t.Errorf("region = %q, want us-east-1 (overridden from eu-west-1)", got)
@@ -302,9 +302,9 @@ func TestCodex_BuildConfig_Region(t *testing.T) {
 	opts := baseOpts()
 	opts.Region = "us-east-1"
 	plan, _ := p.BuildConfig(testConfig(), opts)
-	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock", "aws", "region")
+	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock-runtime", "aws", "region")
 	if !ok {
-		t.Fatal("model_providers.amazon-bedrock.aws.region missing")
+		t.Fatal("model_providers.amazon-bedrock-runtime.aws.region missing")
 	}
 	if got := region.(string); got != "us-east-1" {
 		t.Errorf("region = %q, want us-east-1", got)
@@ -321,9 +321,9 @@ func TestCodex_BuildConfig_ExplicitServingRegion(t *testing.T) {
 	opts.RegionExplicit = true
 	opts.Model = "sol"
 	plan, _ := p.BuildConfig(testConfig(), opts)
-	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock", "aws", "region")
+	region, ok := testutil.NestedMapChain(plan.Keys, "model_providers", "amazon-bedrock-runtime", "aws", "region")
 	if !ok {
-		t.Fatal("model_providers.amazon-bedrock.aws.region missing")
+		t.Fatal("model_providers.amazon-bedrock-runtime.aws.region missing")
 	}
 	if got := region.(string); got != "us-east-1" {
 		t.Errorf("region = %q, want us-east-1 (explicit serving region)", got)

--- a/internal/provider/catalog_test.go
+++ b/internal/provider/catalog_test.go
@@ -240,7 +240,9 @@ func TestDynamicModelSelectionAndCatalogWarnings(t *testing.T) {
 		id    string
 	}{
 		{"codex", "sol", "global.openai.gpt-5.6-sol"},
-		{"grok", "grok-4.6", "xai.grok-4.6"},
+		// Grok's native catalog carries CRIS profile IDs (global.xai.grok-4.6);
+		// BuildConfig normalizes the bare "grok-4.6" key to the same global. ID.
+		{"grok", "grok-4.6", "global.xai.grok-4.6"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.cli, func(t *testing.T) {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -12,15 +12,32 @@ import (
 
 // codex is the OpenAI Codex CLI provider (config at ~/.codex/config.toml, TOML).
 //
-// Codex uses the built-in amazon-bedrock provider which ships a model catalog
-// (eliminates "Model metadata not found" warnings and /model 404s). The config
-// is minimal: model, model_provider, and an [aws] sub-table for region. Auth
-// uses the standard AWS credential chain — Juggernaut's launch wrapper injects
-// AWS_BEARER_TOKEN_BEDROCK. Unlike Claude Code it has NO "use bedrock" env var
-// — routing lives entirely in the config file.
+// Codex routes through its built-in amazon-bedrock-runtime provider, which
+// speaks the bedrock-runtime Responses endpoint with SigV4 (no bearer token in
+// IAM mode) and ships a native inference-profile model catalog (no "Model
+// metadata not found" warnings or /model 404s). The config is minimal: model,
+// model_provider, and an [aws] sub-table for region. Juggernaut's launch
+// wrapper injects AWS_REGION (and AWS_BEARER_TOKEN_BEDROCK for API-key auth).
+// Unlike Claude Code it has NO "use bedrock" env var — routing lives entirely
+// in the config file.
+//
+// Routing note: Juggernaut v6 dropped Mantle. v5 wrote the CUSTOM
+// "amazon-bedrock" provider (model_providers.amazon-bedrock) whose base_url
+// pointed at bedrock-mantle; those configs are migrated on apply (see
+// StripLegacyProviderTables). v6+ writes the built-in amazon-bedrock-runtime.
 type codex struct {
 	BaseProvider
 }
+
+// CodexBedrockRuntimeProviderID is the built-in Codex provider that routes to
+// the bedrock-runtime Responses endpoint (SigV4 / API key). Codex >= 0.153.4
+// ships it; Juggernaut requires that minimum (see cmd's codex version gate).
+const CodexBedrockRuntimeProviderID = "amazon-bedrock-runtime"
+
+// CodexLegacyProviderID is the custom provider id Juggernaut v5 (Mantle era)
+// wrote. It still resolves to bedrock-mantle, which is dead in v6 — configs
+// still pinned to it are migrated to CodexBedrockRuntimeProviderID on apply.
+const CodexLegacyProviderID = "amazon-bedrock"
 
 // ConfigPath is ~/.codex/config.toml (user) or ./.codex/config.toml (project).
 func (c codex) ConfigPath(home, scope string) (string, error) {
@@ -32,12 +49,16 @@ func (c codex) ConfigPath(home, scope string) (string, error) {
 
 // NativeManagedKeys are the top-level config.toml keys Juggernaut owns for Codex.
 // OwnsConfig recognizes a Codex config Juggernaut wrote by its Bedrock provider
-// selection (model_provider == "amazon-bedrock"). A plain user config that merely
-// has a top-level `model` is NOT ours — critical so a first-time
-// `apply --cli=codex` over an existing Codex config still prompts for auth
-// instead of defaulting to iam (Mantle requires a bearer token).
+// selection (model_provider == "amazon-bedrock-runtime" or the legacy v5
+// "amazon-bedrock"). A plain user config that merely has a top-level `model`
+// is NOT ours — critical so a first-time `apply --cli=codex` over an existing
+// Codex config still prompts for auth instead of defaulting to iam.
 func (c codex) OwnsConfig(data map[string]any) bool {
-	return data["model_provider"] == "amazon-bedrock"
+	switch data["model_provider"] {
+	case CodexBedrockRuntimeProviderID, CodexLegacyProviderID:
+		return true
+	}
+	return false
 }
 
 func (c codex) NativeManagedKeys() []string {
@@ -53,12 +74,16 @@ func (c codex) NativeManagedKeys() []string {
 // user may have their own providers; merge only our amazon-bedrock entry.
 func (c codex) DeepMergeKeys() []string { return []string{"model_providers"} }
 
-// OwnedSubKeys: uninstall removes only the region leaf we wrote under
-// model_providers.amazon-bedrock.aws. Users may configure their own profile or
-// other settings in that sub-table — dot-notation targets the leaf so siblings
-// survive.
+// OwnedSubKeys: uninstall removes only the region leaf we wrote — under the
+// current amazon-bedrock-runtime.aws, plus the legacy amazon-bedrock.aws we
+// wrote in v5 so uninstall also cleans a half-migrated file. Users may
+// configure their own profile or other settings in those sub-tables —
+// dot-notation targets the leaf so siblings survive.
 func (c codex) OwnedSubKeys() map[string][]string {
-	return map[string][]string{"model_providers": {"amazon-bedrock.aws.region"}}
+	return map[string][]string{"model_providers": {
+		"amazon-bedrock-runtime.aws.region",
+		"amazon-bedrock.aws.region",
+	}}
 }
 
 // codexBedrockModel describes one OpenAI-family model reachable through native
@@ -123,10 +148,12 @@ func codexModel(key string) (codexBedrockModel, bool) {
 // codexDefaultModel is sol — the flagship for GPT-5.6.
 func codexDefaultModel() string { return "sol" }
 
-// BuildConfig writes Codex's config.toml using the built-in amazon-bedrock
-// provider. This provider ships a model catalog with native Bedrock inference
-// profile IDs (global.openai.gpt-5.6-sol etc.), eliminating the "Model
-// metadata not found" warning.
+// BuildConfig writes Codex's config.toml using the built-in
+// amazon-bedrock-runtime provider. This provider routes to the bedrock-runtime
+// Responses endpoint and ships a model catalog with native Bedrock inference
+// profile IDs (global.openai.gpt-5.6-sol etc.), eliminating the "Model metadata
+// not found" warning. It handles SigV4 itself, so no base_url or env_key is
+// written — only the [aws] region sub-table is needed.
 //
 // The GPT-5.6 family is INFERENCE_PROFILE-only on native Bedrock: the base
 // foundation ID (openai.gpt-5.6-sol) returns 400 "on-demand throughput isn't
@@ -140,8 +167,8 @@ func codexDefaultModel() string { return "sol" }
 // Config shape:
 //
 //	model = "global.openai.gpt-5.6-sol"
-//	model_provider = "amazon-bedrock"
-//	[model_providers.amazon-bedrock.aws]
+//	model_provider = "amazon-bedrock-runtime"
+//	[model_providers.amazon-bedrock-runtime.aws]
 //	  region = "us-west-2"
 func (c codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
 	key := opts.Model
@@ -156,9 +183,9 @@ func (c codex) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error
 	return buildWithRegionWarnings(opts, m.ModelID, m.Regions, ": ", c, func(region string) (ConfigPlan, error) {
 		keys := map[string]any{
 			"model":          m.ModelID,
-			"model_provider": "amazon-bedrock",
+			"model_provider": CodexBedrockRuntimeProviderID,
 			"model_providers": map[string]any{
-				"amazon-bedrock": map[string]any{
+				CodexBedrockRuntimeProviderID: map[string]any{
 					"aws": map[string]any{
 						"region": region,
 					},
@@ -195,6 +222,24 @@ func (c codex) SupportsModel(model CatalogModel) ModelSupport {
 		}
 		return ModelSupport{Supported: true, Reason: "Codex Responses model"}
 	})
+}
+
+// CleanLegacy deletes the v5 [model_providers.amazon-bedrock] table when
+// migrating an existing Codex config to the built-in amazon-bedrock-runtime
+// provider. Deep-merge preserves sibling tables, so without this strip the
+// stale Mantle-era table would persist forever and codex would 404 on it (it
+// still points at the removed Mantle endpoint). This is Codex-scoped: the
+// "provider.amazon-bedrock" table OpenCode uses is a different, still-current
+// native provider and is never touched.
+func (c codex) CleanLegacy(existing map[string]any) {
+	tbl, ok := existing["model_providers"].(map[string]any)
+	if !ok {
+		return
+	}
+	delete(tbl, CodexLegacyProviderID)
+	if len(tbl) == 0 {
+		delete(existing, "model_providers")
+	}
 }
 
 func (c codex) LaunchSpec() LaunchSpec {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -24,7 +24,7 @@ import (
 // Routing note: Juggernaut v6 dropped Mantle. v5 wrote the CUSTOM
 // "amazon-bedrock" provider (model_providers.amazon-bedrock) whose base_url
 // pointed at bedrock-mantle; those configs are migrated on apply (see
-// StripLegacyProviderTables). v6+ writes the built-in amazon-bedrock-runtime.
+// StripLegacyConfig / CleanLegacy). v6+ writes the built-in amazon-bedrock-runtime.
 type codex struct {
 	BaseProvider
 }

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -118,8 +118,9 @@ func TestCodex_DefaultModel(t *testing.T) {
 }
 
 // TestCodex_OwnedSubKeys_LeafRegion: OwnedSubKeys must target the region leaf
-// (amazon-bedrock.aws.region), not the entire aws sub-table. Users may configure
-// their own profile/credentials under aws — uninstall must preserve them.
+// under both the current amazon-bedrock-runtime.aws and the legacy v5
+// amazon-bedrock.aws, not the entire aws sub-table. Users may configure their
+// own profile/credentials under aws — uninstall must preserve them.
 func TestCodex_OwnedSubKeys_LeafRegion(t *testing.T) {
 	p, _ := Get("codex")
 	subs := p.OwnedSubKeys()
@@ -127,10 +128,19 @@ func TestCodex_OwnedSubKeys_LeafRegion(t *testing.T) {
 	if !ok {
 		t.Fatal("model_providers not in OwnedSubKeys")
 	}
-	if len(keys) != 1 {
-		t.Fatalf("expected 1 owned sub-key, got %d: %v", len(keys), keys)
+	want := map[string]bool{
+		"amazon-bedrock-runtime.aws.region": false,
+		"amazon-bedrock.aws.region":         false,
 	}
-	if keys[0] != "amazon-bedrock.aws.region" {
-		t.Errorf("owned sub-key = %q, want amazon-bedrock.aws.region (leaf-level to preserve user aws subkeys)", keys[0])
+	for _, k := range keys {
+		if _, ok := want[k]; !ok {
+			t.Errorf("unexpected owned sub-key %q (want only the two region leaves): %v", k, keys)
+		}
+		want[k] = true
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("owned sub-key %q missing (leaf-level, to preserve user aws subkeys): got %v", k, keys)
+		}
 	}
 }

--- a/internal/provider/grok.go
+++ b/internal/provider/grok.go
@@ -41,6 +41,43 @@ const grokAuthCommand = "juggernaut auth-token"
 // not fail—outside this set.
 var grokRegions = []string{"us-east-1", "us-east-2", "us-west-2"}
 
+// grokDefaultModelID is the Grok model Juggernaut pins by default: the global.
+// inference-profile ID (the bare foundation ID xai.grok-4.6 400s on the
+// bedrock-runtime endpoint, which only serves CRIS profile IDs).
+const grokDefaultModelID = "global.xai.grok-4.6"
+
+// normalizeGrokModelID resolves the model the user passed into a CRIS
+// inference-profile ID the bedrock-runtime endpoint actually accepts. The
+// runtime 400s on bare foundation IDs, so every bare form is normalized to a
+// global. profile ID; an explicit regional profile (global.*/us.*) is kept
+// verbatim so a user's us. pin stays us.
+func normalizeGrokModelID(modelID string) (string, bool) {
+	if modelID == "" {
+		return grokDefaultModelID, true
+	}
+	if bare := bedrock.StripRegionPrefix(modelID); bare != modelID {
+		// Already a regional profile ID — keep it (global./us./…).
+		if strings.HasPrefix(bare, "xai.grok-") {
+			return modelID, true
+		}
+		return "", false
+	}
+	switch {
+	case strings.HasPrefix(modelID, "xai.grok-"):
+		return "global." + modelID, true
+	case strings.HasPrefix(modelID, "grok-"):
+		return "global.xai." + modelID, true
+	}
+	return "", false
+}
+
+// grokModelIs46 reports whether modelID is the Grok 4.6 model under any form
+// (bare, global.xai.grok-4.6, us.xai.grok-4.6) — the only model with a verified
+// 1M context window and a verified serving-region set.
+func grokModelIs46(modelID string) bool {
+	return bedrock.StripRegionPrefix(modelID) == "xai.grok-4.6"
+}
+
 // ConfigPath is ALWAYS ~/.grok/config.toml. Grok's project-scoped
 // .grok/config.toml only accepts mcp_servers/plugins/permission — model config
 // is user-scoped — so both scopes resolve to the user config.
@@ -104,21 +141,16 @@ func (g grok) LaunchSpec() LaunchSpec {
 // still falls through to interactive login. The [auth] block is the documented
 // way to replace login entirely.
 func (g grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error) {
-	modelID := opts.Model
-	if modelID == "" {
-		modelID = "xai.grok-4.6"
-	} else if strings.HasPrefix(modelID, "grok-") {
-		modelID = "xai." + modelID
-	}
-	if !strings.HasPrefix(modelID, "xai.grok-") {
+	modelID, ok := normalizeGrokModelID(opts.Model)
+	if !ok {
 		return ConfigPlan{}, fmt.Errorf("unknown Grok model %q (expected a discovered xai.grok-* model)", opts.Model)
 	}
 
 	// Route to a region that actually serves grok-4.6 rather than writing a
 	// config that can't reach it.
-	modelRegions := grokRegions
-	if modelID != "xai.grok-4.6" {
-		modelRegions = nil
+	var modelRegions []string
+	if grokModelIs46(modelID) {
+		modelRegions = grokRegions
 	}
 
 	return buildWithRegionWarnings(opts, modelID, modelRegions, " ", g, func(region string) (ConfigPlan, error) {
@@ -128,7 +160,7 @@ func (g grok) BuildConfig(cfg *bedrock.Config, opts Options) (ConfigPlan, error)
 			"base_url": baseURL,
 			"name":     modelID + " (Amazon Bedrock)",
 		}
-		if modelID == "xai.grok-4.6" {
+		if grokModelIs46(modelID) {
 			modelBlock["context_window"] = 1000000
 		}
 		keys := map[string]any{
@@ -170,7 +202,10 @@ func (g grok) SupportsModel(model CatalogModel) ModelSupport {
 		if m.Source == "mantle" {
 			return ModelSupport{Reason: "Grok no longer uses Mantle (native only)"}
 		}
-		if !strings.HasPrefix(m.ID, "xai.grok-") {
+		// Catalog entries carry CRIS profile IDs (global.xai.grok-4.6,
+		// us.xai.grok-4.6); strip the regional prefix so the bare xai.grok-
+		// family check matches them, not just the bare foundation form.
+		if !strings.HasPrefix(bedrock.StripRegionPrefix(m.ID), "xai.grok-") {
 			return ModelSupport{Reason: "the Grok client supports xAI Grok models"}
 		}
 		return ModelSupport{Supported: true, Reason: "xAI native model"}

--- a/internal/provider/grok_test.go
+++ b/internal/provider/grok_test.go
@@ -90,7 +90,7 @@ func TestDeepMergeContract(t *testing.T) {
 		owned map[string][]string
 	}{
 		"claude":   {nil, nil},
-		"codex":    {[]string{"model_providers"}, map[string][]string{"model_providers": {"amazon-bedrock.aws.region"}}},
+		"codex":    {[]string{"model_providers"}, map[string][]string{"model_providers": {CodexBedrockRuntimeProviderID + ".aws.region", CodexLegacyProviderID + ".aws.region"}}},
 		"opencode": {[]string{"provider"}, map[string][]string{"provider": {"amazon-bedrock"}}},
 		"grok":     {[]string{"model", "models", "auth"}, map[string][]string{"model": {"bedrock-grok"}, "models": {"default"}, "auth": {"auth_provider_command", "auth_provider_label"}}},
 	}
@@ -102,11 +102,26 @@ func TestDeepMergeContract(t *testing.T) {
 		}
 		os := p.OwnedSubKeys()
 		for k, subs := range want.owned {
-			if len(os[k]) != len(subs) || (len(subs) > 0 && os[k][0] != subs[0]) {
+			if len(os[k]) != len(subs) || !containsAll(os[k], subs) {
 				t.Errorf("%s OwnedSubKeys[%s] = %v, want %v", name, k, os[k], subs)
 			}
 		}
 	}
+}
+
+// containsAll is an order-independent set-membership check for owned sub-key
+// lists (map-slice order is nondeterministic).
+func containsAll(got, want []string) bool {
+	set := make(map[string]bool, len(got))
+	for _, g := range got {
+		set[g] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestGrok_Supports_None(t *testing.T) {
@@ -159,8 +174,10 @@ func TestGrok_BuildConfig(t *testing.T) {
 	if !ok {
 		t.Fatalf("[model.%s] not a map: %T", grokModelName, bg)
 	}
-	if bgMap["model"] != "xai.grok-4.6" {
-		t.Errorf("model = %v, want xai.grok-4.6", bgMap["model"])
+	// The bare default is normalized to the global. CRIS profile ID that the
+	// bedrock-runtime endpoint actually serves.
+	if bgMap["model"] != "global.xai.grok-4.6" {
+		t.Errorf("model = %v, want global.xai.grok-4.6", bgMap["model"])
 	}
 	if base, _ := bgMap["base_url"].(string); base != "https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1" {
 		t.Errorf("base_url = %q, want .../openai/v1", base)
@@ -258,7 +275,7 @@ func TestGrok_BuildConfig_UnknownModel(t *testing.T) {
 }
 
 // TestGrok_BuildConfig_GrokPrefixNormalizes: a model key starting with "grok-"
-// is normalized to "xai.grok-" and accepted.
+// is normalized to a global.xai.grok-* CRIS profile ID and accepted.
 func TestGrok_BuildConfig_GrokPrefixNormalizes(t *testing.T) {
 	p, _ := Get("grok")
 	opts := baseOpts()
@@ -272,12 +289,91 @@ func TestGrok_BuildConfig_GrokPrefixNormalizes(t *testing.T) {
 		t.Fatalf("[model.%s] missing", grokModelName)
 	}
 	bgMap := bg.(map[string]any)
-	if bgMap["model"] != "xai.grok-4.4" {
-		t.Errorf("model = %v, want xai.grok-4.4", bgMap["model"])
+	if bgMap["model"] != "global.xai.grok-4.4" {
+		t.Errorf("model = %v, want global.xai.grok-4.4", bgMap["model"])
 	}
 	// Non-4.6 models don't get context_window
 	if _, hasContext := bgMap["context_window"]; hasContext {
 		t.Error("non-4.6 model must not have context_window")
+	}
+}
+
+// TestGrok_SupportsModel_CRISProfileIDs: the catalog carries CRIS profile IDs
+// (global.xai.grok-4.6, us.xai.grok-4.6) — the SupportsModel gate must accept
+// them, not just the bare xai.grok-* foundation form. Regression: the old
+// HasPrefix("xai.grok-") check hid every live profile ID from
+// `models list --cli=grok`.
+func TestGrok_SupportsModel_CRISProfileIDs(t *testing.T) {
+	p, _ := Get("grok")
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{id: "global.xai.grok-4.6", want: true},
+		{id: "us.xai.grok-4.6", want: true},
+		{id: "xai.grok-4.6", want: true},
+		{id: "global.xai.grok-4.3", want: true},
+		{id: "openai.gpt-5.6-sol", want: false},
+		{id: "xai.grok-4.6-eu", want: true}, // still the xai.grok- family after prefix strip
+	}
+	for _, c := range cases {
+		s := SupportsCatalogModel(p, CatalogModel{ID: c.id, Source: "foundation", Status: "ACTIVE", Availability: "AVAILABLE"})
+		if s.Supported != c.want {
+			t.Errorf("SupportsModel(%q) = %v, want %v (%s)", c.id, s.Supported, c.want, s.Reason)
+		}
+	}
+}
+
+// TestGrok_BuildConfig_CRISForms: bare and regional forms normalize to the
+// global. CRIS ID the runtime serves; an explicit regional profile ID is kept
+// verbatim (a us. pin stays us.); every 4.6 form gets the 1M context window.
+func TestGrok_BuildConfig_CRISForms(t *testing.T) {
+	p, _ := Get("grok")
+	cases := []struct {
+		in, want string
+		context  bool
+	}{
+		{in: "", want: "global.xai.grok-4.6", context: true},
+		{in: "xai.grok-4.6", want: "global.xai.grok-4.6", context: true},
+		{in: "grok-4.6", want: "global.xai.grok-4.6", context: true},
+		{in: "us.xai.grok-4.6", want: "us.xai.grok-4.6", context: true},
+		{in: "global.xai.grok-4.6", want: "global.xai.grok-4.6", context: true},
+		{in: "us.xai.grok-4.4", want: "us.xai.grok-4.4", context: false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			opts := baseOpts()
+			opts.Model = c.in
+			plan, err := p.BuildConfig(testConfig(), opts)
+			if err != nil {
+				t.Fatalf("BuildConfig(%q): %v", c.in, err)
+			}
+			bg, ok := testutil.NestedMapChain(plan.Keys, "model", grokModelName)
+			if !ok {
+				t.Fatalf("[model.%s] missing", grokModelName)
+			}
+			bgMap := bg.(map[string]any)
+			if bgMap["model"] != c.want {
+				t.Errorf("model = %v, want %v", bgMap["model"], c.want)
+			}
+			_, hasContext := bgMap["context_window"]
+			if hasContext != c.context {
+				t.Errorf("context_window present = %v, want %v (model %v)", hasContext, c.context, c.want)
+			}
+		})
+	}
+}
+
+// TestGrok_BuildConfig_UnknownCRISFamily: a regional prefix on a non-Grok
+// family must be rejected, not blindly accepted.
+func TestGrok_BuildConfig_UnknownCRISFamily(t *testing.T) {
+	p, _ := Get("grok")
+	for _, in := range []string{"global.openai.gpt-5.6-sol", "us.anthropic.claude-sonnet-4-6"} {
+		opts := baseOpts()
+		opts.Model = in
+		if _, err := p.BuildConfig(testConfig(), opts); err == nil {
+			t.Errorf("BuildConfig(%q) should error", in)
+		}
 	}
 }
 

--- a/internal/provider/ownsconfig_test.go
+++ b/internal/provider/ownsconfig_test.go
@@ -38,6 +38,54 @@ func TestCodex_OwnsConfig(t *testing.T) {
 	}
 }
 
+// TestCodex_OwnsConfig_RuntimeProvider: the v6 built-in amazon-bedrock-runtime
+// provider (and the v5 custom amazon-bedrock) are both recognized as ours —
+// a re-apply over a migrated config must be a plain re-apply, not a fresh
+// first-time auth prompt.
+func TestCodex_OwnsConfig_RuntimeProvider(t *testing.T) {
+	p, _ := Get("codex")
+	if !p.OwnsConfig(map[string]any{
+		"model":          "global.openai.gpt-5.6-sol",
+		"model_provider": CodexBedrockRuntimeProviderID,
+	}) {
+		t.Error("codex should own a config routed to the built-in amazon-bedrock-runtime")
+	}
+}
+
+// TestCodex_CleanLegacy: a migrate must delete the v5 custom
+// model_providers.amazon-bedrock table (deep-merge would otherwise preserve
+// it as a sibling, and it points at the dead Mantle endpoint), while keeping
+// user-defined providers and dropping an emptied model_providers table.
+func TestCodex_CleanLegacy(t *testing.T) {
+	p, _ := Get("codex")
+	// Legacy table alone → stripped, model_providers dropped.
+	existing := map[string]any{
+		"model_provider": CodexLegacyProviderID,
+		"model_providers": map[string]any{
+			CodexLegacyProviderID: map[string]any{"aws": map[string]any{"region": "us-west-2"}},
+		},
+	}
+	p.(LegacyCleaner).CleanLegacy(existing)
+	if _, ok := existing["model_providers"]; ok {
+		t.Errorf("empty model_providers table should be dropped, got %v", existing["model_providers"])
+	}
+	// User's own provider must survive; only the legacy table goes.
+	withUser := map[string]any{
+		"model_providers": map[string]any{
+			CodexLegacyProviderID: map[string]any{"aws": map[string]any{"region": "us-west-2"}},
+			"my-own":              map[string]any{"base_url": "http://localhost:1/v1"},
+		},
+	}
+	p.(LegacyCleaner).CleanLegacy(withUser)
+	mp := withUser["model_providers"].(map[string]any)
+	if _, ok := mp[CodexLegacyProviderID]; ok {
+		t.Errorf("legacy table must be deleted")
+	}
+	if _, ok := mp["my-own"]; !ok {
+		t.Error("user's own provider must survive")
+	}
+}
+
 // TestCodex_OwnsConfig_OldBedrockMantle: the legacy custom bedrock-mantle
 // provider (pre-amazon-bedrock) must NOT be claimed as currently owned.
 // Plain apply still migrates it via isJuggernautLegacy (cmd/) — OwnsConfig

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -102,6 +102,27 @@ func SupportsCatalogModel(p Provider, model CatalogModel) ModelSupport {
 	return catalogProvider.SupportsModel(model)
 }
 
+// LegacyCleaner is an optional extension implemented by providers whose old
+// configs leave a provider table that a deep-merge would preserve as a sibling
+// of the new one. On a legacy migration, cmd/ calls CleanLegacy to delete the
+// stale table so it does not survive the rewrite and point at a dead endpoint.
+type LegacyCleaner interface {
+	// CleanLegacy mutates the parsed existing config in place, deleting any
+	// provider table Juggernaut no longer routes through.
+	CleanLegacy(existing map[string]any)
+}
+
+// StripLegacyConfig deletes a provider's stale legacy tables from the existing
+// config in place. It is a no-op for providers that don't implement
+// LegacyCleaner (all current CLIs except Codex have no such leftover).
+func StripLegacyConfig(p Provider, existing map[string]any) {
+	cleaner, ok := p.(LegacyCleaner)
+	if !ok {
+		return
+	}
+	cleaner.CleanLegacy(existing)
+}
+
 // CatalogSourcesFor returns the discovery sources relevant to a provider.
 func CatalogSourcesFor(p Provider) []string {
 	catalogProvider, ok := p.(CatalogProvider)

--- a/internal/provider/task3_grok_verify_test.go
+++ b/internal/provider/task3_grok_verify_test.go
@@ -10,8 +10,8 @@ func TestTask3_Grok_NativeEndpoint(t *testing.T) {
 		t.Fatalf("BuildConfig: %v", err)
 	}
 	m, _ := plan.Keys["model"].(map[string]any)["bedrock-grok"].(map[string]any)
-	if m["model"] != "xai.grok-4.6" {
-		t.Errorf("model = %v, want xai.grok-4.6", m["model"])
+	if m["model"] != "global.xai.grok-4.6" {
+		t.Errorf("model = %v, want global.xai.grok-4.6", m["model"])
 	}
 	if base, _ := m["base_url"].(string); base != "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1" {
 		t.Errorf("base_url = %q, want bedrock-runtime", base)


### PR DESCRIPTION
## Why

Mantle was removed in v6, but v5 Codex configs pinned `model_provider = "amazon-bedrock"` — a dead Mantle endpoint. Those configs look owned-and-current, deep-merge forever, and 404 at runtime.

Closes #460. Fixes #457 (closed separately with the Grok-half verification). #458 (OpenCode `grok-4.6` alias, same CRIS bug) is intentionally out of scope.

## What

- **Codex → built-in `amazon-bedrock-runtime` provider.** `BuildConfig` writes `model_provider = "amazon-bedrock-runtime"` + `[model_providers.amazon-bedrock-runtime.aws]` region table — no custom `base_url`; the built-in provider does SigV4 via the AWS credential chain. Model IDs are CRIS inference-profile form (`global.openai.gpt-5.6-sol`), which works in all three verified US regions. `OwnsConfig` recognizes both the new and legacy provider IDs; `OwnedSubKeys` covers both region leaves so uninstall cleans half-migrated files.
- **Legacy = any top-level `model_provider == "amazon-bedrock"`.** A plain `apply` migrates in place: backup first, rewrite to `amazon-bedrock-runtime`, and strip the stale `model_providers.amazon-bedrock` table (new `LegacyCleaner` interface, Codex-only). OpenCode's `provider.amazon-bedrock` table is a different, still-current table and is never touched.
- **Grok:** pin `global.xai.grok-4.6` (the global CRIS profile ID) on the `bedrock-runtime` `/openai/v1` URL. Bare `xai.grok-*` / `grok-*` inputs normalize to `global.*`; an explicit `us.` pin stays verbatim. `SupportsModel` and the 4.6-only gates (`context_window`, serving regions) now strip the CRIS regional prefix before the family test, so `global.`/`us.` profile IDs surface in `models list --cli=grok` (fixes #457).
- **Codex version gate.** CLI < 0.153.4 lacks the built-in provider, so `apply` (dry-run and commit) and `doctor` warn loudly instead of writing a config that would 404. Docs pin the minimum (README, QUICKSTART, AGENTS).

## Tests

- Legacy `amazon-bedrock` config migrates on plain apply: backup saved, stale table removed, config on `amazon-bedrock-runtime` with CRIS model ID.
- Fresh Codex apply writes only `amazon-bedrock-runtime`.
- Already-migrated config re-applies with no migration announcement.
- OpenCode config byte-identical after a Codex migration.
- Grok: bare input upgrades to `global.xai.grok-4.6`; `SupportsModel` accepts `global.`/`us.` CRIS prefixes.
- Version gate: `apply`/`doctor` warn on old codex, silent on ≥ 0.153.4, no-op when binary absent.

Full `go test ./...`, `go vet ./...`, and `git diff --check` green; `cmd` package at 94.9% statement coverage, new gate functions at 80–100%.

## Scope (deliberately not included)

No OpenCode CRIS audit (#458), no uninstall #455/#456, no symlink #454, no Daybreak/Astra handling.
