### PR TITLE
fix(opencode): route grok aliases to the global CRIS ID and drop Mantle from the catalog warning (#458, #452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Juggernaut will be documented in this file.
 
 ### Fixed
 
+- **OpenCode's `grok-4.6` alias now routes to a servable model (fixes #458).**
+  The convenience aliases `grok-4.6` and `grok-4.3` resolved to the bare
+  `xai.grok-4.6` foundation ID, which the `bedrock-runtime` endpoint rejects —
+  it only serves cross-Region inference profile IDs. Both now resolve to
+  `global.xai.grok-4.6`, matching the Grok provider's own normalization.
+  Audit note: the other aliases (`glm-4.7`, `glm-5`, `kimi-k2.5`,
+  `deepseek-v3.2`, `qwen3-coder`) remain bare foundation IDs — GLM 5 is
+  In-Region-only per its model card, and the others are Chat-API-compatible
+  foundation IDs that serve in-region.
+- **Catalog warning no longer names Mantle (fixes #452).** The
+  "was not returned as ACTIVE and available" apply warning referred to the
+  removed Mantle endpoint; it now just names the region.
+
 - **OpenCode config validates against OpenCode's strict schema again (fixes #463).**
   `apply --cli=opencode` was writing an `opencode.json` that OpenCode rejects at
   startup (its config schema is `additionalProperties: false`), so a fresh

--- a/internal/provider/catalog_test.go
+++ b/internal/provider/catalog_test.go
@@ -269,3 +269,21 @@ func TestDynamicModelSelectionAndCatalogWarnings(t *testing.T) {
 		})
 	}
 }
+
+// TestCatalogUnavailableWarning_NoMantleMention: the user-facing warning names
+// the region, not the internal endpoint — Mantle was removed in v6 (#452).
+func TestCatalogUnavailableWarning_NoMantleMention(t *testing.T) {
+	p, _ := Get("opencode")
+	w := catalogUnavailableWarning(
+		[]CatalogModel{catalogModel("unrelated.model", "foundation")},
+		"some.model", "us-west-2", "it remains configured for explicit use", p.(CatalogProvider), nil)
+	if w == "" {
+		t.Fatal("expected a warning for an unavailable selected model")
+	}
+	if strings.Contains(w, "Mantle") {
+		t.Errorf("warning must not mention Mantle, got: %q", w)
+	}
+	if !strings.Contains(w, "us-west-2") {
+		t.Errorf("warning should name the region, got: %q", w)
+	}
+}

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -101,8 +101,11 @@ func (o opencode) LaunchSpec() LaunchSpec {
 }
 
 // opencodeModelAliases are convenience spellings, not an availability roster.
