### PR TITLE
fix(uninstall): keep shared token on scoped uninstalls and clear it on the last CLI's removal (#455, #456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Juggernaut will be documented in this file.
 
 ### Fixed
 
+- **Scoped uninstalls no longer delete the shared Bedrock bearer token
+  (fixes #455).** `uninstall --scope=user` behaved like `--scope=project`:
+  a partial removal that must keep the credential the surviving scopes (and
+  other CLIs) still reference. Any non-empty `--scope` now leaves the token
+  in place.
+- **The last remaining CLI's uninstall clears the shared token (fixes
+  #456).** The retention survey previously only ran when uninstalling
+  Claude, so uninstalling the final configured CLI (Codex, OpenCode, or
+  Grok) left the bearer token behind with nothing using it. A full
+  (unscoped) uninstall now surveys every provider and removes the token
+  only when no Juggernaut-owned config remains anywhere; otherwise it
+  prints the existing "token retained" warning naming the surviving CLI.
+
 - **OpenCode config validates against OpenCode's strict schema again (fixes #463).**
   `apply --cli=opencode` was writing an `opencode.json` that OpenCode rejects at
   startup (its config schema is `additionalProperties: false`), so a fresh

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -912,10 +912,17 @@ func TestApply_DefaultConfig_AlsoWarnsAboutFableDataRetention(t *testing.T) {
 }
 
 func TestUninstall_Codex_PreservesSharedToken(t *testing.T) {
-	_ = setupApplyTest(t)
+	home := setupApplyTest(t)
+	chdirTo(t, home)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("shared-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+	// Claude is still configured, so a codex uninstall must keep the shared
+	// bearer token — even with --full (that would break a still-configured
+	// Claude).
+	seedJuggernautConfig(t, home, "claude")
 
-	// Uninstalling a non-Claude CLI must NOT remove the shared bearer token,
-	// even with --full (that would break a still-configured Claude).
 	out := captureStdout(t, func() {
 		if err := ExecuteArgs([]string{
 			"uninstall", "--cli=codex", "--full", "--force",
@@ -924,7 +931,17 @@ func TestUninstall_Codex_PreservesSharedToken(t *testing.T) {
 		}
 	})
 	if strings.Contains(out, "Removed bearer token from keychain") {
-		t.Errorf("uninstall --cli=codex must NOT remove the shared keychain token, got:\n%s", out)
+		t.Errorf("uninstall --cli=codex must NOT remove the shared keychain token while Claude is configured, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Shared Bedrock bearer token retained") {
+		t.Errorf("expected a retain warning naming claude, got:\n%s", out)
+	}
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after codex uninstall: %v", err)
+	}
+	if got != "shared-token" {
+		t.Errorf("codex uninstall removed the shared token while Claude is configured (got %q)", got)
 	}
 }
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -56,17 +56,26 @@ func runUninstall(_ *cobra.Command, _ []string) error {
 	uninstallSettingsBlocks(home, prov)
 	removeRuntimeState(home, prov)
 	// The Bedrock bearer token is SHARED across all CLIs, so removing it on a
-	// per-CLI uninstall would break any other CLI still configured. Only remove
-	// it when uninstalling Claude (the primary) — and never on a scoped
-	// partial removal: --scope=project must leave the credential that
-	// user-scope Claude and non-Claude providers still reference. `--full`
-	// broadens shell-block removal, NOT shared-credential removal.
-	if !uninstallFlags.dryRun && prov.Name() == "claude" && uninstallFlags.scope != "project" {
-		if otherNeeds := otherProviderNeedsToken(home, prov); otherNeeds != "" {
+	// per-CLI uninstall would break any other CLI still configured. A scoped
+	// uninstall is a partial removal and never touches the credential — the
+	// scopes it leaves (or other CLIs) still reference it. A full removal
+	// surveys every provider: the token goes only when no Juggernaut-owned
+	// config remains anywhere. `--full` broadens shell-block removal, NOT
+	// shared-credential removal.
+	if uninstallFlags.scope == "" {
+		// Dry run: prov's blocks are still on disk, so exclude prov and the
+		// survey reports what a real run would do. Real run: probe every
+		// provider — prov's blocks were just removed, so a surviving probe is
+		// a fail-safe retain (removal failed or the user re-applied mid-run).
+		exclude := prov
+		if !uninstallFlags.dryRun {
+			exclude = nil
+		}
+		if otherNeeds := otherProviderNeedsToken(home, exclude); otherNeeds != "" {
 			fmt.Printf("  ⚠ Shared Bedrock bearer token retained — %s config still present (Juggernaut owns it)\n", otherNeeds)
 			fmt.Println("    If you intend to stop using ALL Bedrock-backed CLIs, re-run this after uninstalling the others,")
 			fmt.Println("    or remove the token manually from the keychain / credential file.")
-		} else {
+		} else if !uninstallFlags.dryRun {
 			removeKeychainToken(home)
 		}
 	}
@@ -220,15 +229,15 @@ func removeKeychainToken(home string) {
 	fmt.Println("  ✓ Removed bearer token from keychain")
 }
 
-// otherProviderNeedsToken reports whether any OTHER provider (excluding the one
-// being uninstalled) still has a Juggernaut-owned config in user or project
-// scope. An empty result means no other provider depends on the shared bearer
-// token. An unreadable config is treated as "still needed" (fail-safe retain):
-// a parse error should never be the reason we delete a credential another CLI
-// may be using.
+// otherProviderNeedsToken reports whether any provider still has a
+// Juggernaut-owned config in user or project scope, optionally excluding one.
+// Pass nil to survey every provider. An empty result means no provider
+// depends on the shared bearer token. An unreadable config is treated as
+// "still needed" (fail-safe retain): a parse error should never be the reason
+// we delete a credential another CLI may be using.
 func otherProviderNeedsToken(home string, exclude provider.Provider) string {
 	for _, name := range provider.AllNames() {
-		if name == exclude.Name() {
+		if exclude != nil && name == exclude.Name() {
 			continue
 		}
 		p, err := provider.Get(name)

--- a/cmd/uninstall_token_test.go
+++ b/cmd/uninstall_token_test.go
@@ -11,6 +11,33 @@ import (
 	"github.com/jpvelasco/juggernaut/v5/internal/testutil"
 )
 
+// Given a Bedrock bearer token is present and no other provider keeps a
+// config,
+// When the user runs a full Claude uninstall with --dry-run,
+// Then the survey runs but nothing is removed: the token survives and no
+// removal is reported.
+func TestUninstall_DryRun_LastProvider_KeepsToken(t *testing.T) {
+	home := setupApplyTest(t)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("probe-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--force", "--dry-run"}); err != nil {
+			t.Fatalf("uninstall dry-run error: %v", err)
+		}
+	})
+
+	got, _ := store.GetWithFallback(home)
+	if got != "probe-token" {
+		t.Errorf("dry-run must not remove the bearer token, got %q", got)
+	}
+	if strings.Contains(out, "Removed bearer token") {
+		t.Errorf("dry-run must not report token removal:\n%s", out)
+	}
+}
+
 // Given a Bedrock bearer token shared by every configured provider,
 // When the user removes ONLY Claude's project-scope block,
 // Then the shared token must survive: user-scope Claude and any non-Claude
@@ -105,6 +132,36 @@ func TestUninstall_FullClaude_WithCodexConfigured_KeepsSharedToken(t *testing.T)
 	}
 }
 
+// claudeOwnedSettingsJSON is a minimal Claude settings.json carrying a
+// Juggernaut block (juggernaut.meta.managedBy == "juggernaut"), which is what
+// (claude).OwnsConfig recognizes.
+const claudeOwnedSettingsJSON = `{"juggernaut":{"auth":{"mode":"iam","region":"us-west-2"},"meta":{"managedBy":"juggernaut"}}}`
+
+// grokOwnedTOML is a minimal Grok config.toml whose [model.bedrock-grok]
+// profile is what (grok).OwnsConfig recognizes.
+const grokOwnedTOML = "[model.bedrock-grok]\nbase_url = \"https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1\"\n"
+
+// seedJuggernautConfig writes a Juggernaut-owned config file for the given
+// provider name (claude or grok) under home.
+func seedJuggernautConfig(t *testing.T, home, provName string) {
+	t.Helper()
+	var dir, file, body string
+	switch provName {
+	case "claude":
+		dir, file, body = filepath.Join(home, ".claude"), "settings.json", claudeOwnedSettingsJSON
+	case "grok":
+		dir, file, body = filepath.Join(home, ".grok"), "config.toml", grokOwnedTOML
+	default:
+		t.Fatalf("unknown provider for fixture: %s", provName)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0o644); err != nil {
+		t.Fatalf("seed %s config: %v", provName, err)
+	}
+}
+
 // tokenSurveyProvider is a hand-built provider for exercising
 // otherProviderNeedsToken's defensive branches that no real registered
 // provider can reach: config construction failures, unreadable config, and
@@ -193,5 +250,180 @@ func TestOtherProviderNeedsToken_DefensiveBranches(t *testing.T) {
 	provider.ForceRegisterForTest("codex", tokenSurveyProvider{base: orig, owns: true})
 	if res := otherProviderNeedsToken(home, exclude); res != "codex" {
 		t.Errorf("owned config: expected retain, got %q", res)
+	}
+
+	// F) a nil exclude surveys EVERY provider — the provider "excluded"
+	// from the caller's perspective (claude) must still be surveyed when it
+	// owns a config.
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(claudeOwnedSettingsJSON), 0o644); err != nil {
+		t.Fatalf("seed claude config: %v", err)
+	}
+	provider.ForceRegisterForTest("codex", orig)
+	if res := otherProviderNeedsToken(home, nil); res != "claude" {
+		t.Errorf("nil exclude: expected claude retained, got %q", res)
+	}
+	if err := os.RemoveAll(filepath.Join(home, ".claude")); err != nil {
+		t.Fatalf("remove .claude: %v", err)
+	}
+
+	// G) same-provider user-scope retain: the survey must consider scopes the
+	// uninstall is NOT removing. An opencode uninstall with claude configured
+	// in user scope keeps the token.
+	provider.ForceRegisterForTest("claude", tokenSurveyProvider{base: provider.MustGet("claude")})
+	if res := otherProviderNeedsToken(home, provider.MustGet("opencode")); res != "claude" {
+		t.Errorf("claude user-scope config present: expected claude retained, got %q", res)
+	}
+}
+
+// Given the user uninstalls Claude with --scope=user (a partial removal),
+// When the uninstall completes,
+// Then the shared token must survive: the project scope and any other CLI
+// still reference it.
+func TestUninstall_UserScope_KeepsSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("shared-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--scope=user", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after user-scope uninstall: %v", err)
+	}
+	if got != "shared-token" {
+		t.Errorf("user-scope uninstall deleted the shared bearer token (got %q)\noutput:\n%s", got, out)
+	}
+}
+
+// Given the LAST CLI (Grok) is uninstalled outright and no other
+// Juggernaut-owned config remains anywhere,
+// When the uninstall completes,
+// Then the shared bearer token is removed — the old Claude-only gate never
+// ran the survey for a non-Claude last uninstall.
+func TestUninstall_LastNonClaude_RemovesSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	chdirTo(t, home) // project-scope probe must find nothing under the cwd
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("last-cli-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=grok", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after last-CLI uninstall: %v", err)
+	}
+	if got != "" {
+		t.Errorf("last-CLI uninstall should remove the shared bearer token, got %q\noutput:\n%s", got, out)
+	}
+	if !strings.Contains(out, "Removed bearer token from keychain") {
+		t.Errorf("expected a token-removal line in output, got:\n%s", out)
+	}
+}
+
+// Given a Grok config is configured and the user uninstalls Claude in full,
+// When the uninstall completes,
+// Then the shared token must survive — the retention survey must consider
+// Grok (and every provider), not just the providers historically known.
+func TestUninstall_FullClaude_WithGrokConfigured_KeepsSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	chdirTo(t, home)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("shared-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+	seedJuggernautConfig(t, home, "grok")
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after uninstall: %v", err)
+	}
+	if got != "shared-token" {
+		t.Errorf("shared bearer token was removed while a Grok config still references it (got %q)\noutput:\n%s", got, out)
+	}
+	if !strings.Contains(out, "Shared Bedrock bearer token retained") {
+		t.Errorf("expected a retain warning in output, got:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "grok") {
+		t.Errorf("retain warning should name the surviving provider (grok), got:\n%s", out)
+	}
+}
+
+// Given a Grok config is configured and the user dries a full Claude
+// uninstall,
+// When the dry run completes,
+// Then nothing is removed — the token survives and no removal is announced.
+func TestUninstall_DryRunClaude_WithGrokConfigured_KeepsSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	chdirTo(t, home)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("shared-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+	seedJuggernautConfig(t, home, "grok")
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=claude", "--dry-run"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after dry run: %v", err)
+	}
+	if got != "shared-token" {
+		t.Errorf("dry run removed the shared bearer token (got %q)\noutput:\n%s", got, out)
+	}
+	if strings.Contains(out, "Removed bearer token") {
+		t.Errorf("dry run must not announce a token removal, got:\n%s", out)
+	}
+}
+
+// Given no Juggernaut-owned config exists for any provider and the user
+// uninstalls Grok outright,
+// When the uninstall completes,
+// Then the shared token is still removed — the survey runs for every last-CLI
+// uninstall, not just Claude's.
+func TestUninstall_LastGrok_NoConfigs_RemovesSharedToken(t *testing.T) {
+	home := setupApplyTest(t)
+	chdirTo(t, home)
+	store := setupIsolatedKeychain(t)
+	if err := store.SetWithFallback("orphan-token", home); err != nil {
+		t.Fatalf("seeding keychain: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := ExecuteArgs([]string{"uninstall", "--cli=grok", "--force"}); err != nil {
+			t.Fatalf("uninstall error: %v", err)
+		}
+	})
+
+	got, err := store.GetWithFallback(home)
+	if err != nil {
+		t.Fatalf("reading token after uninstall: %v", err)
+	}
+	if got != "" {
+		t.Errorf("orphan token should be removed on last-CLI uninstall, got %q\noutput:\n%s", got, out)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the shared Bedrock bearer-token lifecycle on uninstall. The shared token
is shared across every provider, so removal must be coordinated across all of
them, not decided per-CLI.

### Closes #455 — scoped uninstall deleted the shared token
`uninstall --scope=user` behaved like `--scope=project`: a partial removal
that has to keep the credential the surviving scopes (and other CLIs) still
reference. Any non-empty `--scope` is now treated as a partial removal and
leaves the token in place.

### Closes #456 — the last remaining CLI's uninstall left the token behind
The retention survey previously ran only when uninstalling Claude, so
uninstalling the final configured CLI (Codex, OpenCode, or Grok) left the
bearer token behind with nothing using it. A full (unscoped) uninstall now
surveys every provider and removes the token only when no Juggernaut-owned
config remains anywhere; otherwise it prints the existing "token retained"
warning naming the surviving CLI.

## Changes
- `cmd/uninstall.go` — token block runs when `scope == ""`; `exclude := prov` in
  dry-run, `nil` on a real run. Empty survey + non-dry-run removes the token.
- `otherProviderNeedsToken(home, exclude)` accepts `exclude == nil` (nil-safe).
- New focused tests + fixtures in `cmd/uninstall_token_test.go`; `cmd/apply_test.go`
  reworked to seed a real multi-CLI home instead of an empty one.

## Verification
- `go test ./...` green; `golangci-lint run ./cmd/...` 0 issues; `gofmt` clean.
- Focused: scoped uninstall retains the token + names the surviving CLI; unscoped
  uninstall over the last CLI removes it.

Closes #455
Closes #456