-// The live account/region catalog remains authoritative. IDs are native
-// Bedrock foundation IDs verified via `models list --source native` (2026-08-29).
+// The live account/region catalog remains authoritative. IDs are native Bedrock
+// foundation IDs (2026-08-29) — except the grok-4.6/4.3 entries, which use the
+// global. cross-Region inference profile: the bedrock-runtime endpoint 400s on
+// the bare xai.grok-4.6 foundation ID (verified against the Grok 4.6 model
+// card; the Grok provider applies the same normalization).
 var opencodeModelAliases = map[string]string{
 	"gpt-oss-120b":  "openai.gpt-oss-120b-1:0",
 	"gpt-oss-20b":   "openai.gpt-oss-20b-1:0",
@@ -111,8 +114,8 @@ var opencodeModelAliases = map[string]string{
 	"kimi-k2.5":     "moonshotai.kimi-k2.5",
 	"deepseek-v3.2": "deepseek.v3.2",
 	"qwen3-coder":   "qwen.qwen3-coder-480b-a35b-v1:0",
-	"grok-4.6":      "xai.grok-4.6",
-	"grok-4.3":      "xai.grok-4.6", // deprecated: kept for backwards compat; prefer grok-4.6
+	"grok-4.6":      "global.xai.grok-4.6",
+	"grok-4.3":      "global.xai.grok-4.6", // deprecated: kept for backwards compat; prefer grok-4.6
 }
 
 func opencodeDefaultModel() string { return "gpt-oss-120b" }

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -226,7 +226,8 @@ func TestOpenCode_BuildConfig_Aliases(t *testing.T) {
 		"kimi-k2.5":     "moonshotai.kimi-k2.5",
 		"deepseek-v3.2": "deepseek.v3.2",
 		"qwen3-coder":   "qwen.qwen3-coder-480b-a35b-v1:0",
-		"grok-4.3":      "xai.grok-4.6",
+		"grok-4.3":      "global.xai.grok-4.6",
+		"grok-4.6":      "global.xai.grok-4.6",
 	}
 	p, _ := Get("opencode")
 	for key, wantID := range cases {

--- a/internal/provider/plan.go
+++ b/internal/provider/plan.go
@@ -162,7 +162,7 @@ func catalogUnavailableWarning(models []CatalogModel, selectedID, region, suffix
 		return ""
 	}
 	return fmt.Sprintf(
-		"model %q was not returned as ACTIVE and available by Mantle in %s; %s",
+		"model %q was not returned as ACTIVE and available in %s; %s",
 		selectedID, region, suffix)
 }
 

--- a/internal/provider/task2_opencode_verify_test.go
+++ b/internal/provider/task2_opencode_verify_test.go
@@ -78,8 +78,8 @@ func TestTask2_OpenCode_SupportsNativeRejectsMantle(t *testing.T) {
 func TestTask2_OpenCode_AliasesNative(t *testing.T) {
 	cases := map[string]string{
 		"qwen3-coder":  "qwen.qwen3-coder-480b-a35b-v1:0",
-		"grok-4.6":     "xai.grok-4.6",
-		"grok-4.3":     "xai.grok-4.6",
+		"grok-4.6":     "global.xai.grok-4.6",
+		"grok-4.3":     "global.xai.grok-4.6",
 		"gpt-oss-120b": "openai.gpt-oss-120b-1:0",
 		"gpt-oss-20b":  "openai.gpt-oss-20b-1:0",
 	}


### PR DESCRIPTION
## Summary

Two OpenCode/Grok fixes plus a stale-string cleanup:

- **#458** — the `grok-4.6` / `grok-4.3` OpenCode convenience aliases resolved to the bare `xai.grok-4.6` foundation ID, which the `bedrock-runtime` endpoint rejects (it only serves cross-Region inference profile IDs). Both now resolve to `global.xai.grok-4.6`, matching the Grok provider's own normalization.
- **#452** — the "was not returned as ACTIVE and available" apply warning still named the removed Mantle endpoint; it now just names the region.

## Changes

- `internal/provider/opencode.go` — `grok-4.6` and `grok-4.3` aliases → `global.xai.grok-4.6`; comment documents the CRIS-profile reasoning.
- `internal/provider/plan.go` — `catalogUnavailableWarning` is region-only (no "Mantle").
- `CHANGELOG.md` — Unreleased entries for both.
- Tests: `opencode_test.go` and `task2_opencode_verify_test.go` updated for the new ID; `catalog_test.go` adds `TestCatalogUnavailableWarning_NoMantleMention`.

**Alias audit note:** the other OpenCode aliases (`glm-4.7`, `glm-5`, `kimi-k2.5`, `deepseek-v3.2`, `qwen3-coder`) remain bare foundation IDs — GLM 5 is In-Region-only per its model card, and the others are Chat-API-compatible foundation IDs that serve in-region. Only the Grok entries needed the `global.` profile.

## Verification

- `go test ./internal/provider/... -count=1` — ok.
- Code is byte-identical to the previously full-suite-verified `d19af41` state (`git diff d19af41 -- internal/provider/` is empty); the full `go test ./...` passed at that state.

Closes #458
Closes #452